### PR TITLE
Pg10 RHEL support and re-add pgadmin4 to Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ pgsim:
 #============
 # All target
 #============
-all:	upgrade backup collectserver dbaserver grafana pgbadger pgbouncer pgpool postgres postgres-gis prometheus promgateway watch vac backrestrestore
+all:	backup backrestrestore collectserver dbaserver grafana pgadmin4 pgbadger pgbouncer pgpool postgres postgres-gis prometheus promgateway upgrade vac watch
 
 push:
 	./bin/push-to-dockerhub.sh

--- a/rhel7/10.0/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/10.0/Dockerfile.backrest-restore.rhel7
@@ -28,7 +28,7 @@ ENV PGVERSION="10.0"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /
-ADD conf/crunchypg96.repo /etc/yum.repos.d/
+ADD conf/crunchypg10.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm  \
@@ -40,7 +40,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  	procps-ng  \
  && yum -y clean all
 
-RUN yum -y install postgresql96-server  \
+RUN yum -y install postgresql10-server  \
         crunchy-backrest \
  && yum -y clean all
 

--- a/rhel7/10.0/Dockerfile.backup.rhel7
+++ b/rhel7/10.0/Dockerfile.backup.rhel7
@@ -28,7 +28,7 @@ ENV PGVERSION="10.0"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /
-ADD conf/crunchypg96.repo /etc/yum.repos.d/
+ADD conf/crunchypg10.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
@@ -39,7 +39,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 	openssh-clients \
 	procps-ng \
 	unzip \
- && yum -y install postgresql96 postgresql96-server \
+ && yum -y install postgresql10 postgresql10-server \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata

--- a/rhel7/10.0/Dockerfile.collect.rhel7
+++ b/rhel7/10.0/Dockerfile.collect.rhel7
@@ -28,7 +28,7 @@ ENV PGVERSION="10.0"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /
-ADD conf/crunchypg96.repo /etc/yum.repos.d/
+ADD conf/crunchypg10.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN yum -y update && yum -y install gettext \
@@ -37,7 +37,7 @@ RUN yum -y update && yum -y install gettext \
 	libxslt \
 	libxml2 \
 	procps-ng \
- && yum -y install postgresql96-server \
+ && yum -y install postgresql10-server \
  && yum clean all -y
 
 # Install libstatgrab and dependencies

--- a/rhel7/10.0/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/10.0/Dockerfile.pgadmin4.rhel7
@@ -28,7 +28,7 @@ ENV PGVERSION="10.0"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /
-ADD conf/crunchypg96.repo /etc/yum.repos.d/
+ADD conf/crunchypg10.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
@@ -41,7 +41,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 	openssh-clients \
 	procps-ng \
  && yum --enablerepo rhel-7-server-extras-rpms -y install pgadmin4-v1-web \
- && yum -y install postgresql96-devel postgresql96-server \
+ && yum -y install postgresql10-devel postgresql10-server \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/rhel7/10.0/Dockerfile.pgbadger.rhel7
+++ b/rhel7/10.0/Dockerfile.pgbadger.rhel7
@@ -28,7 +28,7 @@ ENV PGVERSION="10.0"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /
-ADD conf/crunchypg96.repo /etc/yum.repos.d/
+ADD conf/crunchypg10.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN yum -y update && yum -y install hostname \

--- a/rhel7/10.0/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/10.0/Dockerfile.pgbouncer.rhel7
@@ -31,7 +31,7 @@ ADD conf/pgbouncer/docker-rhel.repo /etc/yum.repos.d/
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /
-ADD conf/crunchypg96.repo /etc/yum.repos.d/
+ADD conf/crunchypg10.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
@@ -41,7 +41,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 	nss_wrapper \
 	openssh-clients \
 	procps-ng \
- && yum -y install 	postgresql96 pgbouncer \
+ && yum -y install 	postgresql10 pgbouncer \
  && yum clean all -y
 
 # set up cpm directory

--- a/rhel7/10.0/Dockerfile.pgpool.rhel7
+++ b/rhel7/10.0/Dockerfile.pgpool.rhel7
@@ -28,11 +28,11 @@ ENV PGVERSION="10.0"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /
-ADD conf/crunchypg96.repo /etc/yum.repos.d/
+ADD conf/crunchypg10.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN yum -y update && yum -y install hostname gettext  openssh-clients  procps-ng && \
-yum -y install postgresql96 pgpool-II-96 pgpool-II-96-extensions && \
+yum -y install postgresql10 pgpool-II-10 pgpool-II-10-extensions && \
 yum -y clean all
 
 # set up cpm directory
@@ -46,8 +46,8 @@ EXPOSE 5432
 
 ADD bin/pgpool /opt/cpm/bin
 ADD conf/pgpool /opt/cpm/conf/pgpool
-ADD conf/pgpool/pool_hba.conf  /etc/pgpool-II-96/pool_hba.conf
-ADD conf/pgpool/pool_passwd /etc/pgpool-II-96/pool_passwd
+ADD conf/pgpool/pool_hba.conf  /etc/pgpool-II-10/pool_hba.conf
+ADD conf/pgpool/pool_passwd /etc/pgpool-II-10/pool_passwd
 
 RUN chown -R daemon:daemon /opt/cpm/bin
 

--- a/rhel7/10.0/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/10.0/Dockerfile.postgres-gis.rhel7
@@ -31,7 +31,7 @@ ENV PGVERSION="10.0"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /
-ADD conf/crunchypg96.repo /etc/yum.repos.d/
+ADD conf/crunchypg10.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
@@ -43,10 +43,10 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 	openssh-clients \
 	procps-ng \
  	rsync \
-        postgresql96 postgresql96-contrib postgresql96-server \
-	pgaudit96 pgaudit96_set_user \
-	crunchy-backrest plr96 \
-	postgis2_96 postgis2_96-client pgrouting_96 \
+        postgresql10 postgresql10-contrib postgresql10-server \
+	pgaudit10 pgaudit10_set_user \
+	crunchy-backrest plr10 \
+	postgis2_10 postgis2_10-client pgrouting_10 \
  && yum -y reinstall glibc-common \
  && yum -y --setopt=tsflags='' install pgaudit_analyze \
  && yum -y clean all

--- a/rhel7/10.0/Dockerfile.postgres.rhel7
+++ b/rhel7/10.0/Dockerfile.postgres.rhel7
@@ -31,7 +31,7 @@ ENV PGVERSION="10.0"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /
-ADD conf/crunchypg96.repo /etc/yum.repos.d/
+ADD conf/crunchypg10.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
@@ -43,8 +43,8 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 	procps-ng \
  	rsync \
  && yum -y reinstall glibc-common \
- && yum -y install postgresql96 postgresql96-contrib postgresql96-server \
-	pgaudit96 pgaudit96_set_user \
+ && yum -y install postgresql10 postgresql10-contrib postgresql10-server \
+	pgaudit10 pgaudit10_set_user \
 	crunchy-backrest \
  && yum -y --setopt=tsflags='' install pgaudit_analyze \
  && yum -y clean all

--- a/rhel7/10.0/Dockerfile.upgrade.rhel7
+++ b/rhel7/10.0/Dockerfile.upgrade.rhel7
@@ -28,6 +28,7 @@ ENV PGVERSION="10.0"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /
+ADD conf/crunchypg10.repo /etc/yum.repos.d/
 ADD conf/crunchypg96.repo /etc/yum.repos.d/
 ADD conf/crunchypg95.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
@@ -44,6 +45,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y install \
  postgresql95 postgresql95-server postgresql95-contrib pgaudit95 \
  postgresql96 postgresql96-server postgresql96-contrib pgaudit96 \
+ postgresql10 postgresql10-server postgresql10-contrib pgaudit10 \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /pgolddata /pgnewdata /opt/cpm/conf

--- a/rhel7/10.0/Dockerfile.watch.rhel7
+++ b/rhel7/10.0/Dockerfile.watch.rhel7
@@ -28,7 +28,7 @@ ENV PGVERSION="10.0"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /
-ADD conf/crunchypg96.repo /etc/yum.repos.d/
+ADD conf/crunchypg10.repo /etc/yum.repos.d/
 RUN rpm --import CRUNCHY-GPG-KEY.public
 
 # install docker from docker repo
@@ -46,7 +46,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 	openssh-clients \
 	procps-ng \
 	rsync \
- && yum -y install postgresql96-server atomic-openshift-clients \
+ && yum -y install postgresql10-server atomic-openshift-clients \
  && yum clean all -y
 
 # set up cpm directory


### PR DESCRIPTION
I have verified that the changes in this branch successfully will build on RHEL for:
crunchy-backup
crunchy-collect
crunchy-upgrade
crunchy-watch

This seemed like a good test set for basic builds with limited packages.
Note that no Centos testing was done with this branch at this time (so those changes are absent for now)-- only RHEL.