### PR TITLE
permission issues with Kubernetes and HEKETI

### DIFF
--- a/bin/postgres/pathinit.sh
+++ b/bin/postgres/pathinit.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+chown -R postgres /pgdata
+chmod 700 /pgdata
+
+chown -R postgres /pgwal
+
+exec gosu postgres /opt/cpm/bin/start.sh "$@"

--- a/centos7/9.5/Dockerfile.postgres.centos7
+++ b/centos7/9.5/Dockerfile.postgres.centos7
@@ -36,6 +36,14 @@ RUN yum -y install postgresql95-server postgresql95-contrib postgresql95 \
 	pgbackrest \
  && yum -y clean all
 
+ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64.asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm /usr/local/bin/gosu.asc \
+    && rm -r /root/.gnupg/ \
+    && chmod +x /usr/local/bin/gosu
+
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"
 
 # add path settings for postgres user
@@ -64,6 +72,4 @@ EXPOSE 5432
 ADD bin/postgres /opt/cpm/bin
 ADD conf/postgres /opt/cpm/conf
 
-USER 26
-
-CMD ["/opt/cpm/bin/start.sh"]
+CMD ["/opt/cpm/bin/pathinit.sh"]


### PR DESCRIPTION
Hi,

I had a permission issue with Kubernetes and a mounted GlusterFS/HEKETI volume.
That's because you are doing chown in Dockerfile and executing setup.sh as user 26

To allow cluster filesystems to do proper user id mapping, chown should be executed in a root script.

The changes here works for me (however, I'm just testing), but may not be "elegant" enough...