### PR TITLE
GH37 volume parity

### DIFF
--- a/centos7/9.5/Dockerfile.postgres.centos7
+++ b/centos7/9.5/Dockerfile.postgres.centos7
@@ -32,10 +32,10 @@ ENV	PGROOT="/usr/pgsql-${PGVERSION}"
 ADD conf/.bash_profile /var/lib/pgsql/
 
 # set up cpm directory
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /backup /pgconf /recover /backrestrepo
+RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
 
-RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql/ \
-	/pgdata /pgwal /backup /pgconf /recover /backrestrepo
+RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
+	/pgdata /pgwal /pgconf /backup /recover /backrestrepo
 
 
 # add volumes to allow override of pg_hba.conf and postgresql.conf

--- a/centos7/9.6/Dockerfile.postgres.centos7
+++ b/centos7/9.6/Dockerfile.postgres.centos7
@@ -31,10 +31,10 @@ ENV PGROOT="/usr/pgsql-${PGVERSION}"
 ADD conf/.bash_profile /var/lib/pgsql/
 
 # set up cpm directory
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /backup /pgconf /recover /backrestrepo
+RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
 
-RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql/ \
-	/pgdata /pgwal /backup /pgconf /recover /backrestrepo
+RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
+	/pgdata /pgwal /pgconf /backup /recover /backrestrepo
 
 
 # add volumes to allow override of pg_hba.conf and postgresql.conf
@@ -45,7 +45,7 @@ RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql/ \
 # volume for pgbackrest to write to
 
 VOLUME /pgconf /pgdata /pgwal \
-	/backup /recover /backrestrepo
+  /backup /recover /backrestrepo
 
 # open up the postgres port
 EXPOSE 5432

--- a/rhel7/9.5/Dockerfile.postgres.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres.rhel7
@@ -27,7 +27,7 @@ ADD conf/.bash_profile /var/lib/pgsql/
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
 
 RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
-	/pgdata /pgwal /backup /recover /backrestrepo
+	/pgdata /pgwal /pgconf /backup /recover /backrestrepo
 
 # add volumes to allow override of pg_hba.conf and postgresql.conf
 # add volumes to allow backup of postgres files

--- a/rhel7/9.5/Dockerfile.postgres.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres.rhel7
@@ -20,20 +20,24 @@ yum -y install postgresql95 postgresql95-contrib postgresql95-server \
 pgaudit pgaudit_analyze pgaudit_set_user \
 postgis2_95 postgis2_95-client crunchy-backrest pgrouting_95  && yum clean all -y
 
-# set up cpm directory
-#
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /backup /backrestrepo
-
-RUN chown -R postgres:postgres /opt/cpm /pgdata /backup /backrestrepo
-
 # add path settings for postgres user
 ADD conf/.bash_profile /var/lib/pgsql/
+
+# set up cpm directory
+RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
+
+RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
+	/pgdata /pgwal /backup /recover /backrestrepo
 
 # add volumes to allow override of pg_hba.conf and postgresql.conf
 # add volumes to allow backup of postgres files
 # add volumes to offer a restore feature
+# add volumes to allow storage of postgres WAL segment files
+# add volumes to locate WAL files to recover with
 # volume for pgbackrest to write to
-VOLUME /pgconf /pgdata /backup /backrestrepo
+
+VOLUME /pgconf /pgdata /pgwal \
+  /backup /recover /backrestrepo
 
 # open up the postgres port
 EXPOSE 5432

--- a/rhel7/9.6/Dockerfile.postgres.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres.rhel7
@@ -36,7 +36,7 @@ ADD conf/.bash_profile /var/lib/pgsql/
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
 
 RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
-	/pgdata /pgwal /backup /recover /backrestrepo
+	/pgdata /pgwal /pgconf /backup /recover /backrestrepo
 
 # add volumes to allow override of pg_hba.conf and postgresql.conf
 # add volumes to allow backup of postgres files

--- a/rhel7/9.6/Dockerfile.postgres.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres.rhel7
@@ -33,10 +33,10 @@ ENV PGROOT="/usr/pgsql-${PGVERSION}"
 ADD conf/.bash_profile /var/lib/pgsql/
 
 # set up cpm directory
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /backup /recover /backrestrepo
+RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
 
 RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
-	/pgdata /backup /recover /backrestrepo
+	/pgdata /pgwal /backup /recover /backrestrepo
 
 # add volumes to allow override of pg_hba.conf and postgresql.conf
 # add volumes to allow backup of postgres files
@@ -45,7 +45,7 @@ RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
 # add volumes to locate WAL files to recover with
 # volume for pgbackrest to write to
 
-VOLUME /pgconf /pgdata $PGROOT \
+VOLUME /pgconf /pgdata /pgwal \
   /backup /recover /backrestrepo
 
 # open up the postgres port
@@ -57,4 +57,3 @@ ADD conf/postgres /opt/cpm/conf
 USER 26
 
 CMD ["/opt/cpm/bin/start.sh"]
-


### PR DESCRIPTION
Set all mkdir & volume commands the same between rhel7 & centos7 9.5 and 9.6 Postgres images.