### PR TITLE
Fix Kube pgAdmin4 example on OCP

### DIFF
--- a/examples/kube/pgadmin4-http/pgadmin4.json
+++ b/examples/kube/pgadmin4-http/pgadmin4.json
@@ -58,6 +58,10 @@
                 "persistentVolumeClaim": {
                     "claimName": "pgadmin-http-pvc"
                 }
+            },
+            {
+                "name": "run",
+                "emptyDir": {}
             }
         ],
         "containers": [
@@ -94,6 +98,11 @@
                     {
                         "mountPath": "/var/lib/pgadmin",
                         "name": "pgadmin",
+                        "readOnly": false
+                    },
+                    {
+                        "mountPath": "/run/httpd",
+                        "name": "run",
                         "readOnly": false
                     }
                 ]

--- a/examples/kube/pgadmin4-https/pgadmin4.json
+++ b/examples/kube/pgadmin4-https/pgadmin4.json
@@ -76,6 +76,10 @@
                         }
                     ]
                 }
+            },
+            {
+                "name": "run",
+                "emptyDir": {}
             }
         ],
         "containers": [
@@ -122,6 +126,11 @@
                         "mountPath": "/certs",
                         "name": "certs",
                         "readOnly": true
+                    },
+                    {
+                        "mountPath": "/run/httpd",
+                        "name": "run",
+                        "readOnly": false
                     }
                 ]
             }


### PR DESCRIPTION
In order to make the pgAdmin4 Kube example work on OpenShift, the `/run/httpd` volume is required.