### PR TITLE
issue #437 fix sync-primary bug on Docker

### DIFF
--- a/docs/examples.adoc
+++ b/docs/examples.adoc
@@ -1394,7 +1394,7 @@ kubectl logs -c postgres crunchy-pgsql
 Running the example:
 
 ....
-cd $CCPROOT/examples/oepnshift/metrics
+cd $CCPROOT/examples/openshift/metrics
 ./run.sh
 ....
 
@@ -1681,11 +1681,11 @@ and the password ``password'':
 psql -h 127.0.0.1 -p 12010 -U postgres postgres -c 'table pg_stat_replication'
 ....
 
-You should see 2 rows, 1 for the async replica and 1 for the sync replica.  The
+You should see 2 rows; 1 for the asynchronous replica and 1 for the synchronous replica.  The
 sync_state column shows values of async or sync.
 
-You can test replication to the replicas by entering some data on
-the primary like this, and then querying the replicas for that data:
+You can test replication to the replicas by first entering some data on
+the primary, and secondly querying the replicas for that data:
 ....
 psql -h 127.0.0.1 -p 12010 -U postgres postgres -c 'create table foo (id int)'
 psql -h 127.0.0.1 -p 12010 -U postgres postgres -c 'insert into foo values (1)'

--- a/examples/docker/sync/cleanup.sh
+++ b/examples/docker/sync/cleanup.sh
@@ -15,17 +15,17 @@
 
 echo "Cleaning up..."
 
-CONTAINER_NAME=sync-primary
+CONTAINER_NAME=syncprimary
 
 docker stop $CONTAINER_NAME
 docker rm $CONTAINER_NAME
 
-CONTAINER_NAME=sync-replica
+CONTAINER_NAME=syncreplica
 
 docker stop $CONTAINER_NAME
 docker rm $CONTAINER_NAME
 
-CONTAINER_NAME=async-replica
+CONTAINER_NAME=asyncreplica
 
 docker stop $CONTAINER_NAME
 docker rm $CONTAINER_NAME

--- a/examples/docker/sync/run.sh
+++ b/examples/docker/sync/run.sh
@@ -23,14 +23,14 @@ echo "Starting primary container..."
 #sudo chcon -Rt svirt_sandbox_file_t $PGCONF
 # add this next line to the docker run to override pg config files
 
-DATA_DIR=/tmp/sync-primary-data
+DATA_DIR=/tmp/syncprimary-data
 sudo rm -rf $DATA_DIR
 sudo mkdir -p $DATA_DIR
 sudo chown postgres:postgres $DATA_DIR
 sudo chcon -Rt svirt_sandbox_file_t $DATA_DIR
 
-sudo docker stop sync-primary
-sudo docker rm sync-primary
+sudo docker stop syncprimary
+sudo docker rm syncprimary
 
 sudo docker run \
 	-p 12010:5432 \
@@ -42,7 +42,7 @@ sudo docker run \
 	-e MAX_WAL_SENDERS=7 \
 	-e WORK_MEM=5MB \
 	-e PG_MODE=primary \
-	-e SYNC_REPLICA=sync-replica \
+	-e SYNC_REPLICA=syncreplica \
 	-e PG_PRIMARY_USER=primaryuser \
 	-e PG_PRIMARY_PASSWORD=password \
 	-e PG_PRIMARY_PORT=5432 \
@@ -50,8 +50,8 @@ sudo docker run \
 	-e PG_ROOT_PASSWORD=password \
 	-e PG_PASSWORD=password \
 	-e PG_DATABASE=userdb \
-	--name=sync-primary \
-	--hostname=sync-primary \
+	--name=syncprimary \
+	--hostname=syncprimary \
 	-d $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 
 echo "Sleeping in order to let the primary start..."
@@ -59,14 +59,14 @@ sleep 20
 
 echo "Starting synchronous replica..."
 
-DATA_DIR=/tmp/sync-replica
+DATA_DIR=/tmp/syncreplica
 sudo rm -rf $DATA_DIR
 sudo mkdir -p $DATA_DIR
 sudo chown postgres:postgres $DATA_DIR
 sudo chcon -Rt svirt_sandbox_file_t $DATA_DIR
 
-sudo docker stop sync-replica
-sudo docker rm sync-replica
+sudo docker stop syncreplica
+sudo docker rm syncreplica
 
 sudo docker run \
 	-p 12011:5432 \
@@ -80,29 +80,29 @@ sudo docker run \
 	-e PG_MODE=replica \
 	-e PG_PRIMARY_USER=primaryuser \
 	-e PG_PRIMARY_PASSWORD=password \
-	-e PG_PRIMARY_HOST=sync-primary \
-	-e SYNC_REPLICA=sync-replica \
-	--link sync-primary:sync-primary \
+	-e PG_PRIMARY_HOST=syncprimary \
+	-e SYNC_REPLICA=syncreplica \
+	--link syncprimary:syncprimary \
 	-e PG_PRIMARY_PORT=5432 \
 	-e PG_USER=testuser \
 	-e PG_ROOT_PASSWORD=password \
 	-e PG_PASSWORD=password \
 	-e PG_DATABASE=userdb \
-	--name=sync-replica \
-	--hostname=sync-replica \
+	--name=syncreplica \
+	--hostname=syncreplica \
 	-d $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 
 
 echo "Starting asynchronous replica..."
 
-DATA_DIR=/tmp/async-replica
+DATA_DIR=/tmp/asyncreplica
 sudo rm -rf $DATA_DIR
 sudo mkdir -p $DATA_DIR
 sudo chown postgres:postgres $DATA_DIR
 sudo chcon -Rt svirt_sandbox_file_t $DATA_DIR
 
-sudo docker stop async-replica
-sudo docker rm async-replica
+sudo docker stop asyncreplica
+sudo docker rm asyncreplica
 
 sudo docker run \
 	-p 12012:5432 \
@@ -116,13 +116,13 @@ sudo docker run \
 	-e PG_MODE=replica \
 	-e PG_PRIMARY_USER=primaryuser \
 	-e PG_PRIMARY_PASSWORD=password \
-	-e PG_PRIMARY_HOST=sync-primary \
-	--link sync-primary:sync-primary \
+	-e PG_PRIMARY_HOST=syncprimary \
+	--link syncprimary:syncprimary \
 	-e PG_PRIMARY_PORT=5432 \
 	-e PG_USER=testuser \
 	-e PG_ROOT_PASSWORD=password \
 	-e PG_PASSWORD=password \
 	-e PG_DATABASE=userdb \
-	--name=async-replica \
-	--hostname=async-replica \
+	--name=asyncreplica \
+	--hostname=asyncreplica \
 	-d $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG


### PR DESCRIPTION
Regarding issue #437:

- Renamed sync-primary -> syncprimary
- Renamed sync-replica -> syncreplica
- Renamed async-replica -> asyncreplica
- Minor typo fixes in example docs
- Tested the sync example on Docker to make sure the bug is resolved

The reason for these fixes:

Alton discovered an error with Docker that prevented the **sync** example from being run. He received the error:  

`2018-02-12 17:30:13 EST [70]: [1-1] user=,db=,app=,client=LOG: invalid value for parameter "synchronous_standby_names": "sync-replica"
2018-02-12 17:30:13 EST [70]: [2-1] user=,db=,app=,client=DETAIL: syntax error at or near "-"
2018-02-12 17:30:13 EST [70]: [3-1] user=,db=,app=,client=FATAL: configuration file "/pgdata/sync-primary/postgresql.conf" contains errors`

Looking up the definition for synchronous_standby_names (string) in postgresql.conf:

> Each standby_name should have the form of a valid SQL identifier, unless it is *. You can use double-quoting if necessary. But note that standby_names are compared to standby application names case-insensitively, whether double-quoted or not.

Valid SQL identifiers do **not** include "-". Additionally, the OpenShift and Kube examples for the **sync** example make use of names without dashes as well, so this makes the entire sync example consistent.