### PR TITLE
Update EPEL paths that have changed to allow RHEL builds to work again

### DIFF
--- a/bin/install-deps.sh
+++ b/bin/install-deps.sh
@@ -68,8 +68,8 @@ fi
 # Install libstatgrab dependencies for collectapi container
 #
 
-sudo yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/l/log4cplus-1.1.3-0.4.rc3.el7.x86_64.rpm
-sudo yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/l/log4cplus-devel-1.1.3-0.4.rc3.el7.x86_64.rpm
-sudo yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/l/libstatgrab-0.91-4.el7.x86_64.rpm
-sudo yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/l/libstatgrab-devel-0.91-4.el7.x86_64.rpm
+sudo yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/l/log4cplus-1.1.3-0.4.rc3.el7.x86_64.rpm
+sudo yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/l/log4cplus-devel-1.1.3-0.4.rc3.el7.x86_64.rpm
+sudo yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/l/libstatgrab-0.91-4.el7.x86_64.rpm
+sudo yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/l/libstatgrab-devel-0.91-4.el7.x86_64.rpm
 sudo yum -y install gcc

--- a/rhel7/10/Dockerfile.collect.rhel7
+++ b/rhel7/10/Dockerfile.collect.rhel7
@@ -42,8 +42,8 @@ nss_wrapper \
  && yum clean all -y
 
 # Install libstatgrab and dependencies
-RUN yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/l/log4cplus-1.1.3-0.4.rc3.el7.x86_64.rpm
-Run yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/l/libstatgrab-0.91-4.el7.x86_64.rpm
+RUN yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/l/log4cplus-1.1.3-0.4.rc3.el7.x86_64.rpm
+Run yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/l/libstatgrab-0.91-4.el7.x86_64.rpm
 
 # set up cpm directory
 RUN mkdir -p /opt/cpm/bin

--- a/rhel7/9.5/Dockerfile.collect.rhel7
+++ b/rhel7/9.5/Dockerfile.collect.rhel7
@@ -40,8 +40,8 @@ hostname  \
  && yum clean all -y
 
 # Install libstatgrab and dependencies
-RUN yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/l/log4cplus-1.1.3-0.4.rc3.el7.x86_64.rpm
-Run yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/l/libstatgrab-0.91-4.el7.x86_64.rpm
+RUN yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/l/log4cplus-1.1.3-0.4.rc3.el7.x86_64.rpm
+Run yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/l/libstatgrab-0.91-4.el7.x86_64.rpm
 
 # set up cpm directory
 #

--- a/rhel7/9.6/Dockerfile.collect.rhel7
+++ b/rhel7/9.6/Dockerfile.collect.rhel7
@@ -43,8 +43,8 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum clean all -y
 
 # Install libstatgrab and dependencies
-RUN yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/l/log4cplus-1.1.3-0.4.rc3.el7.x86_64.rpm
-Run yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/l/libstatgrab-0.91-4.el7.x86_64.rpm
+RUN yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/l/log4cplus-1.1.3-0.4.rc3.el7.x86_64.rpm
+Run yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/l/libstatgrab-0.91-4.el7.x86_64.rpm
 
 # set up cpm directory
 RUN mkdir -p /opt/cpm/bin


### PR DESCRIPTION
It appears that EPEL has updated some pathing for direct downloads of files.

As an example, the file here:
https://dl.fedoraproject.org/pub/epel/7/x86_64/l/log4cplus-1.1.3-0.4.rc3.el7.x86_64.rpm
no longer exists and has been moved to a "Packages" subfolder, i.e.:
https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/l/log4cplus-1.1.3-0.4.rc3.el7.x86_64.rpm

This change should take care of all of the impacted files.