### PR TITLE
Explicitly pass `-m fast` when caling `pg_ctl stop`.

### DIFF
--- a/bin/postgres/start.sh
+++ b/bin/postgres/start.sh
@@ -16,9 +16,9 @@
 function trap_sigterm() {
 	echo "doing trap logic..." >> $PGDATA/trap.output
 
-	# Clean shutdowns begin here
+	# Clean shutdowns begin here (force fast mode in case of PostgreSQL < 9.5)
 	echo "Clean shut-down of postgres..."
-	pg_ctl -w -D $PGDATA stop
+	pg_ctl -w -D $PGDATA -m fast stop
 
 	# Unclean shutdowns begin here (if all else fails)
 	if [ -f $PGDATA/postmaster.pid ]; then


### PR DESCRIPTION
In PostgreSQL < 9.5 the default is `smart` instead of `fast`.  If this script is used on those older versions it will wait if users are logged onto the database or a backup is in progress.  This may lead to the container being killed forcefully, requiring recovery on the next start.