### PR TITLE
change autowidth to width=100% to get past build-docs.sh error

### DIFF
--- a/docs/metrics.adoc
+++ b/docs/metrics.adoc
@@ -260,7 +260,7 @@ tcpstat, Exposes TCP connection status information from `/proc/net/tcp` and `/pr
 
 These metrics will be deprecated and (re)moved in future releases of node_exporter.
 
-[%autowidth.spread]
+[width="100%"]
 |===
 | Name | Description
 


### PR DESCRIPTION
On CentOS 7, the following procedure fails:
- yum install asciidoc
- yum install dblatex
- cd crunchy-containers/docs
- ./build-docs.sh 

Digging further, the offending item is metrics.adoc.  Here's how to reproduce the issue:
/usr/bin/asciidoc.py --backend docbook -a "a2x-format=pdf" --out-file metrics.xml metrics.adoc

This will generate the following output:
asciidoc: WARNING: metrics.adoc: line 231: table row 5: exceeds columns span
asciidoc: WARNING: metrics.adoc: line 231: table row 11: exceeds columns span
asciidoc: ERROR: metrics.adoc: line 264: illegal style name: %autowidth.spread

In order to solve the error, I switched the autowidth.spread line to a width=100%, which now passes the asciidoc translation.  I'm not an asciidoc expert, but I believe this is the equivalent answer that will work with the base yum libraries.  If I'm wrong, feel free to suggest an alternative.