### PR TITLE
Make sure docker tag of new component matches others, for uniformity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ pgsim:
 	cd sim && make
 	cp sim/build/crunchy-sim bin/crunchy-sim
 	docker build -t crunchy-sim -f $(CCP_BASEOS)/Dockerfile.sim.$(CCP_BASEOS) .
-	docker tag crunchy-sim crunchydata/crunchy-sim:$(CCP_BASEOS)-$(CCP_VERSION)
+	docker tag crunchy-sim crunchydata/crunchy-sim:$(CCP_BASEOS)-$(CCP_PGVERSION)-$(CCP_VERSION)
 
 #============
 # All target


### PR DESCRIPTION
The new sim component doesn't match the others tag-wise, so this change will allow it to be uniform.