### PR TITLE
Fix breakage due to PGDG supporting multiple postgis versions per PG version

### DIFF
--- a/centos7/9.5/Dockerfile.postgres-gis.centos7
+++ b/centos7/9.5/Dockerfile.postgres-gis.centos7
@@ -32,7 +32,7 @@ RUN yum -y update && yum -y install epel-release \
 	R-core libRmath plr95 \
 	pgaudit_95 \
 	pgbackrest \
-	postgis2_95 postgis2_95-client  \
+	postgis22_95 postgis22_95-client  \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/9.6/Dockerfile.postgres-gis.centos7
+++ b/centos7/9.6/Dockerfile.postgres-gis.centos7
@@ -32,7 +32,7 @@ RUN yum -y update && yum -y install epel-release \
 	R-core libRmath plr96 \
 	pgaudit_96 \
 	pgbackrest \
-	postgis2_96 postgis2_96-client \
+	postgis23_96 postgis23_96-client \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"


### PR DESCRIPTION
The CentOS build for PG95 was breaking due to conflicts when it didn't know which PostGIS to choose.  There's a similar issue in PG96.  By selecting a specific version of PostGIS per PG instead of letting it float, the issue is solved.