### PR TITLE
Cleanup the makefile, add .gitignore, alter some yum commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *.whl
+.asciidoc/
+bootstrap-*.zip*
+grafana.tar.gz*
+prometheus-pushgateway.tar.gz*
+prometheus.tar.gz*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 ifndef BUILDBASE
 	export BUILDBASE=$(GOPATH)/src/github.com/crunchydata/crunchy-containers
 endif
@@ -18,82 +17,29 @@ gendeps:
 
 docbuild:
 	cd docs && ./build-docs.sh
-postgres:
-	make versiontest
-	cp `which oc` bin/postgres/
-	docker build -t crunchy-postgres -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres.$(CCP_BASEOS) .
-	docker tag crunchy-postgres crunchydata/crunchy-postgres:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-postgres-gis:
-	make versiontest
-	cp `which kubectl` bin/postgres
-	docker build -t crunchy-postgres-gis -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres-gis.$(CCP_BASEOS) .
-	docker tag crunchy-postgres-gis crunchydata/crunchy-postgres-gis:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-watch:
-	cp `which oc` bin/watch
-	cp `which kubectl` bin/watch
-	docker build -t crunchy-watch -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.watch.$(CCP_BASEOS) .
-	docker tag crunchy-watch crunchydata/crunchy-watch:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-version:
-	docker build -t crunchy-version -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.version.$(CCP_BASEOS) .
-	docker tag crunchy-version crunchydata/crunchy-version:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-backrest:
-	make versiontest
+
+#=============================================
+# Targets that generate images (alphabetized)
+#=============================================
+backrest:	versiontest
 	docker build -t crunchy-backrest -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.backrest.$(CCP_BASEOS) .
 	docker tag crunchy-backrest crunchydata/crunchy-backrest:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-backrestd:
-	make versiontest
+
+# Should this be added to the all target?
+backrestd:	versiontest
 	docker build -t crunchy-backrestd -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.backrestd.$(CCP_BASEOS) .
 	docker tag crunchy-backrestd crunchydata/crunchy-backrestd:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-pgbouncer:
-	make versiontest
-	cp `which oc` bin/pgbouncer
-	cp `which kubectl` bin/pgbouncer
-	cd bounce && godep go install bounce.go
-	cp $(GOBIN)/bounce bin/pgbouncer/
-	docker build -t crunchy-pgbouncer -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgbouncer.$(CCP_BASEOS) .
-	docker tag crunchy-pgbouncer crunchydata/crunchy-pgbouncer:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-pgpool:
-	make versiontest
-	docker build -t crunchy-pgpool -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgpool.$(CCP_BASEOS) .
-	docker tag crunchy-pgpool crunchydata/crunchy-pgpool:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-pgbadger:
-	make versiontest
-	cd badger && godep go install badgerserver.go
-	cp $(GOBIN)/badgerserver bin/pgbadger
-	docker build -t crunchy-pgbadger -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgbadger.$(CCP_BASEOS) .
-	docker tag crunchy-pgbadger crunchydata/crunchy-pgbadger:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-collectserver:
-	make versiontest
+
+backup:	versiontest
+	docker build -t crunchy-backup -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.backup.$(CCP_BASEOS) .
+	docker tag crunchy-backup crunchydata/crunchy-backup:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
+
+collectserver:	versiontest
 	cd collect && godep go install collectserver.go
 	cp $(GOBIN)/collectserver bin/collect
 	docker build -t crunchy-collect -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.collect.$(CCP_BASEOS) .
 	docker tag crunchy-collect crunchydata/crunchy-collect:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-backup:
-	make versiontest
-	docker build -t crunchy-backup -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.backup.$(CCP_BASEOS) .
-	docker tag crunchy-backup crunchydata/crunchy-backup:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-pgadmin4: 
-	make versiontest
-	docker build -t crunchy-pgadmin4 -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgadmin4.$(CCP_BASEOS) .
-	docker tag crunchy-pgadmin4 crunchydata/crunchy-pgadmin4:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-prometheus: 
-	make versiontest
-	docker build -t crunchy-prometheus -f $(CCP_BASEOS)/Dockerfile.prometheus.$(CCP_BASEOS) .
-	docker tag crunchy-prometheus crunchydata/crunchy-prometheus:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-promgateway: 
-	make versiontest
-	docker build -t crunchy-promgateway -f $(CCP_BASEOS)/Dockerfile.promgateway.$(CCP_BASEOS) .
-	docker tag crunchy-promgateway crunchydata/crunchy-promgateway:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-grafana:
-	make versiontest
-	docker build -t crunchy-grafana -f $(CCP_BASEOS)/Dockerfile.grafana.$(CCP_BASEOS) .
-	docker tag crunchy-grafana crunchydata/crunchy-grafana:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
-vac:
-	make versiontest
-	cd vacuum && godep go install vacuum.go
-	cp $(GOBIN)/vacuum bin/vacuum
-	docker build -t crunchy-vacuum -f $(CCP_BASEOS)/Dockerfile.vacuum.$(CCP_BASEOS) .
-	docker tag crunchy-vacuum crunchydata/crunchy-vacuum:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
+
 dbaserver:
 	cp `which oc` bin/dba
 	cp `which kubectl` bin/dba
@@ -102,25 +48,80 @@ dbaserver:
 	docker build -t crunchy-dba -f $(CCP_BASEOS)/Dockerfile.dba.$(CCP_BASEOS) .
 	docker tag crunchy-dba crunchydata/crunchy-dba:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
 
-all:
-	make versiontest
-	make postgres
-	make postgres-gis
-	make backup
-	make watch
-	make pgpool
-	make pgbouncer
-	make pgbadger
-	make collectserver
-	make grafana
-	make promgateway
-	make prometheus
-	make vac
-	make dbaserver
+# dns target if applicable goes here
+
+grafana:	versiontest
+	docker build -t crunchy-grafana -f $(CCP_BASEOS)/Dockerfile.grafana.$(CCP_BASEOS) .
+	docker tag crunchy-grafana crunchydata/crunchy-grafana:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
+
+# Add pgadmin4 to the "all" target when RHEL image ready
+pgadmin4:	versiontest
+	docker build -t crunchy-pgadmin4 -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgadmin4.$(CCP_BASEOS) .
+	docker tag crunchy-pgadmin4 crunchydata/crunchy-pgadmin4:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
+
+pgbadger:	versiontest
+	cd badger && godep go install badgerserver.go
+	cp $(GOBIN)/badgerserver bin/pgbadger
+	docker build -t crunchy-pgbadger -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgbadger.$(CCP_BASEOS) .
+	docker tag crunchy-pgbadger crunchydata/crunchy-pgbadger:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
+
+pgbouncer:	versiontest
+	cp `which oc` bin/pgbouncer
+	cp `which kubectl` bin/pgbouncer
+	cd bounce && godep go install bounce.go
+	cp $(GOBIN)/bounce bin/pgbouncer/
+	docker build -t crunchy-pgbouncer -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgbouncer.$(CCP_BASEOS) .
+	docker tag crunchy-pgbouncer crunchydata/crunchy-pgbouncer:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
+
+pgpool:	versiontest
+	docker build -t crunchy-pgpool -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgpool.$(CCP_BASEOS) .
+	docker tag crunchy-pgpool crunchydata/crunchy-pgpool:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
+
+postgres:	versiontest
+	cp `which kubectl` bin/postgres
+	docker build -t crunchy-postgres -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres.$(CCP_BASEOS) .
+	docker tag crunchy-postgres crunchydata/crunchy-postgres:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
+
+postgres-gis:	versiontest
+	cp `which kubectl` bin/postgres
+	docker build -t crunchy-postgres-gis -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres-gis.$(CCP_BASEOS) .
+	docker tag crunchy-postgres-gis crunchydata/crunchy-postgres-gis:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
+
+prometheus:	versiontest
+	docker build -t crunchy-prometheus -f $(CCP_BASEOS)/Dockerfile.prometheus.$(CCP_BASEOS) .
+	docker tag crunchy-prometheus crunchydata/crunchy-prometheus:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
+
+promgateway:	versiontest
+	docker build -t crunchy-promgateway -f $(CCP_BASEOS)/Dockerfile.promgateway.$(CCP_BASEOS) .
+	docker tag crunchy-promgateway crunchydata/crunchy-promgateway:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
+
+vac:	versiontest
+	cd vacuum && godep go install vacuum.go
+	cp $(GOBIN)/vacuum bin/vacuum
+	docker build -t crunchy-vacuum -f $(CCP_BASEOS)/Dockerfile.vacuum.$(CCP_BASEOS) .
+	docker tag crunchy-vacuum crunchydata/crunchy-vacuum:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
+
+version:
+	docker build -t crunchy-version -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.version.$(CCP_BASEOS) .
+	docker tag crunchy-version crunchydata/crunchy-version:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
+
+watch:
+	cp `which oc` bin/watch
+	cp `which kubectl` bin/watch
+	docker build -t crunchy-watch -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.watch.$(CCP_BASEOS) .
+	docker tag crunchy-watch crunchydata/crunchy-watch:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
+
+#============
+# All target
+#============
+all:	backup collectserver dbaserver grafana pgbadger pgbouncer pgpool postgres postgres-gis prometheus promgateway watch vac
+
 push:
 	./bin/push-to-dockerhub.sh
+
 default:
 	all
+
 test:
 	./tests/docker/test-basic.sh; /usr/bin/test "$$?" -eq 0
 	./tests/docker/test-vacuum.sh; /usr/bin/test "$$?" -eq 0
@@ -131,6 +132,7 @@ test:
 	./tests/docker/test-restore.sh; /usr/bin/test "$$?" -eq 0
 	# ./tests/standalone/test-watch.sh; /usr/bin/test "$$?" -eq 0
 	# docker stop master
+
 testopenshift:
 	./tests/openshift/test-master.sh; /usr/bin/test "$$?" -eq 0
 	./tests/openshift/test-replica.sh; /usr/bin/test "$$?" -eq 0

--- a/rhel7/9.5/Dockerfile.backrest.rhel7
+++ b/rhel7/9.5/Dockerfile.backrest.rhel7
@@ -15,7 +15,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 RUN yum -y install rsync nss_wrapper gettext bind-utils procps-ng \
 openssh-clients  hostname && yum -y reinstall glibc-common && \ 
 yum -y install postgresql95-server \
-crunchy-backrest-1.08* && yum clean all -y
+crunchy-backrest && yum clean all -y
 
 # set up cpm directory
 #

--- a/rhel7/9.5/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbadger.rhel7
@@ -10,7 +10,7 @@ ADD conf/CRUNCHY-GPG-KEY.public  /
 ADD conf/crunchypg95.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public && groupadd -g 26 postgres && useradd -g 26 -u 26 postgres
 
-RUN yum -y install procps-ng pgbadger-9.1* openssh-clients hostname && yum clean all -y
+RUN yum -y install procps-ng pgbadger openssh-clients hostname && yum clean all -y
 
 # set up cpm directory
 #

--- a/rhel7/9.6/Dockerfile.backrest.rhel7
+++ b/rhel7/9.6/Dockerfile.backrest.rhel7
@@ -16,7 +16,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 	openssh-clients \
  	procps-ng \
  	rsync \
- && yum -y install postgresql96-server crunchy-backrest-1.08* \
+ && yum -y install postgresql96-server crunchy-backrest \
  && yum -y clean all
 
 # add path settings for postgres user

--- a/rhel7/9.6/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbadger.rhel7
@@ -12,7 +12,7 @@ RUN rpm --import CRUNCHY-GPG-KEY.public
 RUN yum -y install hostname \
 	openssh-clients \
 	procps-ng \
-	pgbadger-9.0* \
+	pgbadger \
  && yum clean all -y \
  && groupadd -g 26 postgres && useradd -g 26 -u 26 postgres 
 


### PR DESCRIPTION
@jmccormick2001 This is just a maintenance patch to make a few things cleaner.  A few things worth discussion are below:

1) I tested a RHEL7 build on 9.5 and 9.6.  Both passed and generated the same sets of images.  I haven't gotten around to testing on Centos, but based on the RHEL findings, I think it'll work.

2) I reorganized the makefile a bit to use Makefile dependency chaining over individual make-lines (i.e. make versiontest), and I alphabetized individual components for easier maintenance (i.e. it'll make it easier to spot missed items in the "all" target or when doing an "ls" on docker files).  However, this change did beg a couple of questions: should "dns" and "backrestd" be added to the "all" target?  I do see the DNS dockerfiles, but I don't see backrestd docker files, so I wasn't sure if these are future items or deprecated.  I left the comments in the Makefile for these 2 components just as reminders for me to talk about them, so I am happy to push a change to clean that up once I know the right path.

3) I modified a few docker files for pgbadger and backrest to not hardcode versions and instead pull the latest (i.e. matching other components).  If there is a reason why we're using older versions, let me know and we can revisit.  I mostly made the change for consistency.