### PR TITLE
Updating pgadmin4 PG version for 9.6 to use correct one

### DIFF
--- a/centos7/9.6/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.6/Dockerfile.pgadmin4.centos7
@@ -2,8 +2,8 @@ FROM centos:7
 
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
-        PostgresVersion="9.5" \
-        PostgresFullVersion="9.5.11" \
+        PostgresVersion="9.6" \
+        PostgresFullVersion="9.6.7" \
         version="7.3" \
         release="1.8.0" \
         build-date="2018-01-30" \


### PR DESCRIPTION
  Noticed that the 9.6 pgadmin4 docker was using 9.5 postgres.  So fixed that