### PR TITLE
Stricter start.sh to ensure all vars are set

### DIFF
--- a/bin/postgres/setenv.sh
+++ b/bin/postgres/setenv.sh
@@ -30,4 +30,4 @@ export PGWAL=/pgwal/$HOSTNAME-wal
 export PATH=/opt/cpm/bin:$PGROOT/bin:$PATH
 export LD_LIBRARY_PATH=$PGROOT/lib
 
-chown postgres $PGDATA $PGWAL
+# chown postgres $PGDATA $PGWAL

--- a/bin/postgres/start.sh
+++ b/bin/postgres/start.sh
@@ -78,10 +78,10 @@ chown postgres:postgres /pgdata/$HOSTNAME
 
 if [[ -v ARCHIVE_MODE ]]; then
 	if [ $ARCHIVE_MODE == "on" ]; then
-		echo "creating wal directory /pgwal/$HOSTNAME"
-		mkdir -p /pgwal/$HOSTNAME
-		chmod 0700 /pgwal/$HOSTNAME
-		chown postgres:postgres /pgwal/$HOSTNAME
+		echo "creating wal archive directory /pgwal/$HOSTNAME-wal"
+		mkdir -p /pgwal/$HOSTNAME-wal
+		chmod 0700 /pgwal/$HOSTNAME-wal
+		chown postgres:postgres /pgwal/$HOSTNAME-wal
 	fi
 fi
 


### PR DESCRIPTION
Rebased against 1.2.8 master.
Added stricter set statements to start.sh - fail on error or undefined variable.
Resolved setenv.sh problem where chown is called before directory is created.