### PR TITLE
fix toc bullets

### DIFF
--- a/docs/examples.adoc
+++ b/docs/examples.adoc
@@ -1,6 +1,6 @@
 = Examples & Use Cases - Crunchy Containers for PostgreSQL
 Crunchy Data Solutions, Inc.
-:toc:
+:toc: left
 v1.4.1, {docdate}
 :title-logo-image: image:crunchy_logo.png["CrunchyData Logo",align="center",scaledwidth="80%"]
 


### PR DESCRIPTION
For some reason, this works and makes the TOC symbols look like bullets (at least in the preview). Let me know if it still looks wacky afterwards!