### PR TITLE
Fix for backrest-restore on rhel, remove old question-mark syntax

### DIFF
--- a/centos7/9.5/Dockerfile.backup.centos7
+++ b/centos7/9.5/Dockerfile.backup.centos7
@@ -19,7 +19,7 @@ ENV PGVERSION="9.5" \
         PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm"
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
-RUN yum -y update && yum install -y epel-release && yum install -y nss_wrapper gettext procps-ng postgresql9? postgresql9?-server unzip openssh-clients hostname bind-utils && yum clean all -y
+RUN yum -y update && yum install -y epel-release && yum install -y nss_wrapper gettext procps-ng postgresql95 postgresql95-server unzip openssh-clients hostname bind-utils && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /pgdata /opt/cpm/conf
 ADD bin/backup/ /opt/cpm/bin

--- a/centos7/9.5/Dockerfile.collect.centos7
+++ b/centos7/9.5/Dockerfile.collect.centos7
@@ -20,7 +20,7 @@ ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm"
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install gettext libxslt libxml2 procps-ng \
-postgresql9?-server \
+postgresql95-server \
 openssh-clients \
 hostname  \
  && yum clean all -y

--- a/rhel7/9.3/Dockerfile.backup.rhel7
+++ b/rhel7/9.3/Dockerfile.backup.rhel7
@@ -12,7 +12,7 @@ RUN rpm --import CRUNCHY-GPG-KEY.public
 
 # install deps
 RUN yum -y install libxslt libxml2 procps-ng \
-postgresql9?-server   postgresql9?  openssh-clients  hostname bind-utils \
+postgresql93-server   postgresql93  openssh-clients  hostname bind-utils \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /pgdata

--- a/rhel7/9.3/Dockerfile.collect.rhel7
+++ b/rhel7/9.3/Dockerfile.collect.rhel7
@@ -11,7 +11,7 @@ ADD conf/crunchypg93.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN yum -y install gettext libxslt libxml2 procps-ng \
-postgresql9?-server  openssh-clients  hostname   && yum clean all -y
+postgresql93-server  openssh-clients  hostname   && yum clean all -y
 
 # set up cpm directory
 #

--- a/rhel7/9.3/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.3/Dockerfile.pgbadger.rhel7
@@ -11,7 +11,7 @@ ADD conf/crunchypg93.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN yum -y install gettext libxslt libxml2 procps-ng \
-pgbadger*  postgresql9?-server  openssh-clients  hostname && yum clean all -y
+pgbadger*  postgresql93-server  openssh-clients  hostname && yum clean all -y
 
 # set up cpm directory
 #

--- a/rhel7/9.3/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/9.3/Dockerfile.pgbouncer.rhel7
@@ -15,7 +15,7 @@ ADD conf/pgbouncer/docker-rhel.repo /etc/yum.repos.d/
 
 RUN yum -y install docker-engine procps-ng \
 pgbouncer \
-postgresql9? \
+postgresql93 \
 openssh-clients \
 hostname  \
  && yum clean all -y

--- a/rhel7/9.3/Dockerfile.pgpool.rhel7
+++ b/rhel7/9.3/Dockerfile.pgpool.rhel7
@@ -11,7 +11,7 @@ ADD conf/crunchypg93.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN yum -y install gettext libxslt libxml2 procps-ng \
-pgpool-II* postgresql9?  openssh-clients hostname && yum clean all -y
+pgpool-II* postgresql93  openssh-clients hostname && yum clean all -y
 
 # set up cpm directory
 #

--- a/rhel7/9.3/Dockerfile.postgres.rhel7
+++ b/rhel7/9.3/Dockerfile.postgres.rhel7
@@ -12,10 +12,10 @@ RUN rpm --import CRUNCHY-GPG-KEY.public
 
 #RUN rpm -Uvh http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y install rsync nss_wrapper gettext libxslt libxml2 procps-ng \
-postgresql9?-server  \
-postgresql9?-libs  \
-postgresql9?-contrib  \
-postgresql9? \
+postgresql93-server  \
+postgresql93-libs  \
+postgresql93-contrib  \
+postgresql93 \
 openssh-clients \
 hostname bind-utils \
 && yum -y reinstall glibc-common  && yum clean all -y

--- a/rhel7/9.3/Dockerfile.watch.rhel7
+++ b/rhel7/9.3/Dockerfile.watch.rhel7
@@ -14,7 +14,7 @@ RUN rpm --import CRUNCHY-GPG-KEY.public
 ADD conf/watch/docker-rhel.repo /etc/yum.repos.d/
 
 RUN yum -y install docker-engine curl rsync libxslt libxml2 procps-ng \
-postgresql9?  openssh-clients atomic-openshift-clients hostname bind-utils \
+postgresql93  openssh-clients atomic-openshift-clients hostname bind-utils \
  && yum clean all -y
 
 # set up cpm directory

--- a/rhel7/9.5/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.5/Dockerfile.backrest-restore.rhel7
@@ -36,7 +36,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y clean all
 
 RUN yum -y install postgresql95-server  \
-        pgbackrest \
+        crunchy-backrest \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/rhel7/9.5/Dockerfile.backup.rhel7
+++ b/rhel7/9.5/Dockerfile.backup.rhel7
@@ -31,8 +31,8 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 
 # install deps
 RUN yum -y update && yum -y install nss_wrapper gettext procps-ng \
-postgresql9?-server  \
-postgresql9? \
+postgresql95-server  \
+postgresql95 \
 openssh-clients \
 hostname bind-utils \
  && yum clean all -y

--- a/rhel7/9.5/Dockerfile.collect.rhel7
+++ b/rhel7/9.5/Dockerfile.collect.rhel7
@@ -28,7 +28,7 @@ ADD conf/crunchypg95.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN yum -y update && yum -y install gettext libxslt libxml2 procps-ng \
-postgresql9?-server \
+postgresql95-server \
 openssh-clients \
 hostname  \
  && yum clean all -y

--- a/rhel7/9.5/Dockerfile.pgpool.rhel7
+++ b/rhel7/9.5/Dockerfile.pgpool.rhel7
@@ -29,7 +29,7 @@ RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN yum -y update && yum -y install gettext libxslt libxml2 procps-ng \
 pgpool-II-95-*3.4.3* \
-postgresql9? \
+postgresql95 \
 openssh-clients \
 hostname  \
  && yum clean all -y

--- a/rhel7/9.6/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.6/Dockerfile.backrest-restore.rhel7
@@ -36,7 +36,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y clean all
 
 RUN yum -y install postgresql96-server  \
-        pgbackrest \
+        crunchy-backrest \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"


### PR DESCRIPTION
This change-set includes:
1) Fix to use the correct RHEL backrest package name in 9.5 and 9.6 backrest-restore containers.
2) Cleanup all "postgresql-9?" type references, since that syntax isn't needed anymore (i.e. be more verbose).
