### PR TITLE
support hostnames with dashes (e.g. resulting in my-db-0)

### DIFF
--- a/bin/postgres/start.sh
+++ b/bin/postgres/start.sh
@@ -96,7 +96,7 @@ fi
 
 function role_discovery() {
 	PATH=$PATH:/opt/cpm/bin
-	ordinal=$(echo $HOSTNAME | cut -f2 -d'-')
+	ordinal=${HOSTNAME##*-}
 	echo $ordinal is ordinal
 	if [ $ordinal -eq 0 ]; then
 		kubectl label --overwrite=true pod $HOSTNAME  name=$PG_MASTER_HOST


### PR DESCRIPTION
Adapted solution from https://stackoverflow.com/a/3162500/1415532


> **Context:**
I ran into the problem that I used dashes in the names of my services (e.g. `my-db` which results in instances: `my-db-0`, `my-db-1`,...).
The `start.sh` script has a hard assumption that there are no dashes in the `HOSTNAME` and splits it by `-` and access the second part (in my example: `db` instead of `0`).
    ```bash
    ordinal=$(echo $HOSTNAME | cut -f2 -d'-')
    ```
> This prohibits names with dashes.
The script from Stack Overflow enables the usage of dashes.