### PR TITLE
Add application_name="container_setup" to help startup health probes

### DIFF
--- a/bin/postgres/setup.sql
+++ b/bin/postgres/setup.sql
@@ -1,3 +1,4 @@
+SET application_name="container_setup";
 
 create extension postgis;
 create extension postgis_topology;


### PR DESCRIPTION
Add SET application_name="container_setup" to the postgres setup.sql script
This will let us check for that application name in pg_stat_activity to determine if the script has completed.