### PR TITLE
Add configmap example for openshift

### DIFF
--- a/examples/openshift/backrest-restore/delta-restore-job.json
+++ b/examples/openshift/backrest-restore/delta-restore-job.json
@@ -1,60 +1,88 @@
 {
-    "apiVersion": "batch/v1",
-    "kind": "Job",
-    "metadata": {
-        "name": "backrest-job-nfs"
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "backrest-job-nfs"
+  },
+  "parameters": [
+    {
+      "name": "CCP_IMAGE_PREFIX",
+      "description": "The image prefix to use"
     },
-    "spec": {
+    {
+      "name": "CCP_IMAGE_TAG",
+      "description": "The image tag to use"
+    }
+  ],
+  "objects": [
+    {
+      "kind": "Job",
+      "apiVersion": "batch/v1",
+      "metadata": {
+        "name": "backrest-job-nfs"
+      },
+      "spec": {
         "template": {
-            "metadata": {
-                "name": "backrest-job-nfs",
-                "labels": {
-                    "app": "backrest-job-nfs"
+          "labels": {
+            "app": "backrest-job-nfs"
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "pgconf",
+                "configMap": {
+                  "name": "backrestconf"
                 }
-            },
-        "spec": {
-            "containers": [{
+              },
+              {
+                "name": "backrestrepo",
+                "persistentVolumeClaim": {
+                  "claimName": "crunchy-pvc2"
+                }
+              },
+              {
+                "name": "pgdata",
+                "persistentVolumeClaim": {
+                  "claimName": "crunchy-pvc"
+                }
+              }
+            ],
+            "containers": [
+              {
                 "name": "backrest-restore",
-                "image": "crunchydata/crunchy-backrest-restore:$CCP_IMAGE_TAG",
-                "env": [{
-                    "name": "STANZA",
-                    "value": "db"
-                }, {
-		    "name": "DELTA"
-		}],
-                "volumeMounts": [{
+                "image": "${CCP_IMAGE_PREFIX}/crunchy-backrest-restore:${CCP_IMAGE_TAG}",
+                "volumeMounts": [
+                  {
                     "mountPath": "/pgdata",
                     "name": "pgdata",
                     "readOnly": false
-                }, {
+                  },
+                  {
                     "mountPath": "/pgconf",
                     "name": "pgconf",
-                    "readOnly": true
-                }, {
+                    "readOnly": false
+                  },
+                  {
                     "mountPath": "/backrestrepo",
                     "name": "backrestrepo",
                     "readOnly": false
-                }]
-            }],
-            "volumes": [{
-                "name": "pgconf",
-                "configMap": {
-                    "name": "backrestconf"
-                }
-            }, {
-                "name": "backrestrepo",
-                "persistentVolumeClaim": {
-                    "claimName": "crunchy-pvc2"
-                }
-            }, {
-                "name": "pgdata",
-           	     "persistentVolumeClaim": {
-                    "claimName": "crunchy-pvc"
-          	     }
-            }],
-                "restartPolicy": "Never"
-    	}
-
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "STANZA",
+                    "value": "db"
+                  },
+                  {
+                    "name": "DELTA"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Never"
+          }
         }
+      }
     }
+  ]
 }

--- a/examples/openshift/backrest-restore/delta-restore.sh
+++ b/examples/openshift/backrest-restore/delta-restore.sh
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 oc delete job backrest-job-nfs
-
-expenv -f $DIR/delta-restore-job.json | oc create -f -
+oc process -f $DIR/delta-restore-job.json CCP_IMAGE_PREFIX=$CCP_IMAGE_PREFIX CCP_IMAGE_TAG=$CCP_IMAGE_TAG | oc create -f -

--- a/examples/openshift/backrest-restore/full-restore-job.json
+++ b/examples/openshift/backrest-restore/full-restore-job.json
@@ -1,58 +1,85 @@
 {
-    "apiVersion": "batch/v1",
-    "kind": "Job",
-    "metadata": {
-        "name": "backrest-job-nfs"
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "backrest-job-nfs"
+  },
+  "parameters": [
+    {
+      "name": "CCP_IMAGE_PREFIX",
+      "description": "The image prefix to use"
     },
-    "spec": {
+    {
+      "name": "CCP_IMAGE_TAG",
+      "description": "The image tag to use"
+    }
+  ],
+  "objects": [
+    {
+      "kind": "Job",
+      "apiVersion": "batch/v1",
+      "metadata": {
+        "name": "backrest-job-nfs"
+      },
+      "spec": {
         "template": {
-            "metadata": {
-                "name": "backrest-job-nfs",
-                "labels": {
-                    "app": "backrest-job-nfs"
+          "labels": {
+            "app": "backrest-job-nfs"
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "pgconf",
+                "configMap": {
+                  "name": "backrestconf"
                 }
-            },
-        "spec": {
-            "containers": [{
+              },
+              {
+                "name": "backrestrepo",
+                "persistentVolumeClaim": {
+                  "claimName": "crunchy-pvc2"
+                }
+              },
+              {
+                "name": "pgdata",
+                "persistentVolumeClaim": {
+                  "claimName": "crunchy-pvc"
+                }
+              }
+            ],
+            "containers": [
+              {
                 "name": "backrest-restore",
-                "image": "crunchydata/crunchy-backrest-restore:$CCP_IMAGE_TAG",
-                "env": [{
-                    "name": "STANZA",
-                    "value": "db"
-                }],
-                "volumeMounts": [{
+                "image": "${CCP_IMAGE_PREFIX}/crunchy-backrest-restore:${CCP_IMAGE_TAG}",
+                "volumeMounts": [
+                  {
                     "mountPath": "/pgdata",
                     "name": "pgdata",
                     "readOnly": false
-                }, {
+                  },
+                  {
                     "mountPath": "/pgconf",
                     "name": "pgconf",
-                    "readOnly": true
-                }, {
+                    "readOnly": false
+                  },
+                  {
                     "mountPath": "/backrestrepo",
                     "name": "backrestrepo",
                     "readOnly": false
-                }]
-            }],
-            "volumes": [{
-                "name": "pgconf",
-                "configMap": {
-                    "name": "backrestconf"
-                }
-            }, {
-                "name": "backrestrepo",
-                "persistentVolumeClaim": {
-                    "claimName": "crunchy-pvc2"
-                }
-            }, {
-                "name": "pgdata",
-           	     "persistentVolumeClaim": {
-                    "claimName": "crunchy-pvc"
-          	     }
-            }],
-                "restartPolicy": "Never"
-    	}
-
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "STANZA",
+                    "value": "db"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Never"
+          }
         }
+      }
     }
+  ]
 }

--- a/examples/openshift/backrest-restore/full-restore.sh
+++ b/examples/openshift/backrest-restore/full-restore.sh
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 oc delete job backrest-job-nfs
-
-expenv -f $DIR/full-restore-job.json | oc create -f -
+oc process -f $DIR/full-restore-job.json CCP_IMAGE_PREFIX=$CCP_IMAGE_PREFIX CCP_IMAGE_TAG=$CCP_IMAGE_TAG | oc create -f -

--- a/examples/openshift/backrest/cleanup.sh
+++ b/examples/openshift/backrest/cleanup.sh
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 oc delete service primary-backrest
 oc delete pod primary-backrest
 oc delete configmap backrestconf
 
-sudo PV_PATH=$PV_PATH  rm  -rf $PV_PATH/archive $PV_PATH/backup
+sudo PV_PATH=$PV_PATH rm -rf $PV_PATH/archive $PV_PATH/backup

--- a/examples/openshift/backrest/primary-pod.json
+++ b/examples/openshift/backrest/primary-pod.json
@@ -1,154 +1,198 @@
 {
-    "kind": "Template",
-    "apiVersion": "v1",
-    "metadata": {
-        "name": "primary-backrest-pgbackrest-example",
-        "creationTimestamp": null,
-        "annotations": {
-            "description": "Crunchy PostgreSQL on NFS Example with pgbackrest enabled",
-            "iconClass": "icon-database",
-            "tags": "database,postgresql,replication"
-        }
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "primary-backrest-pgbackrest-example",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "Crunchy PostgreSQL on NFS Example with pgbackrest enabled",
+      "iconClass": "icon-database",
+      "tags": "database,postgresql,replication"
+    }
+  },
+  "parameters": [
+    {
+      "name": "CCP_IMAGE_PREFIX",
+      "description": "The image prefix to use"
     },
-    "parameters": [{
-        "name": "PG_PRIMARY_USER",
-        "description": "The username used for primary / replica replication",
-        "value": "primaryuser"
-    }, {
-        "name": "CCP_IMAGE_TAG",
-        "description": "The image tag to use"
-    }, {
-        "name": "PG_PRIMARY_PASSWORD",
-        "description": "The password for the PG primary user",
-        "value": "password"
-    }, {
-        "name": "PG_USER",
-        "description": "The username that clients will use to connect to PG server",
-        "value": "testuser"
-    }, {
-        "name": "PG_PASSWORD",
-        "description": "The password for the PG primary user",
-        "value": "password"
-    }, {
-        "name": "PG_DATABASE",
-        "description": "The name of the database that will be created",
-        "value": "userdb"
-    }, {
-        "name": "PG_ROOT_PASSWORD",
-        "description": "The password for the PG administrator",
-        "value": "password"
-    }],
-
-    "objects": [{
-        "kind": "Service",
-        "apiVersion": "v1",
-        "metadata": {
-            "name": "primary-backrest",
-            "labels": {
-                "name": "primary-backrest"
-            }
-        },
-        "spec": {
-            "ports": [{
-                "protocol": "TCP",
-                "port": 5432,
-                "targetPort": 5432,
-                "nodePort": 0
-            }],
-            "selector": {
-                "name": "primary-backrest"
-            },
-            "type": "ClusterIP",
-            "sessionAffinity": "None"
-        },
-        "status": {
-            "loadBalancer": {}
+    {
+      "name": "CCP_IMAGE_TAG",
+      "description": "The image tag to use"
+    },
+    {
+      "name": "PG_PRIMARY_USER",
+      "description": "The username used for primary / replica replication",
+      "value": "primaryuser"
+    },
+    {
+      "name": "PG_PRIMARY_PASSWORD",
+      "description": "The password for the PG primary user",
+      "value": "password"
+    },
+    {
+      "name": "PG_USER",
+      "description": "The username that clients will use to connect to PG server",
+      "value": "testuser"
+    },
+    {
+      "name": "PG_PASSWORD",
+      "description": "The password for the PG primary user",
+      "value": "password"
+    },
+    {
+      "name": "PG_DATABASE",
+      "description": "The name of the database that will be created",
+      "value": "userdb"
+    },
+    {
+      "name": "PG_ROOT_PASSWORD",
+      "description": "The password for the PG administrator",
+      "value": "password"
+    }
+  ],
+  "objects": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "primary-backrest",
+        "labels": {
+          "name": "primary-backrest"
         }
-    }, {
-        "kind": "Pod",
-        "apiVersion": "v1",
-        "metadata": {
-            "name": "primary-backrest",
-            "labels": {
-                "name": "primary-backrest"
-            }
+      },
+      "spec": {
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 5432,
+            "targetPort": 5432,
+            "nodePort": 0
+          }
+        ],
+        "selector": {
+          "name": "primary-backrest"
         },
-        "spec": {
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {
+
+        }
+      }
+    },
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "primary-backrest",
+        "labels": {
+          "name": "primary-backrest"
+        }
+      },
+      "spec": {
+        "securityContext": {
+          "supplementalGroups": [
+            65534
+          ]
+        },
+        "volumes": [
+          {
+            "name": "pgdata",
+            "persistentVolumeClaim": {
+              "claimName": "crunchy-pvc"
+            }
+          },
+          {
+            "name": "pgconf",
+            "configMap": {
+              "name": "backrestconf"
+            }
+          },
+          {
+            "name": "backrestrepo",
+            "persistentVolumeClaim": {
+              "claimName": "crunchy-pvc2"
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "postgres",
+            "image": "${CCP_IMAGE_PREFIX}/crunchy-postgres:${CCP_IMAGE_TAG}",
+            "ports": [
+              {
+                "containerPort": 5432,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "PG_PRIMARY_USER",
+                "value": "${PG_PRIMARY_USER}"
+              },
+              {
+                "name": "PG_PRIMARY_PORT",
+                "value": "5432"
+              },
+              {
+                "name": "PG_MODE",
+                "value": "primary"
+              },
+              {
+                "name": "PG_PRIMARY_PASSWORD",
+                "value": "${PG_PRIMARY_PASSWORD}"
+              },
+              {
+                "name": "PG_USER",
+                "value": "${PG_USER}"
+              },
+              {
+                "name": "PG_PASSWORD",
+                "value": "${PG_PASSWORD}"
+              },
+              {
+                "name": "PG_DATABASE",
+                "value": "${PG_DATABASE}"
+              },
+              {
+                "name": "PGHOST",
+                "value": "/tmp"
+              },
+              {
+                "name": "ARCHIVE_TIMEOUT",
+                "value": "60"
+              },
+              {
+                "name": "PG_ROOT_PASSWORD",
+                "value": "${PG_ROOT_PASSWORD}"
+              }
+            ],
             "securityContext": {
-                "supplementalGroups": [65534]
-            },
-            "volumes": [{
-                "name": "pgdata",
-		"persistentVolumeClaim": {
-		"claimName": "crunchy-pvc"
-		}
-            }, {
-                "name": "pgconf",
-		"configMap": {
-			"name": "backrestconf"
-		}
-            }, {
-                "name": "backrestrepo",
-                "persistentVolumeClaim": {
-                    "claimName": "crunchy-pvc2"
-                }
-            }],
-            "containers": [{
-                "name": "postgres",
-                "image": "crunchydata/crunchy-postgres:${CCP_IMAGE_TAG}",
-                "ports": [{
-                    "containerPort": 5432,
-                    "protocol": "TCP"
-                }],
-                "env": [{
-                    "name": "PG_PRIMARY_USER",
-                    "value": "${PG_PRIMARY_USER}"
-                }, {
-                    "name": "PG_PRIMARY_PORT",
-                    "value": "5432"
-                }, {
-                    "name": "PG_MODE",
-                    "value": "primary"
-                }, {
-                    "name": "PG_PRIMARY_PASSWORD",
-                    "value": "${PG_PRIMARY_PASSWORD}"
-                }, {
-                    "name": "PG_USER",
-                    "value": "${PG_USER}"
-                }, {
-                    "name": "PG_PASSWORD",
-                    "value": "${PG_PASSWORD}"
-                }, {
-                    "name": "PG_DATABASE",
-                    "value": "${PG_DATABASE}"
-                }, {
-                    "name": "PGHOST",
-                    "value": "/tmp"
-                }, {
-                    "name": "ARCHIVE_TIMEOUT",
-                    "value": "60"
-                }, {
-                    "name": "PG_ROOT_PASSWORD",
-                    "value": "${PG_ROOT_PASSWORD}"
-                }],
-                "securityContext": {
-                    "capabilities": {}
-                },
+              "capabilities": {
 
-                "volumeMounts": [{
-                    "mountPath": "/pgdata",
-                    "name": "pgdata",
-                    "readOnly": false
-                }, {
-                    "mountPath": "/pgconf",
-                    "name": "pgconf",
-                    "readOnly": true
-                }, {
-                    "mountPath": "/backrestrepo",
-                    "name": "backrestrepo",
-                    "readOnly": false
-                }]
-            }]
-        }
-    }]
+              }
+            },
+            "volumeMounts": [
+              {
+                "mountPath": "/pgdata",
+                "name": "pgdata",
+                "readOnly": false
+              },
+              {
+                "mountPath": "/pgconf",
+                "name": "pgconf",
+                "readOnly": true
+              },
+              {
+                "mountPath": "/backrestrepo",
+                "name": "backrestrepo",
+                "readOnly": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/examples/openshift/backrest/run-only-pod.sh
+++ b/examples/openshift/backrest/run-only-pod.sh
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-oc process -f $DIR/primary-pod.json -p CCP_IMAGE_TAG=$CCP_IMAGE_TAG | oc create -f -
-
+oc process -f $DIR/primary-pod.json -p CCP_IMAGE_PREFIX=$CCP_IMAGE_PREFIX CCP_IMAGE_TAG=$CCP_IMAGE_TAG | oc create -f -

--- a/examples/openshift/backrest/run.sh
+++ b/examples/openshift/backrest/run.sh
@@ -13,14 +13,9 @@
 # limitations under the License.
 
 
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-sudo DIR=$DIR PV_PATH=$PV_PATH cp $DIR/pgbackrest.conf $PV_PATH
-
 oc create configmap backrestconf --from-file pgbackrest.conf
-
-oc process -f $DIR/primary-pod.json -p CCP_IMAGE_TAG=$CCP_IMAGE_TAG | oc create -f -
-
+oc process -f $DIR/primary-pod.json -p CCP_IMAGE_PREFIX=$CCP_IMAGE_PREFIX CCP_IMAGE_TAG=$CCP_IMAGE_TAG | oc create -f -


### PR DESCRIPTION
These changes sync the examples between kubernetes and openshift (#341).

* Templatized job specifications on the openshift examples
* Changed examples to use `oc process` instead of `expenv` on OCP
* Added `${CCP_IMAGE_PREFIX}` to container image spec (was hardcoded to `crunchydata`)
* Removed hard copy of pgbackrest.conf to PV (now uses configmap)
* Cleanup of some whitespace