### PR TITLE
examples: fixup statefulsets volumes' claimName

### DIFF
--- a/examples/kube/statefulset/set.json
+++ b/examples/kube/statefulset/set.json
@@ -66,7 +66,7 @@
                 "volumes": [{
                     "name": "pgdata",
                     "persistentVolumeClaim": {
-                        "claimName": "crunchy-pvc"
+                        "claimName": "pgset-pvc"
                     }
                 }]
             }


### PR DESCRIPTION
pvc is pgset-pvc, but not crunchy-pvc