### PR TITLE
CentOS compiling against for pg10 pre-release versions

### DIFF
--- a/centos7/10.0/Dockerfile.backrest-restore.centos7
+++ b/centos7/10.0/Dockerfile.backrest-restore.centos7
@@ -15,9 +15,10 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos10-10-1.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+#RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/testing/10/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install epel-release \
  && yum -y install  \
@@ -28,7 +29,7 @@ RUN yum -y update && yum -y install epel-release \
  	procps-ng  \
  && yum -y clean all
 
-RUN yum -y install postgresql96-server  \
+RUN yum -y install postgresql10-server  \
         pgbackrest \
  && yum -y clean all
 

--- a/centos7/10.0/Dockerfile.backup.centos7
+++ b/centos7/10.0/Dockerfile.backup.centos7
@@ -15,10 +15,10 @@ LABEL name="crunchydata/backup" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos10-10-1.noarch.rpm"
 
-# PGDG Postgres repo
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+#RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/testing/10/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum install -y epel-release \
  && yum -y update glibc-common \
@@ -29,7 +29,7 @@ RUN yum -y update && yum install -y epel-release \
 	openssh-clients \
 	procps-ng \
 	unzip \
- && yum -y install postgresql96 postgresql96-server \
+ && yum -y install postgresql10 postgresql10-server \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /pgdata /opt/cpm/conf

--- a/centos7/10.0/Dockerfile.collect.centos7
+++ b/centos7/10.0/Dockerfile.collect.centos7
@@ -15,9 +15,10 @@ LABEL name="crunchydata/collect" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos10-10-1.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+#RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/testing/10/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install gettext \
 	hostname  \
@@ -25,7 +26,7 @@ RUN yum -y update && yum -y install gettext \
 	libxslt \
 	libxml2 \
 	procps-ng \
- && yum -y install postgresql96-server \
+ && yum -y install postgresql10-server \
  && yum clean all -y
 
 # Install libstatgrab and dependencies

--- a/centos7/10.0/Dockerfile.pgadmin4.centos7
+++ b/centos7/10.0/Dockerfile.pgadmin4.centos7
@@ -15,9 +15,10 @@ LABEL name="crunchydata/pgadmin4" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos10-10-1.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+#RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/testing/10/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install epel-release \
  && yum -y install glibc-common-*2.17* \
@@ -28,7 +29,7 @@ RUN yum -y update && yum -y install epel-release \
 	openssh-clients \
 	procps-ng \
 	pgadmin4-v1-web \
- && yum -y install postgresql96-devel postgresql96-server \
+ && yum -y install postgresql10-devel postgresql10-server \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/10.0/Dockerfile.pgbadger.centos7
+++ b/centos7/10.0/Dockerfile.pgbadger.centos7
@@ -15,9 +15,10 @@ LABEL name="crunchydata/pgbadger" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos10-10-1.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+#RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/testing/10/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install hostname \
 	pgbadger \

--- a/centos7/10.0/Dockerfile.pgbouncer.centos7
+++ b/centos7/10.0/Dockerfile.pgbouncer.centos7
@@ -15,9 +15,10 @@ LABEL name="crunchydata/pgbouncer" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos10-10-1.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+#RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/testing/10/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 # install docker from docker repo
 ADD conf/pgbouncer/docker-rhel.repo /etc/yum.repos.d/
@@ -29,7 +30,7 @@ RUN yum -y update && yum -y install epel-release \
 	nss_wrapper \
 	openssh-clients \
 	procps-ng \
- && yum -y install 	postgresql96 pgbouncer \
+ && yum -y install 	postgresql10 pgbouncer \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf

--- a/centos7/10.0/Dockerfile.pgpool.centos7
+++ b/centos7/10.0/Dockerfile.pgpool.centos7
@@ -15,16 +15,16 @@ LABEL name="crunchydata/pgpool" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos10-10-1.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
-
+#RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/testing/10/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install hostname \
 	gettext \
 	openssh-clients \
 	procps-ng \
- && yum -y install postgresql96 pgpool-II-96 pgpool-II-96-extensions \
+ && yum -y install postgresql10 pgpool-II-10 pgpool-II-10-extensions \
  && yum -y clean all
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf
@@ -37,8 +37,8 @@ EXPOSE 5432
 
 ADD bin/pgpool /opt/cpm/bin
 ADD conf/pgpool /opt/cpm/conf/pgpool
-ADD conf/pgpool/pool_hba.conf  /etc/pgpool-II-96/pool_hba.conf
-ADD conf/pgpool/pool_passwd /etc/pgpool-II-96/pool_passwd
+ADD conf/pgpool/pool_hba.conf  /etc/pgpool-II-10/pool_hba.conf
+ADD conf/pgpool/pool_passwd /etc/pgpool-II-10/pool_passwd
 
 RUN chown -R daemon:daemon /opt/cpm/bin
 

--- a/centos7/10.0/Dockerfile.postage.centos7
+++ b/centos7/10.0/Dockerfile.postage.centos7
@@ -15,16 +15,17 @@ LABEL name="crunchydata/postage" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos10-10-1.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+#RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/testing/10/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install epel-release \
  && yum -y install glibc-common-*2.17* \
  && yum -y install gcc \
  openssl-devel \
  openssl
- && yum -y install postgresql96-devel postgresql96-server \
+ && yum -y install postgresql10-devel postgresql10-server \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/10.0/Dockerfile.postgres-gis.centos7
+++ b/centos7/10.0/Dockerfile.postgres-gis.centos7
@@ -15,9 +15,10 @@ LABEL name="crunchydata/postgres-gis" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos10-10-1.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+#RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/testing/10/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install epel-release \
  && yum -y update glibc-common \
@@ -28,11 +29,11 @@ RUN yum -y update && yum -y install epel-release \
 	openssh-clients \
  	procps-ng  \
 	rsync \
-	postgresql96-server postgresql96-contrib postgresql96 \
-	R-core libRmath plr96 \
-	pgaudit_96 \
+	postgresql10-server postgresql10-contrib postgresql10 \
+	R-core libRmath plr10 \
+	pgaudit_10 \
 	pgbackrest \
-	postgis2_96 postgis2_96-client \
+	postgis2_10 postgis2_10-client \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/10.0/Dockerfile.postgres.centos7
+++ b/centos7/10.0/Dockerfile.postgres.centos7
@@ -15,9 +15,10 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos10-10-1.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+#RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/testing/10/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install epel-release \
  && yum -y update glibc-common \
@@ -31,8 +32,8 @@ RUN yum -y update && yum -y install epel-release \
 	rsync \
  && yum -y clean all
 
-RUN yum -y install postgresql96-server postgresql96-contrib postgresql96 \
-	pgaudit_96 \
+RUN yum -y install postgresql10-server postgresql10-contrib postgresql10 \
+	pgaudit_10 \
 	pgbackrest \
  && yum -y clean all
 

--- a/centos7/10.0/Dockerfile.upgrade.centos7
+++ b/centos7/10.0/Dockerfile.upgrade.centos7
@@ -17,6 +17,8 @@ LABEL name="crunchydata/upgrade" \
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/pgdg-centos95-9.5-3.noarch.rpm
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm
+#RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/10.0/redhat/rhel-7-x86_64/pgdg-centos10-10-1.noarch.rpm
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/testing/10/redhat/rhel-7-x86_64/pgdg-centos10-10-1.noarch.rpm
 
 RUN yum -y update && yum install -y epel-release \
  && yum -y update glibc-common \
@@ -30,6 +32,7 @@ RUN yum -y update && yum install -y epel-release \
  && yum -y install \
  postgresql95 postgresql95-server postgresql95-contrib pgaudit_95 \
  postgresql96 postgresql96-server postgresql96-contrib pgaudit_96 \
+ postgresql10 postgresql10-server postgresql10-contrib pgaudit_10 \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /pgolddata /pgnewdata /opt/cpm/conf

--- a/centos7/10.0/Dockerfile.watch.centos7
+++ b/centos7/10.0/Dockerfile.watch.centos7
@@ -15,9 +15,10 @@ LABEL name="crunchydata/watch" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="10.0" PGDG_REPO="pgdg-centos10-10-1.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+#RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/testing/10/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 # install docker from docker repo
 ADD conf/watch/docker-rhel.repo /etc/yum.repos.d/
@@ -35,7 +36,7 @@ RUN yum -y update && yum -y install epel-release \
 	openssh-clients \
 	procps-ng \
 	rsync \
- && yum -y install postgresql96-server atomic-openshift-clients \
+ && yum -y install postgresql10-server atomic-openshift-clients \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf


### PR DESCRIPTION
The CentOS builds now work on PG10, but there are some cautions here:

1. When PG10 becomes official, the repos will need to change to use the official repo file.  Right now, the Dockerfiles are pointing to the pre-release area to allow things to function.  I left a commented line in the dockerfile above each pre-release repo definition which is where I believe the final PG10 repo will be staged.  If that's the case, fixing this will be as easy as just uncommenting a line and removing the test repo line for each Dockerfile on the day that PG10 comes out officially.
2. PGDG does not yet have everything in their pg10 repo.  Because of this, certain images will build, but they are missing content:
- postgres-gis (missing plr10, pgaudit_10, postgis2_10 postgis2_10-client packages)
- postgres (missing pgaudit_10 package)
- upgrade (missing pgaudit_10 package)

Regardless, this branch does build, so this is perhaps worth consideration for merging to the master branch.