### PR TITLE
Add docker-compose master/replica example

### DIFF
--- a/examples/compose/master-replica/README.md
+++ b/examples/compose/master-replica/README.md
@@ -1,0 +1,53 @@
+# Master/Replica Docker Compose Example
+
+This is a `docker-compose` example of deploying a master 
+and read replicas using the Crunchy Container image from DockerHub.
+
+## Prerequirements
+
+* [Docker Installed](https://docs.docker.com/engine/installation/) - Tested on 17.06
+* [Docker-Compose Installed](https://docs.docker.com/compose/install/) - Tested on 1.14.0
+
+## Deploy
+
+To deploy this example, run the following commands:
+
+```bash
+$ git clone git@github.com:CrunchyData/crunchy-containers.git
+$ cd ./crunchy-containers/examples/compose/master-replica
+$ docker-compose up
+```
+
+### Optional: Scale Replica
+
+To deploy more than one replica, run the following:
+
+```bash
+$ docker-compose up --scale db-replica=3
+```
+
+## Using
+
+To `psql` into the created database containers, first identify the ports exposed 
+on the containers:
+
+```bash
+$ docker ps
+```
+
+Next, using `psql`, connect to the service:
+
+```bash
+$ psql -d userdb -h 0.0.0.0 -p <CONTAINER_PORT> -U testuser
+```
+
+**Note:** See `PG_PASSWORD` in `docker-compose.yml` for the user password.
+
+## Clean Up
+
+To tear down the example, run the following:
+
+```bash
+$ docker-compose stop
+$ docker-compose rm
+```

--- a/examples/compose/master-replica/docker-compose.yml
+++ b/examples/compose/master-replica/docker-compose.yml
@@ -1,0 +1,54 @@
+# Create a primary and async replica from the dockerhub images
+# db-replica can be optionally scaled using:
+# docker-compose up --scale db-replica=2
+---
+version: '3'
+
+services:
+  db-primary:
+    container_name: db-primary
+    image: crunchydata/crunchy-postgres:centos7-9.6-1.4.1
+    ports:
+    - "5432"
+    volumes:
+    - ./primary:/pgdata
+    environment:
+    - PGHOST=/tmp
+    - MAX_CONNECTIONS=101
+    - SHARED_BUFFERS=128MB
+    - MAX_WAL_SENDERS=7
+    - WORK_MEM=5MB
+    - TEMP_BUFFERS=9MB
+    - PG_MASTER_USER=master
+    - PG_MASTER_HOST=db-primary
+    - PG_MASTER_PASSWORD=password
+    - PG_MASTER_PORT=5432
+    - PG_MODE=master
+    - PG_USER=testuser
+    - PG_PASSWORD=password
+    - PG_ROOT_PASSWORD=password
+    - PG_DATABASE=userdb
+  db-replica:
+    image: crunchydata/crunchy-postgres:centos7-9.6-1.4.1
+    ports:
+    - "5432"
+    volumes:
+    - ./replica:/pgdata
+    links:
+    - db-primary
+    environment:
+    - PGHOST=/tmp
+    - MAX_CONNECTIONS=101
+    - SHARED_BUFFERS=128MB
+    - MAX_WAL_SENDERS=7
+    - WORK_MEM=5MB
+    - TEMP_BUFFERS=9MB
+    - PG_MASTER_USER=master
+    - PG_MASTER_HOST=db-primary
+    - PG_MASTER_PORT=5432
+    - PG_MASTER_PASSWORD=password
+    - PG_MODE=slave
+    - PG_USER=testuser
+    - PG_PASSWORD=password
+    - PG_ROOT_PASSWORD=password
+    - PG_DATABASE=userdb

--- a/examples/compose/master-replica/docker-compose.yml
+++ b/examples/compose/master-replica/docker-compose.yml
@@ -6,12 +6,11 @@ version: '3'
 
 services:
   db-primary:
-    container_name: db-primary
     image: crunchydata/crunchy-postgres:centos7-9.6-1.4.1
     ports:
     - "5432"
     volumes:
-    - ./primary:/pgdata
+    - primary:/pgdata
     environment:
     - PGHOST=/tmp
     - MAX_CONNECTIONS=101
@@ -33,7 +32,7 @@ services:
     ports:
     - "5432"
     volumes:
-    - ./replica:/pgdata
+    - replica:/pgdata
     links:
     - db-primary
     environment:
@@ -52,3 +51,7 @@ services:
     - PG_PASSWORD=password
     - PG_ROOT_PASSWORD=password
     - PG_DATABASE=userdb
+
+volumes:
+  primary:
+  replica:


### PR DESCRIPTION
Here's a docker-compose example of the `master-replica` example in the `docker` folder.  This uses DockerHub prebuilt images rather than building locally.  We can expand on these to include the images or build from source in the future.