### PR TITLE
Misc accuracy fixes

### DIFF
--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -92,10 +92,33 @@ the value of PG_PASSWORD from above for the password when prompted:
 psql -h basic.openshift.svc.cluster.local -U testuser userdb
 ....
 
+=== *master-replica* - Creating a master and replica database cluster
+
+Run the following command to deploy a master and replica database cluster:
+
+....
+cd $CCPROOT/examples/openshift/master-replica
+./run.sh
+....
+
+Similarly to the previous example on *basic*, you can view the generated
+passwords by running this command:
+
+....
+oc describe pod ms-master | grep PG
+....
+
+You can then connect to the database instance as follows using the password
+shown with the previous command:
+
+....
+psql -h mc-master -U testuser -W userdb
+....
+
 === *pgpool*  - pgpool for master replica examples
 
 You can create a pgpool service that will work with the
-master and replica created in the previous Example 1 and Example 2.
+master and replica created in the previous example.
 
 You will need to edit the pgpool-for-master-replica-rc-dc-replicas-only.json and supply the
 testuser password that was generated when you created

--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -502,6 +502,7 @@ First, create the crunchy-metrics pod which contains
 the prometheus data store and the grafana graphing web application:
 
 ....
+cd $CCPROOT/examples/openshift/metrics
 ./run.sh
 ....
 

--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -305,21 +305,19 @@ This example uses a pvc based volume for the master and the replicas.  In
 some scenarios, customers might want to have all the Postgres
 instances using NFS volumes for persistence.
 
-Relevant files for this example:
-
- * master-replica-rc-pvc.json
-This file creates the master and replica deployment, creating pods and services
-where the replica is controlled by a Replication Controller, allowing you
-to scale up the replicas.
-
 To run the example, follow these steps:
 
 As the project user, create the master replica deployment:
 ....
+cd $CCPROOT/examples/openshift/master-replica-rc-pvc
 ./run.sh
 ....
 
-If you examing your NFS directory, you will see postgres data directories
+Note:  The *master-replica.json* file creates the master and replica deployment,
+creating pods and services where the replica is controlled by a Replication Controller,
+allowing you to scale up the replicas.
+
+If you examine your NFS directory, you will see postgres data directories
 created and used by your master and replica pods.
 
 Next, add some test data to the master:
@@ -409,7 +407,7 @@ encoded password value is *password*.  Run the example
 as follows:
 
 ....
-cd $CCPROOT/examples/openshift/secret/run.sh
+cd $CCPROOT/examples/openshift/secret
 ./run.sh
 ....
 

--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -198,8 +198,8 @@ psql -c 'select inet_server_addr()' -h pg-replica-rc -U master postgres
 === *backup* - Performing a Full Backup
 
 This example assumes you have a database pod running called *basic*
-as created by the *basic* example and that you have configured NFS as decribed
-in the Prerequisites section of this document..
+as created by the *basic* example and that you have configured NFS as described
+in Step 5 of the install.asciidoc.
 
 You can perform a database backup by executing the following
 step:

--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -37,7 +37,7 @@ cd $CCPROOT/examples/pv
 ./create-pvc.sh
 ....
 
-If you are wanting to run the examples on a minishift instance
+If you are wanting to run the examples on a Minishift instance
 you will need to create the PVs using hostPath as follows:
 ....
 oc login -u system:admin
@@ -55,7 +55,7 @@ oc edit scc restricted
 
 Above, you will change runAsUser.Type strategy to RunAsAny.
 
-On the boot2docker instance running minishift, you will need
+On the boot2docker instance running Minishift, you will need
 to set the host path permissions as follows:
 ....
 chmod 777 /mnt/sda1/data
@@ -452,7 +452,8 @@ service account the ability to edit resources within the openshift and
 default projects :
 
 ....
-oc create -f sa.json
+cd $CCPROOT/examples/openshift/watch
+oc create -f watch-sa.json
 oc policy add-role-to-group edit system:serviceaccounts -n openshift
 oc policy add-role-to-group edit system:serviceaccounts -n default
 ....
@@ -460,7 +461,6 @@ oc policy add-role-to-group edit system:serviceaccounts -n default
 Next, create the container that will 'watch' the Postgresql cluster:
 
 ....
-cd $CCPROOT/examples/openshift/watch
 ./run.sh
 ....
 

--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -120,7 +120,7 @@ psql -h mc-master -U testuser -W userdb
 You can create a pgpool service that will work with the
 master and replica created in the previous example.
 
-You will need to edit the pgpool-for-master-replica-rc-dc-replicas-only.json and supply the
+You will need to edit the pgpool-rc.json and supply the
 testuser password that was generated when you created
 the master replica pods, then run the following command
 to deploy the pgpool service:
@@ -448,7 +448,7 @@ cd $CCPROOT/examples/openshift/master-replica-dc
 
 Next, create an Openshift service account which is used by the crunchy-watch
 container to perform the failover, also set policies that allow the
-service account the ability to edit resources within the openshift and
+service account the ability to edit resources within the Openshift and
 default projects :
 
 ....
@@ -468,13 +468,13 @@ At this point, the watcher will sleep every 20 seconds (configurable) to
 see if the master is responding.  If the master doesn't respond, the watcher
 will perform the following logic:
 
- * log into openshift using the service account
+ * log into Openshift using the service account
  * set its current project
  * find the first replica pod
  * delete the master service saving off the master service definition
  * create the trigger file on the first replica pod
  * wait 20 seconds for the failover to complete on the replica pod
- * edit the replica pod's lable to match that of the master
+ * edit the replica pod's label to match that of the master
  * recreate the master service using the stored service definition
  * loop through the other remaining replica and delete its pod
 
@@ -486,7 +486,7 @@ started as each new replica is started by Openshift.
 
 To test it out, delete the master pod and view the watch pod log:
 ....
-oc delete pod pg-master-rc-dc
+oc delete pod pg-master-dc
 oc logs watch
 oc get pod
 ....

--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -163,14 +163,14 @@ a single pod since it can not be scaled like read-only replicas.
 Running the example:
 
 ....
-oc create -f master-replica-rc-dc-replicas-only.json | oc create -f -
+oc create -f master-replica.json | oc create -f -
 ....
 
 Connect to the PostgreSQL instances with the following:
 
 ....
-psql -h pg-master-rc-dc.pgproject.svc.cluster.local -U testuser userdb
-psql -h pg-replica-rc-dc.pgproject.svc.cluster.local -U testuser userdb
+psql -h master-dc.pgproject.svc.cluster.local -U testuser userdb
+psql -h replica-dc.pgproject.svc.cluster.local -U testuser userdb
 ....
 
 Here is an example of increasing or scaling up the Postgres 'replica' pods to 2:
@@ -239,6 +239,7 @@ First, locate the database backup you want to restore, for example:
 
 Then create the pod:
 ....
+cd $CCPROOT/examples/openshift/master-restore
 ./run.sh
 ....
 

--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -138,7 +138,7 @@ psql -h pgpool-rc -U testuser userdb
 psql -h pgpool-rc -U testuser postgres
 ....
 
-when prompted, enter the password for the PG_USERNAME testuser
+When prompted, enter the password for the PG_USERNAME testuser
 that was set for the pg-master pod, typically it is *password*.
 
 At this point, you can enter SELECT and INSERT statements and
@@ -153,7 +153,7 @@ running:
 psql -h pgpool-rc -U testuser userdb -c 'show pool_nodes'
 ....
 
-=== *master-replica-rc-dc* - master replica with scalable replicas
+=== *master-replica-dc* - master replica with scalable replicas
 
 This example is similar to the previous examples but
 builds a master pod, and a single replica that can be scaled up

--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -610,6 +610,7 @@ The example assumes you have run the master/replica example
 found here:
 ....
 $CCPROOT/examples/openshift/master-replica-dc
+./run.sh
 ....
 
 Then you would start up the pgbouncer container using the following
@@ -991,7 +992,7 @@ by the Openshift 'process' command.  To inspect what value was
 supplied, you can inspect the master pod as follows:
 
 ....
-oc get pod pg-master-rc-1-n5z8r -o json
+oc get pod ms-master -o json | grep PG
 ....
 
 Look for the values of the environment variables:

--- a/examples/openshift/configmap/run.sh
+++ b/examples/openshift/configmap/run.sh
@@ -21,4 +21,4 @@ $DIR/cleanup.sh
 
 oc create configmap postgresql-conf --from-file=postgresql.conf --from-file=pghba=pg_hba.conf
 
-oc process -v CCP_IMAGE_TAG=$CCP_IMAGE_TAG -f $DIR/configmap.json | oc create -f -
+oc process -p CCP_IMAGE_TAG=$CCP_IMAGE_TAG -f $DIR/configmap.json | oc create -f -

--- a/examples/openshift/pgadmin4/run.sh
+++ b/examples/openshift/pgadmin4/run.sh
@@ -28,4 +28,4 @@ if [ ! -d "$DATADIR" ]; then
 	sudo chmod -R 777 $DATADIR
 fi
 
-oc process -v CCP_IMAGE_TAG=$CCP_IMAGE_TAG -f $DIR/pgadmin4.json | oc create -f -
+oc process -p CCP_IMAGE_TAG=$CCP_IMAGE_TAG -f $DIR/pgadmin4.json | oc create -f -

--- a/examples/openshift/vacuum-job/run.sh
+++ b/examples/openshift/vacuum-job/run.sh
@@ -16,4 +16,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc process -v CCP_IMAGE_TAG=$CCP_IMAGE_TAG -f $DIR/vacuum-job.json | oc create -f -
+oc process -p CCP_IMAGE_TAG=$CCP_IMAGE_TAG -f $DIR/vacuum-job.json | oc create -f -


### PR DESCRIPTION
One note - the "failover" example refers to a json file called "master-replica-rc-dc-replicas-only.json". In another directory (under the master-replica-dc example) it also referred to master-replica-rc-dc-replicas-only.json, but I was able to correct it to master-replica.json. Is that the same file necessary to run the failover example? pg-replica-rc-1 also is nonexistent.

Please verify the master-replica example I inserted (right after basic) is correct.

Also, under Tip 6 - Encoding Secrets, there is a random statement, "docker to be installed." - was there any meaning behind that or can it just be removed?
