### PR TITLE
Add debug flag

### DIFF
--- a/bin/backrest_restore/setenv.sh
+++ b/bin/backrest_restore/setenv.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 if [ -d /usr/pgsql-10 ]; then
 	export PGROOT=/usr/pgsql-10
 elif [ -d /usr/pgsql-9.6 ]; then

--- a/bin/backrest_restore/start.sh
+++ b/bin/backrest_restore/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash  -x
+#!/bin/bash 
 
 # Copyright 2018 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,9 @@
 
 set -e
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 echo STANZA $STANZA set
 if [ ! -v STANZA ]; then
 	echo "STANZA env var is not set, required value"
@@ -25,14 +28,7 @@ echo "Starting restore. Examine restore log in /backrestrepo for results" `date`
 
 # this lets us run the pgbackrest cmd  on Openshift
 # when it is configured to use random UIDs
-export USER_ID=$(id -u)
-export GROUP_ID=$(id -g)
-envsubst < /opt/cpm/conf/passwd.template > /tmp/passwd
-envsubst < /opt/cpm/conf/group.template > /tmp/group
-export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
-export NSS_WRAPPER_PASSWD=/tmp/passwd
-export NSS_WRAPPER_GROUP=/tmp/group
-
+ose_hack
 
 if [ -v DELTA ]; then
     pgbackrest --config=/pgconf/pgbackrest.conf --stanza=$STANZA --log-path=/backrestrepo --delta restore

--- a/bin/backup/start-backupjob.sh
+++ b/bin/backup/start-backupjob.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Copyright 2018 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,23 +24,9 @@
 # $BACKUP_USER pg user we are connecting with
 # $BACKUP_PASS pg user password we are connecting with
 # $BACKUP_PORT pg port we are connecting to
-#
 
-# ls -l /
-# ls -l /pgdata
-
-# env
-
-function ose_hack() {
-        export USER_ID=$(id -u)
-        export GROUP_ID=$(id -g)
-        envsubst < /opt/cpm/conf/passwd.template > /tmp/passwd
-        export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
-        export NSS_WRAPPER_PASSWD=/tmp/passwd
-        export NSS_WRAPPER_GROUP=/etc/group
-}
-
-
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
 ose_hack
 
 BACKUPBASE=/pgdata/$BACKUP_HOST-backups

--- a/bin/collect/start-collectserver.sh
+++ b/bin/collect/start-collectserver.sh
@@ -13,11 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 export PATH=$PATH:/opt/cpm/bin
 
 /opt/cpm/bin/collectserver 
-
-#while true; do
-#	sleep 1000
-#done
-

--- a/bin/collect/start.sh
+++ b/bin/collect/start.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+# Copyright 2018 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 POSTGRES_EXPORTER_PIDFILE=/tmp/postgres_exporter.pid
 NODE_EXPORTER_PIDFILE=/tmp/node_exporter.pid
 COLLECTSERVER_PIDFILE=/tmp/collectserver.pid

--- a/bin/collect/xlog-count.sh
+++ b/bin/collect/xlog-count.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 export PATH=$PATH:/opt/cpm/bin
 
 # get the number of archive files in pg_xlog

--- a/bin/common/common_lib.sh
+++ b/bin/common/common_lib.sh
@@ -13,10 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source /opt/cpm/bin/common_lib.sh
-enable_debugging
-source /opt/cpm/bin/setenv.sh
+function enable_debugging() {
+    if [[ ${DEBUG:-false} == "true" ]]
+    then
+        echo "Turning Debugging On"
+        export PS4='+(${BASH_SOURCE}:${LINENO})> ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+        set -x
+    fi
+}
 
-ose_hack
-
-$PGROOT/bin/psql -f /opt/cpm/bin/readiness.sql -U $PG_USER postgres
+function ose_hack() {
+    export USER_ID=$(id -u)
+    export GROUP_ID=$(id -g)
+    envsubst < /opt/cpm/conf/passwd.template > /tmp/passwd
+    export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+    export NSS_WRAPPER_PASSWD=/tmp/passwd
+    export NSS_WRAPPER_GROUP=/etc/group
+}

--- a/bin/dba/create-backup-job.sh
+++ b/bin/dba/create-backup-job.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Copyright 2018 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,9 @@
 #export TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 #/opt/cpm/bin/oc login https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT --insecure-skip-tls-verify=true --token="$TOKEN"
 #/opt/cpm/bin/oc projects $OSE_PROJECT
+
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
 
 echo "create-backup-job.sh......"
 echo $1 is template for backup

--- a/bin/dba/create-vac-job.sh
+++ b/bin/dba/create-vac-job.sh
@@ -17,6 +17,9 @@
 #/opt/cpm/bin/oc login https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT --insecure-skip-tls-verify=true --token="$TOKEN"
 #/opt/cpm/bin/oc projects $OSE_PROJECT
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 echo "create-vac-job.sh......"
 echo $1 is tempfile
 echo $2 is JOB_HOST

--- a/bin/dba/start-dba.sh
+++ b/bin/dba/start-dba.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 export PATH=$PATH:/opt/cpm/bin
 
 function trap_sigterm() {
@@ -25,13 +28,11 @@ trap 'trap_sigterm' SIGINT SIGTERM
 export TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 
 handle_ose() {
-export CMD=oc
+    export CMD=oc
+    oc login https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT --insecure-skip-tls-verify=true --token="$TOKEN"
+    oc project $OSE_PROJECT
 
-oc login https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT --insecure-skip-tls-verify=true --token="$TOKEN"
-oc project $OSE_PROJECT
-
-oc policy add-role-to-group edit system:serviceaccounts -n $OSE_PROJECT
-#oc policy add-role-to-group edit system:serviceaccounts -n default
+    oc policy add-role-to-group edit system:serviceaccounts -n $OSE_PROJECT
 }
 
 handle_kube() {

--- a/bin/grafana/start-grafana.sh
+++ b/bin/grafana/start-grafana.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 export PATH=$PATH:/opt/cpm/bin
 
 # start up grafana server 

--- a/bin/pgbadger/badger-generate.sh
+++ b/bin/pgbadger/badger-generate.sh
@@ -1,5 +1,4 @@
-#!/bin/bash -x
-
+#!/bin/bash
 
 # Copyright 2015 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
 
 if [ -v BADGER_TARGET ]; then
 	echo "BADGER_TARGET is set ...this is the standalone case"

--- a/bin/pgbadger/start-pgbadger.sh
+++ b/bin/pgbadger/start-pgbadger.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 export PIDFILE=/tmp/badgerserver.pid
 
 function trap_sigterm() {

--- a/bin/pgbouncer/pgbouncer-watch.sh
+++ b/bin/pgbouncer/pgbouncer-watch.sh
@@ -14,6 +14,10 @@
 # limitations under the License.
 
 #export OSE_HOST=openshift.default.svc.cluster.local
+
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 if [ ! -v SLEEP_TIME ]; then
 	SLEEP_TIME=10
 fi

--- a/bin/pgbouncer/startpgbouncer.sh
+++ b/bin/pgbouncer/startpgbouncer.sh
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+ose_hack
+
 function trap_sigterm() {
         echo "doing trap logic..."
 	kill -SIGINT $PGBOUNCER_PID
@@ -21,17 +25,6 @@ function trap_sigterm() {
 
 trap 'trap_sigterm' SIGINT SIGTERM
 
-
-function ose_hack() {
-	export USER_ID=$(id -u)
-	export GROUP_ID=$(id -g)
-	envsubst < /opt/cpm/conf/passwd.template > /tmp/passwd
-	export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
-	export NSS_WRAPPER_PASSWD=/tmp/passwd
-	export NSS_WRAPPER_GROUP=/etc/group
-}
-
-ose_hack
 
 rm -rf /tmp/pgbouncer.pid
 

--- a/bin/pgdump/start-pgdumpjob.sh
+++ b/bin/pgdump/start-pgdumpjob.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash 
 
 # Copyright 2018 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -65,16 +65,8 @@
 
 # env
 
-function ose_hack() {
-        export USER_ID=$(id -u)
-        export GROUP_ID=$(id -g)
-        envsubst < /opt/cpm/conf/passwd.template > /tmp/passwd
-        export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
-        export NSS_WRAPPER_PASSWD=/tmp/passwd
-        export NSS_WRAPPER_GROUP=/etc/group
-}
-
-
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
 ose_hack
 
 TS=`date +%Y-%m-%d-%H-%M-%S`

--- a/bin/pgpool/startpgpool.sh
+++ b/bin/pgpool/startpgpool.sh
@@ -14,6 +14,10 @@
 # limitations under the License.
 
 # clean up leftovers from previous runs of pgpool
+
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 rm -rf /tmp/pgpool.pid
 rm -rf /tmp/.s.*
 

--- a/bin/postgres/check-for-secrets.sh
+++ b/bin/postgres/check-for-secrets.sh
@@ -1,3 +1,20 @@
+#!/bin/bash
+
+# Copyright 2018 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
 
 if [ -d "/pguser" ]; then
 	echo "pgpguser does exist"

--- a/bin/postgres/initdb.sh
+++ b/bin/postgres/initdb.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 # Copyright 2018 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
 
 ls -l /
 id

--- a/bin/postgres/liveness.sh
+++ b/bin/postgres/liveness.sh
@@ -13,16 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source /opt/cpm/bin/setenv.sh
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
 
-function ose_hack() {
-        export USER_ID=$(id -u)
-        export GROUP_ID=$(id -g)
-        envsubst < /opt/cpm/conf/passwd.template > /tmp/passwd
-        export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
-        export NSS_WRAPPER_PASSWD=/tmp/passwd
-        export NSS_WRAPPER_GROUP=/etc/group
-}
+source /opt/cpm/bin/setenv.sh
 
 ose_hack
 

--- a/bin/postgres/seed.sh
+++ b/bin/postgres/seed.sh
@@ -18,6 +18,8 @@
 # we will execute this script on each host since
 # we dont' want to open up the superuser 'postgres' access 
 # to outside of the container
-#
+
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
 
 psql -U postgres postgres < /opt/cpm/bin/setup.sql

--- a/bin/postgres/setenv.sh
+++ b/bin/postgres/setenv.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 if [ -d /usr/pgsql-10 ]; then
 	export PGROOT=/usr/pgsql-10
 elif [ -d /usr/pgsql-9.6 ]; then

--- a/bin/postgres/sshd.sh
+++ b/bin/postgres/sshd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash  -x
+#!/bin/bash
 
 # Copyright 2018 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,16 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-function ose_hack() {
-	export USER_ID=$(id -u)
-	export GROUP_ID=$(id -g)
-	envsubst < /opt/cpm/conf/passwd.template > /tmp/passwd
-	envsubst < /opt/cpm/conf/group.template > /tmp/group
-	export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
-	export NSS_WRAPPER_PASSWD=/tmp/passwd
-	export NSS_WRAPPER_GROUP=/tmp/group
-}
-
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
 
 function start_sshd() {
     ose_hack

--- a/bin/postgres/start-secrets.sh
+++ b/bin/postgres/start-secrets.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 export PG_MODE=$PG_MODE
 export PG_PRIMARY_HOST=$PG_PRIMARY_HOST
 export PG_PRIMARY_PORT=$PG_PRIMARY_PORT

--- a/bin/prometheus/start-prometheus.sh
+++ b/bin/prometheus/start-prometheus.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 export PATH=$PATH:/opt/cpm/bin
 
 DATA=/data/prometheus

--- a/bin/setenv.sh
+++ b/bin/setenv.sh
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source /opt/cpm/bin/common_lib.sh
+
+enable_debugging
+ose_hack
+
 if [ -d /usr/pgsql-9.5 ]; then
 	export PGROOT=/usr/pgsql-9.5
 elif [ -d /usr/pgsql-9.4 ]; then

--- a/bin/upgrade/start.sh
+++ b/bin/upgrade/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Copyright 2018 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,9 @@
 # $OLD_VERSION (e.g. 9.5) 
 # $NEW_VERSION (e.g. 9.6)
 #
+
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
 
 function trap_sigterm() {
         echo "doing trap logic..." >> $PGDATA/trap.output
@@ -59,16 +62,6 @@ if [[ ! -d "$PGDATANEW" ]]; then
 	echo $PGDATANEW " does not exist and is required"
 #	exit 2
 fi
-
-function ose_hack() {
-        export USER_ID=$(id -u)
-        export GROUP_ID=$(id -g)
-        envsubst < /opt/cpm/conf/passwd.template > /tmp/passwd
-        export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
-        export NSS_WRAPPER_PASSWD=/tmp/passwd
-        export NSS_WRAPPER_GROUP=/etc/group
-}
-
 
 ose_hack
 

--- a/bin/vacuum/start-vacuum.sh
+++ b/bin/vacuum/start-vacuum.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 echo $PG_USER is PG_USER
 if [ ! -v PG_USER ]; then
 	echo "PG_USER env var is not set, required value"

--- a/bin/version/start-version.sh
+++ b/bin/version/start-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash  -x
+#!/bin/bash
 
 # Copyright 2015 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,13 +15,16 @@
 
 #export OSE_HOST=openshift.default.svc.cluster.local
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 function create_pgpass() {
-cd /tmp
+    cd /tmp
 cat >> ".pgpass" <<-EOF
 *:*:*:*:${PG_PRIMARY_PASSWORD}
 EOF
-chmod 0600 .pgpass
-export PGPASSFILE=/tmp/.pgpass
+    chmod 0600 .pgpass
+    export PGPASSFILE=/tmp/.pgpass
 }
 
 create_pgpass

--- a/bin/watch/start.sh
+++ b/bin/watch/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash  -x
+#!/bin/bash 
 
 # Copyright 2015 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,9 @@
 
 #export OSE_HOST=openshift.default.svc.cluster.local
 
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
 function trap_sigterm() {
 	echo "Doing trap logic..."  >> /tmp/trap.out
 	shutdownrequested=true
@@ -22,15 +25,6 @@ function trap_sigterm() {
 
 trap 'trap_sigterm' SIGINT SIGTERM
 shutdownrequested=false
-
-function ose_hack() {
-	export USER_ID=$(id -u)
-	export GROUP_ID=$(id -g)
-	envsubst < /opt/cpm/conf/passwd.template > /tmp/passwd
-	export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
-	export NSS_WRAPPER_PASSWD=/tmp/passwd
-	export NSS_WRAPPER_GROUP=/etc/group
-}
 
 CONTAINER_FLAG=
 

--- a/centos7/10/Dockerfile.backrest-restore.centos7
+++ b/centos7/10/Dockerfile.backrest-restore.centos7
@@ -52,6 +52,7 @@ RUN chown -R postgres:postgres /opt/cpm  \
 VOLUME /pgconf /pgdata /backrestrepo
 
 ADD bin/backrest_restore /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/backrest_restore /opt/cpm/conf
 
 USER 26

--- a/centos7/10/Dockerfile.backup.centos7
+++ b/centos7/10/Dockerfile.backup.centos7
@@ -33,6 +33,7 @@ RUN yum -y update && yum install -y epel-release \
 
 RUN mkdir -p /opt/cpm/bin /pgdata /opt/cpm/conf
 ADD bin/backup/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/backup/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata
 

--- a/centos7/10/Dockerfile.collect.centos7
+++ b/centos7/10/Dockerfile.collect.centos7
@@ -32,6 +32,7 @@ RUN mkdir -p /opt/cpm/bin
 ADD postgres_exporter /opt/cpm/bin
 ADD node_exporter.tar.gz /opt/cpm/bin
 ADD bin/collect /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/collect /opt/cpm/conf
 
 RUN chown -R postgres:postgres /opt/cpm/bin /opt/cpm/conf

--- a/centos7/10/Dockerfile.pgbadger.centos7
+++ b/centos7/10/Dockerfile.pgbadger.centos7
@@ -30,6 +30,7 @@ RUN mkdir -p /opt/cpm/bin
 EXPOSE 10000
 
 ADD bin/pgbadger /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 
 RUN chown -R postgres:postgres /opt/cpm/bin
 

--- a/centos7/10/Dockerfile.pgbouncer.centos7
+++ b/centos7/10/Dockerfile.pgbouncer.centos7
@@ -41,6 +41,7 @@ VOLUME ["/pgconf"]
 EXPOSE 5432
 
 ADD bin/pgbouncer /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgbouncer /opt/cpm/conf
 
 RUN chown -R daemon:daemon /opt/cpm/bin

--- a/centos7/10/Dockerfile.pgdump.centos7
+++ b/centos7/10/Dockerfile.pgdump.centos7
@@ -33,6 +33,7 @@ RUN yum -y update && yum install -y epel-release \
 
 RUN mkdir -p /opt/cpm/bin /pgdata /opt/cpm/conf
 ADD bin/pgdump/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgdump/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata
 

--- a/centos7/10/Dockerfile.pgpool.centos7
+++ b/centos7/10/Dockerfile.pgpool.centos7
@@ -35,6 +35,7 @@ VOLUME ["/pgconf"]
 EXPOSE 5432
 
 ADD bin/pgpool /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgpool /opt/cpm/conf/pgpool
 ADD conf/pgpool/pool_hba.conf  /etc/pgpool-II-10/pool_hba.conf
 ADD conf/pgpool/pool_passwd /etc/pgpool-II-10/pool_passwd

--- a/centos7/10/Dockerfile.postgres-gis.centos7
+++ b/centos7/10/Dockerfile.postgres-gis.centos7
@@ -64,6 +64,7 @@ EXPOSE 5432
 
 ADD bin/postgres /opt/cpm/bin
 ADD bin/postgres-gis /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/postgres /opt/cpm/conf
 
 USER 26

--- a/centos7/10/Dockerfile.postgres.centos7
+++ b/centos7/10/Dockerfile.postgres.centos7
@@ -62,6 +62,7 @@ VOLUME ["/pgconf", "/pgdata", "/pgwal", "/backup", "/recover", "/backrestrepo", 
 EXPOSE 5432
 
 ADD bin/postgres /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/postgres /opt/cpm/conf
 
 USER 26

--- a/centos7/10/Dockerfile.upgrade.centos7
+++ b/centos7/10/Dockerfile.upgrade.centos7
@@ -36,6 +36,7 @@ RUN yum -y update && yum install -y epel-release \
 
 RUN mkdir -p /opt/cpm/bin /pgolddata /pgnewdata /opt/cpm/conf
 ADD bin/upgrade/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/upgrade/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata
 

--- a/centos7/10/Dockerfile.watch.centos7
+++ b/centos7/10/Dockerfile.watch.centos7
@@ -41,6 +41,7 @@ RUN yum -y update && yum -y install epel-release \
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf
 
 ADD bin/watch /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/watch /opt/cpm/conf
 
 RUN chown -R postgres:postgres /opt/cpm

--- a/centos7/9.5/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.5/Dockerfile.backrest-restore.centos7
@@ -51,6 +51,7 @@ RUN chown -R postgres:postgres /opt/cpm  \
 VOLUME /pgconf /pgdata /backrestrepo
 
 ADD bin/backrest_restore /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/backrest_restore /opt/cpm/conf
 
 USER 26

--- a/centos7/9.5/Dockerfile.backup.centos7
+++ b/centos7/9.5/Dockerfile.backup.centos7
@@ -23,6 +23,7 @@ RUN yum -y update && yum install -y epel-release && yum install -y nss_wrapper g
 
 RUN mkdir -p /opt/cpm/bin /pgdata /opt/cpm/conf
 ADD bin/backup/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/backup/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata
 

--- a/centos7/9.5/Dockerfile.collect.centos7
+++ b/centos7/9.5/Dockerfile.collect.centos7
@@ -31,6 +31,7 @@ RUN mkdir -p /opt/cpm/bin
 ADD postgres_exporter /opt/cpm/bin
 ADD node_exporter.tar.gz /opt/cpm/bin
 ADD bin/collect /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/collect /opt/cpm/conf
 
 RUN chown -R postgres:postgres /opt/cpm/bin /opt/cpm/conf

--- a/centos7/9.5/Dockerfile.pgbadger.centos7
+++ b/centos7/9.5/Dockerfile.pgbadger.centos7
@@ -27,6 +27,7 @@ RUN mkdir -p /opt/cpm/bin
 EXPOSE 10000
 
 ADD bin/pgbadger /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 
 RUN chown -R postgres:postgres /opt/cpm/bin
 

--- a/centos7/9.5/Dockerfile.pgbouncer.centos7
+++ b/centos7/9.5/Dockerfile.pgbouncer.centos7
@@ -38,6 +38,7 @@ VOLUME ["/pgconf"]
 EXPOSE 5432
 
 ADD bin/pgbouncer /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgbouncer /opt/cpm/conf
 
 RUN chown -R daemon:daemon /opt/cpm/bin

--- a/centos7/9.5/Dockerfile.pgdump.centos7
+++ b/centos7/9.5/Dockerfile.pgdump.centos7
@@ -23,6 +23,7 @@ RUN yum -y update && yum install -y epel-release && yum install -y nss_wrapper g
 
 RUN mkdir -p /opt/cpm/bin /pgdata /opt/cpm/conf
 ADD bin/pgdump/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgdump/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata
 

--- a/centos7/9.5/Dockerfile.pgpool.centos7
+++ b/centos7/9.5/Dockerfile.pgpool.centos7
@@ -34,6 +34,7 @@ VOLUME ["/pgconf"]
 EXPOSE 5432
 
 ADD bin/pgpool /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgpool /opt/cpm/conf/pgpool
 ADD conf/pgpool/pool_hba.conf  /etc/pgpool-II-95/pool_hba.conf
 ADD conf/pgpool/pool_passwd /etc/pgpool-II-95/pool_passwd

--- a/centos7/9.5/Dockerfile.postgres-gis.centos7
+++ b/centos7/9.5/Dockerfile.postgres-gis.centos7
@@ -65,6 +65,7 @@ EXPOSE 5432
 
 ADD bin/postgres /opt/cpm/bin
 ADD bin/postgres-gis /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/postgres /opt/cpm/conf
 
 USER 26

--- a/centos7/9.5/Dockerfile.postgres.centos7
+++ b/centos7/9.5/Dockerfile.postgres.centos7
@@ -63,6 +63,7 @@ VOLUME ["/pgconf", "/pgdata", "/pgwal", "/backup", "/recover", "/backrestrepo", 
 EXPOSE 5432
 
 ADD bin/postgres /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/postgres /opt/cpm/conf
 
 USER 26

--- a/centos7/9.5/Dockerfile.watch.centos7
+++ b/centos7/9.5/Dockerfile.watch.centos7
@@ -30,6 +30,7 @@ RUN mkdir -p /opt/cpm/bin /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm
 
 ADD bin/watch /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/watch /opt/cpm/conf
 
 USER 26

--- a/centos7/9.6/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.6/Dockerfile.backrest-restore.centos7
@@ -51,6 +51,7 @@ RUN chown -R postgres:postgres /opt/cpm  \
 VOLUME /pgconf /pgdata /backrestrepo
 
 ADD bin/backrest_restore /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/backrest_restore /opt/cpm/conf
 
 USER 26

--- a/centos7/9.6/Dockerfile.backup.centos7
+++ b/centos7/9.6/Dockerfile.backup.centos7
@@ -34,6 +34,7 @@ RUN yum -y update && yum install -y epel-release \
 
 RUN mkdir -p /opt/cpm/bin /pgdata /opt/cpm/conf
 ADD bin/backup/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/backup/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata
 

--- a/centos7/9.6/Dockerfile.collect.centos7
+++ b/centos7/9.6/Dockerfile.collect.centos7
@@ -32,6 +32,7 @@ RUN mkdir -p /opt/cpm/bin
 ADD postgres_exporter /opt/cpm/bin
 ADD node_exporter.tar.gz /opt/cpm/bin
 ADD bin/collect /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/collect /opt/cpm/conf
 
 RUN chown -R postgres:postgres /opt/cpm/bin /opt/cpm/conf

--- a/centos7/9.6/Dockerfile.pgbadger.centos7
+++ b/centos7/9.6/Dockerfile.pgbadger.centos7
@@ -30,6 +30,7 @@ RUN mkdir -p /opt/cpm/bin
 EXPOSE 10000
 
 ADD bin/pgbadger /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 
 RUN chown -R postgres:postgres /opt/cpm/bin
 

--- a/centos7/9.6/Dockerfile.pgbouncer.centos7
+++ b/centos7/9.6/Dockerfile.pgbouncer.centos7
@@ -41,6 +41,7 @@ VOLUME ["/pgconf"]
 EXPOSE 5432
 
 ADD bin/pgbouncer /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgbouncer /opt/cpm/conf
 
 RUN chown -R daemon:daemon /opt/cpm/bin

--- a/centos7/9.6/Dockerfile.pgdump.centos7
+++ b/centos7/9.6/Dockerfile.pgdump.centos7
@@ -34,6 +34,7 @@ RUN yum -y update && yum install -y epel-release \
 
 RUN mkdir -p /opt/cpm/bin /pgdata /opt/cpm/conf
 ADD bin/pgdump/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgdump/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata
 

--- a/centos7/9.6/Dockerfile.pgpool.centos7
+++ b/centos7/9.6/Dockerfile.pgpool.centos7
@@ -36,6 +36,7 @@ VOLUME ["/pgconf"]
 EXPOSE 5432
 
 ADD bin/pgpool /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgpool /opt/cpm/conf/pgpool
 ADD conf/pgpool/pool_hba.conf  /etc/pgpool-II-96/pool_hba.conf
 ADD conf/pgpool/pool_passwd /etc/pgpool-II-96/pool_passwd

--- a/centos7/9.6/Dockerfile.postgres-gis.centos7
+++ b/centos7/9.6/Dockerfile.postgres-gis.centos7
@@ -64,6 +64,7 @@ EXPOSE 5432
 
 ADD bin/postgres /opt/cpm/bin
 ADD bin/postgres-gis /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/postgres /opt/cpm/conf
 
 USER 26

--- a/centos7/9.6/Dockerfile.postgres.centos7
+++ b/centos7/9.6/Dockerfile.postgres.centos7
@@ -62,6 +62,7 @@ VOLUME ["/pgconf", "/pgdata", "/pgwal", "/backup", "/recover", "/backrestrepo", 
 EXPOSE 5432
 
 ADD bin/postgres /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/postgres /opt/cpm/conf
 
 USER 26

--- a/centos7/9.6/Dockerfile.upgrade.centos7
+++ b/centos7/9.6/Dockerfile.upgrade.centos7
@@ -34,6 +34,7 @@ RUN yum -y update && yum install -y epel-release \
 
 RUN mkdir -p /opt/cpm/bin /pgolddata /pgnewdata /opt/cpm/conf
 ADD bin/upgrade/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/upgrade/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata
 

--- a/centos7/9.6/Dockerfile.watch.centos7
+++ b/centos7/9.6/Dockerfile.watch.centos7
@@ -41,6 +41,7 @@ RUN yum -y update && yum -y install epel-release \
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf
 
 ADD bin/watch /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/watch /opt/cpm/conf
 
 RUN chown -R postgres:postgres /opt/cpm

--- a/centos7/Dockerfile.dba.centos7
+++ b/centos7/Dockerfile.dba.centos7
@@ -21,6 +21,7 @@ RUN mkdir -p /opt/cpm/bin
 RUN mkdir -p /opt/cpm/conf
 
 ADD bin/dba /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/dba /opt/cpm/conf
 
 USER root

--- a/centos7/Dockerfile.grafana.centos7
+++ b/centos7/Dockerfile.grafana.centos7
@@ -22,6 +22,7 @@ EXPOSE 3000
 
 ADD grafana.tar.gz /opt/cpm/bin
 ADD bin/grafana /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/grafana /opt/cpm/conf
 
 RUN chown -R daemon:daemon /opt/cpm /data

--- a/centos7/Dockerfile.prometheus.centos7
+++ b/centos7/Dockerfile.prometheus.centos7
@@ -21,6 +21,7 @@ EXPOSE 9090
 
 ADD prometheus.tar.gz /opt/cpm/bin
 ADD bin/prometheus /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/prometheus /opt/cpm/conf
 
 RUN chown -R daemon:daemon /opt/cpm /data

--- a/centos7/Dockerfile.promgateway.centos7
+++ b/centos7/Dockerfile.promgateway.centos7
@@ -22,6 +22,7 @@ RUN chown -R daemon:daemon /opt/cpm
 EXPOSE 9091
 
 ADD prometheus-pushgateway.tar.gz /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD bin/promgateway /opt/cpm/bin
 
 USER daemon

--- a/centos7/Dockerfile.sim.centos7
+++ b/centos7/Dockerfile.sim.centos7
@@ -3,6 +3,7 @@ FROM centos:7
 LABEL Release="1.7.0" Vendor="Crunchy Data Solutions"
 
 ADD bin/crunchy-sim /usr/bin
+ADD bin/common /opt/cpm/bin
 
 VOLUME /config
 

--- a/centos7/Dockerfile.vacuum.centos7
+++ b/centos7/Dockerfile.vacuum.centos7
@@ -20,6 +20,7 @@ RUN yum -y update && yum -y install procps-ng iproute bind-utils openssh-clients
 RUN mkdir -p /opt/cpm/bin
 
 ADD bin/vacuum /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 
 USER root
 

--- a/docs/containers.adoc
+++ b/docs/containers.adoc
@@ -78,6 +78,8 @@ executed when the database is first created.
  * WORK_MEM - default is 4MB, set this value to override this PostgreSQL configuration setting
  * MAX_WAL_SENDERS - default is 6, set this value to override this PostgreSQL configuration setting
  * ENABLE_SSHD- default is false, set this value to true to enable SSHD.  See link:sshd.adoc[SSHD Documentation] for detailed setup instructions
+ * DEBUG - default is false, set this value to true to debugging in logs.
+   Note: this mode can reveal secrets in logs.
 
 === Features
 
@@ -166,6 +168,8 @@ to persist database backups.
    backup with
  * BACKUP_PORT - required, this is the database port we will be doing the
    backup with
+ * DEBUG - default is false, set this value to true to debugging in logs.
+   Note: this mode can reveal secrets in logs.
 
 == crunchy-dump
 
@@ -225,6 +229,8 @@ to persist database dumps.
  * PGDUMP_TABLE option to specify which tables matched by the specified pattern are output by pg_dump
  * PGDUMP_TABLESTOEXCLUDE option to specify which tables matched by the specified pattern should be excluded from the output by pg_dump
  * PGDUMP_VERBOSE option to specify verbose mode to output detailed object comments and start/stop times to the output by pg_dump; as well as progress messages to standard error (STDERR)
+ * DEBUG - default is false, set this value to true to debugging in logs.
+   Note: this mode can reveal secrets in logs.
 
 == crunchy-collect
 
@@ -254,6 +260,8 @@ which is found in the crunchy-grafana container.
  * NODE_EXPORTER_URL - The HTTP URL of the node_exporter utility which collects host and OS level system metrics.
  * POSTGRES_EXPORTER_URL - The HTTP URL of the postgres_exporter utility which collects PostgreSQL server metrics.
  * DATA_SOURCE_NAME - The URL for the PostgreSQL server's data source name. This is *required* to be in the form of *postgresql://*.
+ * DEBUG - default is false, set this value to true to debugging in logs.
+   Note: this mode can reveal secrets in logs.
 
 == crunchy-prometheus
 
@@ -281,6 +289,11 @@ The crunchy-prometheus data in this example is stored in emptyDir volume types.
 To persist the data and Grafana templates in the long term, you will want to
 use a pvc based volume type as specified in *examples/openshift/metrics/run-pvc.json*.
 
+=== Environment Variables
+
+ * DEBUG - default is false, set this value to true to debugging in logs.
+   Note: this mode can reveal secrets in logs.
+
 == crunchy-promgateway
 
 === Description
@@ -295,6 +308,11 @@ link:https://github.com/CrunchyData/crunchy-containers/blob/master/docs/metrics.
 The following port is exposed by the crunchy-promgateway container:
 
 * crunchy-promgateway:9091 - the Prometheus promgateway REST API
+
+=== Environment Variables
+
+ * DEBUG - default is false, set this value to true to debugging in logs.
+   Note: this mode can reveal secrets in logs.
 
 == crunchy-grafana
 
@@ -314,6 +332,11 @@ The following port is exposed by the crunchy-grafana container:
 
 * crunchy-grafana:3000 - the Grafana web user interface
 
+=== Environment Variables
+
+ * DEBUG - default is false, set this value to true to debugging in logs.
+   Note: this mode can reveal secrets in logs.
+
 == crunchy-pgbadger
 
 The crunchy-pgbadger container executes the pgbadger utility.  A small
@@ -329,6 +352,8 @@ http://<<ip address>>:10000/api/badgergenerate
  * BADGER_TARGET - only used in standalone mode to specify the
    name of the container, also used to find the location of the
    database log files in /pgdata/$BADGER_TARGET/pg_log/*.log
+ * DEBUG - default is false, set this value to true to debugging in logs.
+   Note: this mode can reveal secrets in logs.
 
 === Features
 
@@ -352,7 +377,9 @@ capable.
  * PG_PASSWORD - user password to connect to PostgreSQL
  * PG_PRIMARY_SERVICE_NAME - database host to connect to for the primary node
  * PG_REPLICA_SERVICE_NAME - database host to connect to for the replica node
-
+ * DEBUG - default is false, set this value to true to debugging in logs.
+   Note: this mode can reveal secrets in logs.
+ 
 === Features
 
 The following features are supported by the crunchy-pgpool container:
@@ -417,6 +444,8 @@ the watch logic to interact with the replica containers.
    the normal replica selection
  * WATCH_PRE_HOOK - path to an executable file to run before failover is processed.
  * WATCH_POST_HOOK - path to an executable file to run after failover is processed.
+ * DEBUG - default is false, set this value to true to debugging in logs.
+   Note: this mode can reveal secrets in logs.
 
 === Logic
 
@@ -467,6 +496,8 @@ The complete set of environment variables read by the crunchy-vacuum job include
     * VAC_ANALYZE - when set to true adds the ANALYZE parameter to the VACUUM command
     * VAC_VERBOSE - when set to true adds the VERBOSE parameter to the VACUUM command
     * VAC_FREEZE - when set to true adds the FREEZE parameter to the VACUUM command
+    * DEBUG - default is false, set this value to true to debugging in logs.
+      Note: this mode can reveal secrets in logs.
 
 == crunchy-dba
 
@@ -493,6 +524,8 @@ of crunchy-dba:
  setting value must be a valid cron expression as described below.
  * BACKUP_SCHEDULE - if set, this will start a backup job container.  The
  setting value must be a valid cron expression as described below.
+ * DEBUG - default is false, set this value to true to debugging in logs.
+   Note: this mode can reveal secrets in logs.
 
 For a vacuum job, you are required to supply the following
 environment variables:
@@ -520,7 +553,6 @@ environment variables:
  * BACKUP_PV_HOST - the NFS host used to build the PV
  * BACKUP_PVC_STORAGE - a value like 75M means to allow 75 megabytes for the PVC used
  in performing the backup
-
 
 === CRON Expression Format
 
@@ -673,6 +705,8 @@ utility and a failover watch script.
  * PG_PRIMARY_SERVICE - the name of the primary database container
  * PG_REPLICA_SERVICE - the name of the replica database container, this is
    used to know which container to trigger the failover on
+ * DEBUG - default is false, set this value to true to debugging in logs.
+   Note: this mode can reveal secrets in logs.
 
 === Features
 
@@ -696,7 +730,12 @@ The crunchy-backrest-restore container executes the pgbackrest utility, allowing
 === Environment Variables
 
  * STANZA - required - must be set to the desired stanza for restore
- * DELTA - when set, will add the --delta option to the restore. The delta option allows pgBackRest to automatically determine which files in the database cluster directory can be preserved and which ones need to be restored from the backup — it also removes files not present in the backup manifest so it will dispose of divergent changes.
+ * DELTA - when set, will add the --delta option to the restore. The delta option 
+   allows pgBackRest to automatically determine which files in the database cluster 
+   directory can be preserved and which ones need to be restored from the backup — 
+   it also removes files not present in the backup manifest so it will dispose of divergent changes.
+ * DEBUG - default is false, set this value to true to debugging in logs.
+   Note: this mode can reveal secrets in logs.
 
 === Features
 
@@ -762,6 +801,8 @@ a 9.5 to a 9.6 version.
    option when initdb is executed at initialization, if not set, the
    default is to *not* enable data checksums
  * XLOGDIR - if set, initdb will use the specified directory for WAL
+ * DEBUG - default is false, set this value to true to debugging in logs.  
+   Note: this mode can reveal secrets in logs.
 
 === Features
 
@@ -791,6 +832,8 @@ The crunchy-sim container is a simple traffic simulator for PostgreSQL
 * PGSIM_INTERVAL - required, The units of the simulation interval
 * PGSIM_MININTERVAL - required, the minimum interval value
 * PGSIM_MAXINTERVAL - requited, the maximum interval value
+* DEBUG - default is false, set this value to true to debugging in logs.  
+  Note: this mode can reveal secrets in logs.
 
 Valid values for PGSIM_INTERVAL are as follows:
 

--- a/rhel7/10/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/10/Dockerfile.backrest-restore.rhel7
@@ -63,6 +63,7 @@ RUN chown -R postgres:postgres /opt/cpm  \
 VOLUME /pgconf /pgdata /backrestrepo
 
 ADD bin/backrest_restore /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/backrest_restore /opt/cpm/conf
 
 USER 26

--- a/rhel7/10/Dockerfile.backup.rhel7
+++ b/rhel7/10/Dockerfile.backup.rhel7
@@ -44,6 +44,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata
 ADD bin/backup/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/backup/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata
 

--- a/rhel7/10/Dockerfile.collect.rhel7
+++ b/rhel7/10/Dockerfile.collect.rhel7
@@ -52,6 +52,7 @@ ADD postgres_exporter /opt/cpm/bin
 ADD node_exporter.tar.gz /opt/cpm/bin
 
 ADD bin/collect /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 
 RUN chown -R postgres:postgres /opt/cpm/bin
 

--- a/rhel7/10/Dockerfile.pgbadger.rhel7
+++ b/rhel7/10/Dockerfile.pgbadger.rhel7
@@ -43,6 +43,7 @@ RUN mkdir -p /opt/cpm/bin
 EXPOSE 10000
 
 ADD bin/pgbadger /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 
 RUN chown -R postgres:postgres /opt/cpm/bin
 

--- a/rhel7/10/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/10/Dockerfile.pgbouncer.rhel7
@@ -54,6 +54,7 @@ VOLUME ["/pgconf"]
 EXPOSE 5432
 
 ADD bin/pgbouncer /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgbouncer /opt/cpm/conf
 
 RUN chown -R daemon:daemon /opt/cpm/bin

--- a/rhel7/10/Dockerfile.pgdump.rhel7
+++ b/rhel7/10/Dockerfile.pgdump.rhel7
@@ -44,6 +44,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata
 ADD bin/pgdump/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgdump/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata
 

--- a/rhel7/10/Dockerfile.pgpool.rhel7
+++ b/rhel7/10/Dockerfile.pgpool.rhel7
@@ -45,6 +45,7 @@ VOLUME ["/pgconf"]
 EXPOSE 5432
 
 ADD bin/pgpool /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgpool /opt/cpm/conf/pgpool
 ADD conf/pgpool/pool_hba.conf  /etc/pgpool-II-10/pool_hba.conf
 ADD conf/pgpool/pool_passwd /etc/pgpool-II-10/pool_passwd

--- a/rhel7/10/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/10/Dockerfile.postgres-gis.rhel7
@@ -83,6 +83,7 @@ EXPOSE 5432
 
 ADD bin/postgres /opt/cpm/bin
 ADD bin/postgres-gis /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/postgres /opt/cpm/conf
 
 USER 26

--- a/rhel7/10/Dockerfile.postgres.rhel7
+++ b/rhel7/10/Dockerfile.postgres.rhel7
@@ -80,6 +80,7 @@ VOLUME ["/pgconf", "/pgdata", "/pgwal", "/backup", "/recover", "/backrestrepo", 
 EXPOSE 5432
 
 ADD bin/postgres /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/postgres /opt/cpm/conf
 
 USER 26

--- a/rhel7/10/Dockerfile.upgrade.rhel7
+++ b/rhel7/10/Dockerfile.upgrade.rhel7
@@ -50,6 +50,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 
 RUN mkdir -p /opt/cpm/bin /pgolddata /pgnewdata /opt/cpm/conf
 ADD bin/upgrade/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/upgrade/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata
 

--- a/rhel7/10/Dockerfile.watch.rhel7
+++ b/rhel7/10/Dockerfile.watch.rhel7
@@ -53,6 +53,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf
 
 ADD bin/watch /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/watch /opt/cpm/conf
 
 RUN chown -R postgres:postgres /opt/cpm

--- a/rhel7/9.5/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.5/Dockerfile.backrest-restore.rhel7
@@ -63,6 +63,7 @@ RUN chown -R postgres:postgres /opt/cpm \
 VOLUME /pgconf /pgdata /backrestrepo
 
 ADD bin/backrest_restore /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/backrest_restore /opt/cpm/conf
 
 USER 26

--- a/rhel7/9.5/Dockerfile.backup.rhel7
+++ b/rhel7/9.5/Dockerfile.backup.rhel7
@@ -44,6 +44,7 @@ RUN yum -y update && yum -y install nss_wrapper gettext procps-ng \
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata
 ADD bin/backup/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/backup/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata
 

--- a/rhel7/9.5/Dockerfile.collect.rhel7
+++ b/rhel7/9.5/Dockerfile.collect.rhel7
@@ -50,8 +50,8 @@ RUN mkdir -p /opt/cpm/bin
 ADD postgres_exporter /opt/cpm/bin
 ADD node_exporter.tar.gz /opt/cpm/bin
 ADD bin/collect /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/collect /opt/cpm/conf
-
 
 RUN chown -R postgres:postgres /opt/cpm/bin /opt/cpm/conf
 

--- a/rhel7/9.5/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbadger.rhel7
@@ -42,6 +42,7 @@ RUN mkdir -p /opt/cpm/bin
 EXPOSE 10000
 
 ADD bin/pgbadger /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 
 RUN chown -R postgres:postgres /opt/cpm/bin
 

--- a/rhel7/9.5/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbouncer.rhel7
@@ -55,6 +55,7 @@ VOLUME ["/pgconf"]
 EXPOSE 5432
 
 ADD bin/pgbouncer /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgbouncer /opt/cpm/conf
 
 RUN chown -R pgbouncer:pgbouncer /opt/cpm/bin

--- a/rhel7/9.5/Dockerfile.pgdump.rhel7
+++ b/rhel7/9.5/Dockerfile.pgdump.rhel7
@@ -44,6 +44,7 @@ RUN yum -y update && yum -y install nss_wrapper gettext procps-ng \
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata
 ADD bin/pgdump/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgdump/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata
 

--- a/rhel7/9.5/Dockerfile.pgpool.rhel7
+++ b/rhel7/9.5/Dockerfile.pgpool.rhel7
@@ -51,6 +51,7 @@ VOLUME ["/pgconf"]
 EXPOSE 5432
 
 ADD bin/pgpool /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgpool /opt/cpm/conf/pgpool
 ADD conf/pgpool/pool_hba.conf  /etc/pgpool-II-95/pool_hba.conf
 ADD conf/pgpool/pool_passwd /etc/pgpool-II-95/pool_passwd

--- a/rhel7/9.5/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres-gis.rhel7
@@ -82,6 +82,7 @@ EXPOSE 5432
 
 ADD bin/postgres /opt/cpm/bin
 ADD bin/postgres-gis /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/postgres /opt/cpm/conf
 
 USER 26

--- a/rhel7/9.5/Dockerfile.postgres.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres.rhel7
@@ -79,6 +79,7 @@ VOLUME ["/pgconf", "/pgdata", "/pgwal", "/backup", "/recover", "/backrestrepo", 
 EXPOSE 5432
 
 ADD bin/postgres /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/postgres /opt/cpm/conf
 
 USER 26

--- a/rhel7/9.5/Dockerfile.watch.rhel7
+++ b/rhel7/9.5/Dockerfile.watch.rhel7
@@ -43,6 +43,7 @@ RUN mkdir -p /opt/cpm/bin /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm
 
 ADD bin/watch /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/watch /opt/cpm/conf
 
 USER 26

--- a/rhel7/9.6/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.6/Dockerfile.backrest-restore.rhel7
@@ -63,6 +63,7 @@ RUN chown -R postgres:postgres /opt/cpm  \
 VOLUME /pgconf /pgdata /backrestrepo
 
 ADD bin/backrest_restore /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/backrest_restore /opt/cpm/conf
 
 USER 26

--- a/rhel7/9.6/Dockerfile.backup.rhel7
+++ b/rhel7/9.6/Dockerfile.backup.rhel7
@@ -44,6 +44,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata
 ADD bin/backup/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/backup/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata
 

--- a/rhel7/9.6/Dockerfile.collect.rhel7
+++ b/rhel7/9.6/Dockerfile.collect.rhel7
@@ -52,6 +52,7 @@ RUN mkdir -p /opt/cpm/bin
 ADD postgres_exporter /opt/cpm/bin
 ADD node_exporter.tar.gz /opt/cpm/bin
 ADD bin/collect /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/collect /opt/cpm/conf
 
 RUN chown -R postgres:postgres /opt/cpm/bin /opt/cpm/conf

--- a/rhel7/9.6/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbadger.rhel7
@@ -43,6 +43,7 @@ RUN mkdir -p /opt/cpm/bin
 EXPOSE 10000
 
 ADD bin/pgbadger /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 
 RUN chown -R postgres:postgres /opt/cpm/bin
 

--- a/rhel7/9.6/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbouncer.rhel7
@@ -54,6 +54,7 @@ VOLUME ["/pgconf"]
 EXPOSE 5432
 
 ADD bin/pgbouncer /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgbouncer /opt/cpm/conf
 
 RUN chown -R daemon:daemon /opt/cpm/bin

--- a/rhel7/9.6/Dockerfile.pgdump.rhel7
+++ b/rhel7/9.6/Dockerfile.pgdump.rhel7
@@ -44,6 +44,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata
 ADD bin/pgdump/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgdump/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata
 

--- a/rhel7/9.6/Dockerfile.pgpool.rhel7
+++ b/rhel7/9.6/Dockerfile.pgpool.rhel7
@@ -45,6 +45,7 @@ VOLUME ["/pgconf"]
 EXPOSE 5432
 
 ADD bin/pgpool /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/pgpool /opt/cpm/conf/pgpool
 ADD conf/pgpool/pool_hba.conf  /etc/pgpool-II-96/pool_hba.conf
 ADD conf/pgpool/pool_passwd /etc/pgpool-II-96/pool_passwd

--- a/rhel7/9.6/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres-gis.rhel7
@@ -83,6 +83,7 @@ EXPOSE 5432
 
 ADD bin/postgres /opt/cpm/bin
 ADD bin/postgres-gis /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/postgres /opt/cpm/conf
 
 USER 26

--- a/rhel7/9.6/Dockerfile.postgres.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres.rhel7
@@ -80,6 +80,7 @@ VOLUME ["/pgconf", "/pgdata", "/pgwal", "/backup", "/recover", "/backrestrepo", 
 EXPOSE 5432
 
 ADD bin/postgres /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/postgres /opt/cpm/conf
 
 USER 26

--- a/rhel7/9.6/Dockerfile.upgrade.rhel7
+++ b/rhel7/9.6/Dockerfile.upgrade.rhel7
@@ -48,6 +48,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 
 RUN mkdir -p /opt/cpm/bin /pgolddata /pgnewdata /opt/cpm/conf
 ADD bin/upgrade/ /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/upgrade/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata
 

--- a/rhel7/9.6/Dockerfile.watch.rhel7
+++ b/rhel7/9.6/Dockerfile.watch.rhel7
@@ -53,6 +53,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf
 
 ADD bin/watch /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/watch /opt/cpm/conf
 
 RUN chown -R postgres:postgres /opt/cpm

--- a/rhel7/Dockerfile.dba.rhel7
+++ b/rhel7/Dockerfile.dba.rhel7
@@ -27,6 +27,7 @@ RUN mkdir -p /opt/cpm/bin
 RUN mkdir -p /opt/cpm/conf
 
 ADD bin/dba /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/dba /opt/cpm/conf
 
 USER root

--- a/rhel7/Dockerfile.grafana.rhel7
+++ b/rhel7/Dockerfile.grafana.rhel7
@@ -31,6 +31,7 @@ EXPOSE 3000
 
 ADD grafana.tar.gz /opt/cpm/bin
 ADD bin/grafana /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/grafana /opt/cpm/conf
 
 RUN chown -R daemon:daemon /opt/cpm /data

--- a/rhel7/Dockerfile.prometheus.rhel7
+++ b/rhel7/Dockerfile.prometheus.rhel7
@@ -30,6 +30,7 @@ EXPOSE 9090
 
 ADD prometheus.tar.gz /opt/cpm/bin
 ADD bin/prometheus /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 ADD conf/prometheus /opt/cpm/conf
 
 RUN chown -R daemon:daemon /opt/cpm /data

--- a/rhel7/Dockerfile.promgateway.rhel7
+++ b/rhel7/Dockerfile.promgateway.rhel7
@@ -32,6 +32,7 @@ EXPOSE 9091
 
 ADD prometheus-pushgateway.tar.gz /opt/cpm/bin
 ADD bin/promgateway /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 
 USER daemon
 

--- a/rhel7/Dockerfile.vacuum.rhel7
+++ b/rhel7/Dockerfile.vacuum.rhel7
@@ -29,6 +29,7 @@ RUN yum -y update && yum -y install procps-ng iproute bind-utils openssh-clients
 RUN mkdir -p /opt/cpm/bin
 
 ADD bin/vacuum /opt/cpm/bin
+ADD bin/common /opt/cpm/bin
 
 USER root
 


### PR DESCRIPTION
This PR addresses #353 by adding a DEBUG flag to every container.  Here's what it looks like when `DEBUG=true`:

```bash
$ kubectl logs basic
+(/opt/cpm/bin/start.sh:32)> trap trap_sigterm SIGINT SIGTERM
+(/opt/cpm/bin/start.sh:34)> date
Turning Debugging On
+(/opt/cpm/bin/start.sh:36)> source /opt/cpm/bin/setenv.sh
++(/opt/cpm/bin/setenv.sh:16)> source /opt/cpm/bin/common_lib.sh
++(/opt/cpm/bin/setenv.sh:18)> '[' -d /usr/pgsql-10 ']'
++(/opt/cpm/bin/setenv.sh:19)> export PGROOT=/usr/pgsql-10
++(/opt/cpm/bin/setenv.sh:19)> PGROOT=/usr/pgsql-10
++(/opt/cpm/bin/setenv.sh:30)> echo 'setting PGROOT to ' /usr/pgsql-10
++(/opt/cpm/bin/setenv.sh:32)> export PGDATA=/pgdata/basic
```

This also introduces a common library which we can use to deploy functions to every image.  As of now this only contains `ose_hack` and `enable_debugging`.  I've removed `ose_hack` duplicates as part of this effort.

Any new images (like pgrestore @steve-hetzel ) should include these changes.  I've left out pgadmin4 intentionally as I have a patch for that soon.