### PR TITLE
Update the statefulset-dyn spec to enable successful deployment of replication cluster

### DIFF
--- a/examples/kube/statefulset-dyn/set.json
+++ b/examples/kube/statefulset-dyn/set.json
@@ -14,6 +14,9 @@
                 }
             },
             "spec": {
+                "securityContext":{
+                    "fsGroup": 26
+                },
                 "containers": [{
                     "name": "pgset",
                     "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
@@ -29,7 +32,7 @@
                         "value": "/tmp"
                     }, {
                         "name": "PG_MODE",
-                        "value": "primary"
+                        "value": "set"
                     }, {
                         "name": "PG_PRIMARY_PASSWORD",
                         "value": "password"
@@ -45,6 +48,12 @@
                     }, {
                         "name": "PG_ROOT_PASSWORD",
                         "value": "password"
+                    }, {
+                        "name": "PG_PRIMARY_PORT",
+                        "value": "5432"
+                    }, {
+                        "name": "PG_PRIMARY_HOST",
+                        "value": "pgset-primary"
                     }],
                     "volumeMounts": [{
                         "name": "pgdata",


### PR DESCRIPTION
1. Why is this change necessary?

- The example spec at: 
https://github.com/CrunchyData/crunchycontainers/blob/master/examples/kube/statefulset-dyn  needs a few updates to successfully deploy a replication cluster

2. How does this change address the issue?

- This commit makes the following edits to achieve the said objective:

   - Add securityContext with fsgroup: 26
   - Change PG_MODE value to "set" instead of "primary"
   - Add PG_PRIMARY_PORT with value set to 5432
   - Add PG_PRIMARY_HOST with value set to "pgset-primary"

3. Which issue does this address?
- fixes #287 

Signed-off-by: ksatchit <karthik.s@cloudbyte.com>