### PR TITLE
Add missing repo

### DIFF
--- a/rhel7/9.5/Dockerfile.collect.rhel7
+++ b/rhel7/9.5/Dockerfile.collect.rhel7
@@ -24,6 +24,11 @@ COPY docs/collect/help.1 /help.1
 COPY docs/collect/help.md /help.md
 COPY docs/licenses /licenses
 
+# Crunchy Postgres repo
+ADD conf/CRUNCHY-GPG-KEY.public  /
+ADD conf/crunchypg95.repo /etc/yum.repos.d/
+RUN rpm --import CRUNCHY-GPG-KEY.public
+
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 # Install postgres client tools and libraries


### PR DESCRIPTION
Crunchy RPMs weren't being installed on 9.5 RHEL7 collect due to RPM import missing.