### PR TITLE
Add note about min server spec

### DIFF
--- a/docs/install.adoc
+++ b/docs/install.adoc
@@ -311,6 +311,15 @@ OpenShift Enterprise on your host.  The main instructions are here:
 
 https://docs.openshift.com/container-platform/3.6/install_config/install/quick_install.html
 
+*Note:* If you install OpenShift Enterprise on a server with less than `16GB` memory and `40GB` 
+of disk, the following Ansible variables need to be added to `~/.config/openshift/installer.cfg.yml`
+prior to installation:
+
+```
+openshift_check_min_host_disk_gb: '10' # min 10gb disk
+openshift_check_min_host_memory_gb: '3' # min 3gb memory 
+```
+
 For testing purposes, OpenShift Origin is the simplest to install and configure. The
 easiest way to get OpenShift Origin up and running is through the link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md[oc cluster up] cluster configuration.
 


### PR DESCRIPTION
This adds a note about the newest OSE (3.6) installation enforcing minimum requirements on the target servers and how you can override them.