### PR TITLE
Update all example references to 1.6.0

### DIFF
--- a/bin/tag.sh
+++ b/bin/tag.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CCP_VERSION=1.4.0
+CCP_VERSION=1.6.0
 REGISTRY=52.2.93.43:5000
 containers="crunchydata/crunchy-vacuum crunchydata/crunchy-prometheus crunchydata/crunchy-promgateway crunchydata/crunchy-grafana crunchydata/crunchy-collect crunchydata/crunchy-pgbadger crunchydata/crunchy-pgpool crunchydata/crunchy-watch crunchydata/crunchy-backup crunchydata/crunchy-postgres"
 for i in $containers;

--- a/docs/all-in-one/all-in-one.adoc
+++ b/docs/all-in-one/all-in-one.adoc
@@ -1,6 +1,6 @@
 = all-in-one explained
 Crunchy Data Solutions, Inc.
-v1.4.0, {docdate}
+v1.6.0, {docdate}
 :title-logo-image: image:crunchy_logo.png["CrunchyData Logo",align="center",scaledwidth="80%"]
 
 == All-In-One Crunchy OSE Image
@@ -58,7 +58,7 @@ Firefox is installed and the OpenShift console is available at https://10.0.2.15
 
 === Crunchy Images
 
-The crunchy version 1.4.0 container images are preinstalled
+The crunchy version 1.6.0 container images are preinstalled
 in the VM instance.
 
 === Crunchy Examples

--- a/docs/all-in-one/bashrc
+++ b/docs/all-in-one/bashrc
@@ -1,1 +1,1 @@
-export CCP_IMAGE_TAG=centos7-9.6-1.4.0
+export CCP_IMAGE_TAG=centos7-9.6-1.6.0

--- a/docs/all-in-one/crunchy-on-ose.sh
+++ b/docs/all-in-one/crunchy-on-ose.sh
@@ -86,7 +86,7 @@ function clone {
 	mkdir -p $HOME/cdev/bin $HOME/cdev/src $HOME/cdev/pkg
 	export GOPATH=$HOME/cdev
 	export CCPROOT=$GOPATH/src/github.com/crunchydata/crunchy-containers
-	export CCP_IMAGE_TAG=centos7-9.6-1.4.0
+	export CCP_IMAGE_TAG=centos7-9.6-1.6.0
 	export GOBIN=$GOPATH/bin
 	cd $HOME/cdev/src
 	mkdir -p github.com/crunchydata

--- a/docs/bump.sh
+++ b/docs/bump.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-OLD="1.3.0"
-NEW="1.4.0"
+OLD="1.5.0"
+NEW="1.6.0"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DPATH=$DIR/*.adoc
 BPATH=/tmp/backups

--- a/docs/dedicated.adoc
+++ b/docs/dedicated.adoc
@@ -66,7 +66,7 @@ mkdir crunchydata
 cd crunchydata
 git clone https://github.com/crunchydata/crunchy-containers
 cd crunchy-containers
-git checkout 1.5
+git checkout 1.6.0
 godep restore
 ....
 

--- a/docs/examples.adoc
+++ b/docs/examples.adoc
@@ -2564,13 +2564,13 @@ you perform a pg_upgrade on a 9.5 database converting its data
 to a 9.6 version.
 
 This example assumes you have run *primary-pvc* using a PG 9.5 image
-such as *centos7-9.5-1.5* prior to running this upgrade.
+such as *centos7-9.5-1.6.0* prior to running this upgrade.
 
 Prior to starting this example, shut down the *primary-pvc* database
 using the *examples/kube/primary-pvc/cleanup.sh* script.
 
 Prior to running this example, make sure your CCP_IMAGE_TAG
-environment variable is using a PG 9.6 image such as *centos7-9.6-1.5*.
+environment variable is using a PG 9.6 image such as *centos7-9.6-1.6.0*.
 
 Start the upgrade as follows:
 ....

--- a/examples/compose/primary-replica/docker-compose.yml
+++ b/examples/compose/primary-replica/docker-compose.yml
@@ -6,7 +6,7 @@ version: '3'
 
 services:
   db-primary:
-    image: crunchydata/crunchy-postgres:centos7-9.6-1.5
+    image: crunchydata/crunchy-postgres:centos7-9.6-1.6.0
     ports:
     - "5432"
     volumes:
@@ -28,7 +28,7 @@ services:
     - PG_ROOT_PASSWORD=password
     - PG_DATABASE=userdb
   db-replica:
-    image: crunchydata/crunchy-postgres:centos7-9.6-1.5
+    image: crunchydata/crunchy-postgres:centos7-9.6-1.6.0
     ports:
     - "5432"
     volumes:

--- a/examples/dedicated/crunchy-backup/backup-job.json
+++ b/examples/dedicated/crunchy-backup/backup-job.json
@@ -45,7 +45,7 @@
     }, {
         "name": "CCP_IMAGE_TAG",
         "description": "image tag to use",
-        "value": "rhel7-9.6-1.5"
+        "value": "rhel7-9.6-1.6.0"
     }],
 
     "objects": [{

--- a/examples/dedicated/crunchy-backup/example.sh
+++ b/examples/dedicated/crunchy-backup/example.sh
@@ -28,7 +28,7 @@ oc process -n $PROJECT crunchy-backup \
 	DB_NAME=example \
 	BACKUP_USER=primaryuser \
 	BACKUP_PASS=password \
-	CCP_IMAGE_TAG=rhel7-9.6-1.4.0 \
+	CCP_IMAGE_TAG=rhel7-9.6-1.6.0 \
 	CCP_IMAGE_PREFIX=172.30.240.45:5000/$PROJECT \
 	PVC_NAME=backup-pvc \
 	PVC_SIZE=300M \

--- a/examples/dedicated/crunchy-pgadmin4/example.sh
+++ b/examples/dedicated/crunchy-pgadmin4/example.sh
@@ -25,7 +25,7 @@ PROJECT=jeff-project
 
 oc process -n $PROJECT crunchy-pgadmin4 \
 	NAME=pgadmin4 \
-	CCP_IMAGE_TAG=rhel7-9.6-1.4.0 \
+	CCP_IMAGE_TAG=rhel7-9.6-1.6.0 \
 	CCP_IMAGE_PREFIX=172.30.240.45:5000/$PROJECT \
 	PVC_NAME=pgadmin4-pvc \
 	PVC_SIZE=300M \

--- a/examples/dedicated/crunchy-pgadmin4/pgadmin4.json
+++ b/examples/dedicated/crunchy-pgadmin4/pgadmin4.json
@@ -21,7 +21,7 @@
         }, {
             "name": "CCP_IMAGE_TAG",
             "description": "image version to use",
-            "value": "rhel7-9.6-1.4.0"
+            "value": "rhel7-9.6-1.6.0"
         }, {
             "name": "PVC_NAME",
             "description": "The name for the pvc",

--- a/examples/dedicated/crunchy-primary/example.sh
+++ b/examples/dedicated/crunchy-primary/example.sh
@@ -33,7 +33,7 @@ oc process -n $PROJECT crunchy-primary \
 	PG_PASSWORD=password \
 	PG_DATABASE=userdb \
 	PG_ROOT_PASSWORD=password \
-	CCP_IMAGE_TAG=rhel7-9.6-1.4.0 \
+	CCP_IMAGE_TAG=rhel7-9.6-1.6.0 \
 	CCP_IMAGE_PREFIX=172.30.240.45:5000/$PROJECT \
 	CCP_IMAGE_NAME=crunchy-postgres \
 	PVC_NAME=example-pvc \

--- a/examples/dedicated/crunchy-primary/primary.json
+++ b/examples/dedicated/crunchy-primary/primary.json
@@ -28,7 +28,7 @@
     }, {
         "name": "CCP_IMAGE_TAG",
         "description": "The image tag to use",
-        "value": "rhel7-9.6-1.5"
+        "value": "rhel7-9.6-1.6.0"
     }, {
         "name": "CCP_IMAGE_PREFIX",
         "description": "The image prefix to use",

--- a/examples/dedicated/crunchy-replica/example.sh
+++ b/examples/dedicated/crunchy-replica/example.sh
@@ -24,7 +24,7 @@ PROJECT=jeff-project
 #oc process --parameters -n $PROJECT crunchy-replica
 
 oc process -n $PROJECT crunchy-replica \
-	CCP_IMAGE_TAG=rhel7-9.6-1.4.0 \
+	CCP_IMAGE_TAG=rhel7-9.6-1.6.0 \
 	CCP_IMAGE_PREFIX=172.30.240.45:5000/$PROJECT \
 	CCP_IMAGE_NAME=crunchy-postgres \
 	SERVICE_NAME=replica \

--- a/examples/dedicated/crunchy-replica/replica.json
+++ b/examples/dedicated/crunchy-replica/replica.json
@@ -17,7 +17,7 @@
     }, {
         "name": "CCP_IMAGE_TAG",
         "description": "the image tag to use",
-        "value": "rhel7-9.6-1.5"
+        "value": "rhel7-9.6-1.6.0"
     }, {
         "name": "CCP_IMAGE_NAME",
         "description": "The image name to use",

--- a/examples/dedicated/crunchy-restore/example.sh
+++ b/examples/dedicated/crunchy-restore/example.sh
@@ -33,7 +33,7 @@ oc process -n $PROJECT crunchy-restore \
 	PG_PASSWORD=password \
 	PG_DATABASE=userdb \
 	PG_ROOT_PASSWORD=password \
-	CCP_IMAGE_TAG=rhel7-9.6-1.4.0 \
+	CCP_IMAGE_TAG=rhel7-9.6-1.6.0 \
 	CCP_IMAGE_PREFIX=172.30.240.45:5000/$PROJECT \
 	CCP_IMAGE_NAME=crunchy-postgres \
 	BACKUP_PATH=example-backups/2017-04-05-13-25-51 \

--- a/examples/dedicated/crunchy-restore/primary-restore.json
+++ b/examples/dedicated/crunchy-restore/primary-restore.json
@@ -36,7 +36,7 @@
     }, {
         "name": "CCP_IMAGE_TAG",
         "description": "The image tag to use",
-        "value": "rhel7-9.6-1.5"
+        "value": "rhel7-9.6-1.6.0"
     }, {
         "name": "PG_PRIMARY_PASSWORD",
         "description": "The password for the PG primary user",

--- a/examples/dedicated/push-images.sh
+++ b/examples/dedicated/push-images.sh
@@ -27,7 +27,7 @@ docker login -p $TOKEN -u unused $REG
 
 #	for CONTAINER in "crunchy-postgres" "crunchy-postgres-gis" "crunchy-backup" "crunchy-pgadmin4"
 # tag the local image using openshift naming
-for CCP_IMAGE_TAG in "rhel7-9.6-1.5"
+for CCP_IMAGE_TAG in "rhel7-9.6-1.6.0"
 do
 	for CONTAINER in "crunchy-pgadmin4"
 	do

--- a/examples/openshift/workshop/README.adoc
+++ b/examples/openshift/workshop/README.adoc
@@ -1,7 +1,7 @@
 
 = Openshift Tutorial - Crunchy Containers
 Crunchy Data Solutions, Inc.
-v1.4.0, {docdate}
+v1.6.0, {docdate}
 :title-logo-image: image:crunchy_logo.png["CrunchyData Logo",align="center",scaledwidth="80%"]
 
 == Openshift Tutorial
@@ -42,16 +42,16 @@ be entered for configured databases.
 To execute the examples, pull down the container images
 from Dockerhub onto the VM host:
 ....
-docker pull crunchydata/crunchy-postgres:centos7-9.5-1.4.0
-docker pull crunchydata/crunchy-postgres-gis:centos7-9.5-1.4.0
-docker pull crunchydata/crunchy-backup:centos7-9.5-1.4.0
-docker pull crunchydata/crunchy-collect:centos7-9.5-1.4.0
-docker pull crunchydata/crunchy-pgbadger:centos7-9.5-1.4.0
-docker pull crunchydata/crunchy-pgadmin4:centos7-9.5-1.4.0
-docker pull crunchydata/crunchy-prometheus:centos7-9.5-1.4.0
-docker pull crunchydata/crunchy-promgateway:centos7-9.5-1.4.0
-docker pull crunchydata/crunchy-grafana:centos7-9.5-1.4.0
-docker pull crunchydata/crunchy-watch:centos7-9.5-1.4.0
+docker pull crunchydata/crunchy-postgres:centos7-9.5-1.6.0
+docker pull crunchydata/crunchy-postgres-gis:centos7-9.5-1.6.0
+docker pull crunchydata/crunchy-backup:centos7-9.5-1.6.0
+docker pull crunchydata/crunchy-collect:centos7-9.5-1.6.0
+docker pull crunchydata/crunchy-pgbadger:centos7-9.5-1.6.0
+docker pull crunchydata/crunchy-pgadmin4:centos7-9.5-1.6.0
+docker pull crunchydata/crunchy-prometheus:centos7-9.5-1.6.0
+docker pull crunchydata/crunchy-promgateway:centos7-9.5-1.6.0
+docker pull crunchydata/crunchy-grafana:centos7-9.5-1.6.0
+docker pull crunchydata/crunchy-watch:centos7-9.5-1.6.0
 ....
 
 
@@ -60,12 +60,12 @@ Running the example:
 ....
 git clone https://github.com/crunchydata/crunchy-containers.git
 cd crunchy-containers/examples/workshop
-oc new-app -p CCP_IMAGE_TAG=centos7-9.5-1.4.0 -f primary.json
-oc new-app -p CCP_IMAGE_TAG=centos7-9.5-1.4.0 -f replicas.json
-oc new-app -p CCP_IMAGE_TAG=centos7-9.5-1.4.0 -f pgadmin4.json
-oc new-app -p CCP_IMAGE_TAG=centos7-9.5-1.4.0 -f metrics.json
+oc new-app -p CCP_IMAGE_TAG=centos7-9.5-1.6.0 -f primary.json
+oc new-app -p CCP_IMAGE_TAG=centos7-9.5-1.6.0 -f replicas.json
+oc new-app -p CCP_IMAGE_TAG=centos7-9.5-1.6.0 -f pgadmin4.json
+oc new-app -p CCP_IMAGE_TAG=centos7-9.5-1.6.0 -f metrics.json
 oc policy add-role-to-group edit system:serviceaccounts -n default
-oc new-app -p CCP_IMAGE_TAG=centos7-9.5-1.4.0 -f watch.json
+oc new-app -p CCP_IMAGE_TAG=centos7-9.5-1.6.0 -f watch.json
 oc create -f jeff-route.json
 ....
 

--- a/examples/templates-sml/backup/backup-job.json
+++ b/examples/templates-sml/backup/backup-job.json
@@ -37,7 +37,7 @@
     }, {
         "name": "CCP_IMAGE_TAG",
         "description": "image tag to use",
-        "value": "rhel7-9.6-1.5"
+        "value": "rhel7-9.6-1.6.0"
     }],
 
     "objects": [{

--- a/examples/templates-sml/crunchy-large/example.sh
+++ b/examples/templates-sml/crunchy-large/example.sh
@@ -33,7 +33,7 @@ oc process -n $PROJECT crunchy-primary \
 	PG_PASSWORD=password \
 	PG_DATABASE=userdb \
 	PG_ROOT_PASSWORD=password \
-	CCP_IMAGE_TAG=rhel7-9.6-1.4.0 \
+	CCP_IMAGE_TAG=rhel7-9.6-1.6.0 \
 	CCP_IMAGE_PREFIX=172.30.240.45:5000/$PROJECT \
 	CCP_IMAGE_NAME=crunchy-postgres \
 	PVC_NAME=example-pvc \

--- a/examples/templates-sml/crunchy-large/large.json
+++ b/examples/templates-sml/crunchy-large/large.json
@@ -16,7 +16,7 @@
     }, {
         "name": "CCP_IMAGE_TAG",
         "description": "The image tag to use",
-        "value": "rhel7-9.6-1.5"
+        "value": "rhel7-9.6-1.6.0"
     }, {
         "name": "PG_PRIMARY_PASSWORD",
         "description": "The password for the PG primary user",

--- a/examples/templates-sml/crunchy-medium/example.sh
+++ b/examples/templates-sml/crunchy-medium/example.sh
@@ -33,7 +33,7 @@ oc process -n $PROJECT crunchy-primary \
 	PG_PASSWORD=password \
 	PG_DATABASE=userdb \
 	PG_ROOT_PASSWORD=password \
-	CCP_IMAGE_TAG=rhel7-9.6-1.4.0 \
+	CCP_IMAGE_TAG=rhel7-9.6-1.6.0 \
 	CCP_IMAGE_PREFIX=172.30.240.45:5000/$PROJECT \
 	CCP_IMAGE_NAME=crunchy-postgres \
 	PVC_NAME=example-pvc \

--- a/examples/templates-sml/crunchy-medium/medium.json
+++ b/examples/templates-sml/crunchy-medium/medium.json
@@ -16,7 +16,7 @@
     }, {
         "name": "CCP_IMAGE_TAG",
         "description": "The image tag to use",
-        "value": "rhel7-9.6-1.5"
+        "value": "rhel7-9.6-1.6.0"
     }, {
         "name": "PG_PRIMARY_PASSWORD",
         "description": "The password for the PG primary user",

--- a/examples/templates-sml/crunchy-small/example.sh
+++ b/examples/templates-sml/crunchy-small/example.sh
@@ -33,7 +33,7 @@ oc process -n $PROJECT crunchy-primary \
 	PG_PASSWORD=password \
 	PG_DATABASE=userdb \
 	PG_ROOT_PASSWORD=password \
-	CCP_IMAGE_TAG=rhel7-9.6-1.4.0 \
+	CCP_IMAGE_TAG=rhel7-9.6-1.6.0 \
 	CCP_IMAGE_PREFIX=172.30.240.45:5000/$PROJECT \
 	CCP_IMAGE_NAME=crunchy-postgres \
 	PVC_NAME=example-pvc \

--- a/examples/templates-sml/crunchy-small/small.json
+++ b/examples/templates-sml/crunchy-small/small.json
@@ -16,7 +16,7 @@
     }, {
         "name": "CCP_IMAGE_TAG",
         "description": "The image tag to use",
-        "value": "rhel7-9.6-1.5"
+        "value": "rhel7-9.6-1.6.0"
     }, {
         "name": "PG_PRIMARY_PASSWORD",
         "description": "The password for the PG primary user",

--- a/examples/templates-sml/metrics/metrics.json
+++ b/examples/templates-sml/metrics/metrics.json
@@ -12,7 +12,7 @@
     },
     "parameters": [{
         "name": "CCP_IMAGE_TAG",
-        "value": "rhel7-9.6-1.5",
+        "value": "rhel7-9.6-1.6.0",
         "description": "The image tag to use"
     }, {
         "name": "STORAGE_CLASS",


### PR DESCRIPTION
All example references updated.

The only one I question a bit was docs/dedicated.adoc.  I assume that the git tag will be 1.6.0 instead of 1.6.  If that's not the case, please let me know and I can push a change to have it be 1.6.