### PR TITLE
issue #509 add issue & pr request templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,40 @@
+**I'm submitting a ...**
+
+ <!--- What kind of an issue is this? Put an `x` in all the boxes that apply: -->
+ - [ ] bug report
+ - [ ] feature request
+ - [ ] support request
+
+
+
+**Do you want to request a *feature* or report a *bug*?**
+
+
+
+**What is the current behavior?**
+
+
+
+**If the current behavior is a bug, please provide the steps to reproduce:**
+
+
+
+**What is the expected behavior?**
+
+
+
+**What is the motivation or use case for changing the behavior?**
+
+
+
+**Other information** (e.g. detailed explanation, related issues, suggestions how to fix, etc)
+
+
+
+**Please tell us about your environment:**
+
+ - Operating System:
+ - Container Image Tag:
+ - PostgreSQL Version:
+ - Platform (Docker, Kubernetes, OpenShift):
+ - Platform Version:

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+**Checklist:**
+
+ <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
+ - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
+ - [ ] Have you updated or added documentation for the change, as applicable?
+ - [ ] Have you tested your changes on all related environments with successful results, as applicable?
+
+
+
+**Type of Changes:**
+
+ <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+ - [ ] Bug fix (non-breaking change which fixes an issue)
+ - [ ] New feature (non-breaking change which adds functionality)
+ - [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+
+
+**What is the current behavior? (link to any open issues here)**
+
+
+
+**What is the new behavior (if this is a feature change)?**
+
+
+
+**Other information**:


### PR DESCRIPTION
**This commit addresses issue #509.**

**"Is this useful? What does it solve?"**

The purpose of including GitHub PR and Issue templates is to customize and standardize the information included when a user either opens a new issue or submits a pull request. 

It ensures enough details are added to issues that we can debug properly without soliciting too much additional information, and additionally allows for detailed pull requests that describe exactly what changes were made.

Specifically, the goal of the Issue Template is to determine:
- what kind of issue is being opened
- the expected behavior
- the use case for changing the behavior
- the environment
- and any other information necessary for including

And the goal of the Pull Request Template is to determine:
- what kind of change was made
- if the user tested the change thoroughly
- what the point of the changes are
- if the documentation been updated

The Issue Template was modified slightly from the version available [here](https://github.com/stevemao/github-issue-templates/blob/master/conversational/ISSUE_TEMPLATE.md).

The PR Template was put together from these three templates - [1](https://github.com/stevemao/github-issue-templates/blob/master/checklist/PULL_REQUEST_TEMPLATE.md) [2](https://github.com/stevemao/github-issue-templates/blob/master/conversational/PULL_REQUEST_TEMPLATE.md) [3](https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md)

These templates that were modified have **no copyright**, and are licensed as being under the "[Public License](https://creativecommons.org/publicdomain/zero/1.0/)".