### PR TITLE
Remove metrics.adoc references

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,9 +23,9 @@ The project includes the following containers:
  * link:docs/containers.adoc#crunchy-pgpool[crunchy-pgpool] - executes pgpool
  * link:docs/containers.adoc#crunchy-pgbadger[crunchy-pgbadger] - executes pgbadger
  * link:docs/containers.adoc#crunchy-watch[crunchy-watch] - performs a form of automated failover
- * link:docs/metrics.adoc#crunchy-collect[crunchy-collect] - collects Postgres metrics
- * link:docs/metrics.adoc#crunchy-prometheus[crunchy-prometheus] -stores Postgres metrics
- * link:docs/metrics.adoc#crunchy-grafana[crunchy-grafana] - graphs Postgres metrics
+ * link:docs/containers.adoc#crunchy-collect[crunchy-collect] - collects Postgres metrics
+ * link:docs/containers.adoc#crunchy-prometheus[crunchy-prometheus] -stores Postgres metrics
+ * link:docs/containers.adoc#crunchy-grafana[crunchy-grafana] - graphs Postgres metrics
  * link:docs/containers.adoc#crunchy-pgbouncer[crunchy-pgbouncer] - pgbouncer connection pooler and simple form of failover
  * link:docs/containers.adoc#crunchy-pgadmin4[crunchy-pgadmin4] - pgadmin4 web application
  * link:docs/containers.adoc#crunchy-dba[crunchy-dba] - implements a cron scheduler to perform simple DBA tasks

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -18,7 +18,6 @@
 a2x -f pdf ./examples.adoc
 a2x -f pdf ./dedicated.adoc
 a2x -f pdf ./install.adoc
-a2x -f pdf ./metrics.adoc
 a2x -f pdf ./containers.adoc
 a2x -f pdf ./pitr.adoc
 
@@ -27,7 +26,6 @@ a2x -f pdf ./pitr.adoc
 #a2x -f xhtml ./examples.adoc -D ./xhtml/
 #a2x -f xhtml ./dedicated.adoc -D ./xhtml/
 #a2x -f xhtml ./install.adoc -D ./xhtml/
-#a2x -f xhtml ./metrics.adoc -D ./xhtml/
 #a2x -f xhtml ./containers.adoc -D ./xhtml/
 #a2x -f xhtml ./pitr.adoc -D ./xhtml/
 


### PR DESCRIPTION
There were some left over references from the removal of `metrics.adoc` that I missed.