### PR TITLE
misc 1.8.2 bugfixes

### DIFF
--- a/bin/pull-from-crunchy.sh
+++ b/bin/pull-from-crunchy.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 REG_CCP_IMAGE_PREFIX=registry.crunchydata.com/crunchydata
-for CONTAINER in crunchy-prometheus crunchy-grafana crunchy-collect crunchy-pgbadger crunchy-pgpool crunchy-watch crunchy-backup crunchy-postgres crunchy-postgres-gis crunchy-pgbouncer crunchy-pgadmin4 crunchy-dump crunchy-restore crunchy-backrest-restore
+for CONTAINER in crunchy-prometheus crunchy-dba crunchy-vacuum crunchy-upgrade crunchy-grafana crunchy-collect crunchy-pgbadger crunchy-pgpool crunchy-watch crunchy-backup crunchy-postgres crunchy-postgres-gis crunchy-pgbouncer crunchy-pgadmin4 crunchy-dump crunchy-restore crunchy-backrest-restore
 do
 	echo $CONTAINER is the container
 	docker pull $REG_CCP_IMAGE_PREFIX/$CONTAINER:$CCP_IMAGE_TAG

--- a/bin/pull-from-dockerhub.sh
+++ b/bin/pull-from-dockerhub.sh
@@ -38,3 +38,6 @@ docker pull $CCP_IMAGE_PREFIX/crunchy-pgbouncer:$CCP_IMAGE_TAG
 docker pull $CCP_IMAGE_PREFIX/crunchy-pgadmin4:$CCP_IMAGE_TAG
 docker pull $CCP_IMAGE_PREFIX/crunchy-dump:$CCP_IMAGE_TAG
 docker pull $CCP_IMAGE_PREFIX/crunchy-restore:$CCP_IMAGE_TAG
+docker pull $CCP_IMAGE_PREFIX/crunchy-upgrade:$CCP_IMAGE_TAG
+docker pull $CCP_IMAGE_PREFIX/crunchy-dba:$CCP_IMAGE_TAG
+docker pull $CCP_IMAGE_PREFIX/crunchy-vacuum:$CCP_IMAGE_TAG

--- a/bin/push-to-dockerhub.sh
+++ b/bin/push-to-dockerhub.sh
@@ -27,3 +27,4 @@ docker push  $CCP_IMAGE_PREFIX/crunchy-pgbouncer:$CCP_IMAGE_TAG
 docker push  $CCP_IMAGE_PREFIX/crunchy-pgadmin4:$CCP_IMAGE_TAG
 docker push  $CCP_IMAGE_PREFIX/crunchy-vacuum:$CCP_IMAGE_TAG
 docker push  $CCP_IMAGE_PREFIX/crunchy-dba:$CCP_IMAGE_TAG
+docker push $CCP_IMAGE_PREFIX/crunchy-upgrade:$CCP_IMAGE_TAG

--- a/examples/kube/pgaudit/test-pgaudit.sh
+++ b/examples/kube/pgaudit/test-pgaudit.sh
@@ -18,7 +18,7 @@ echo -e "\nTesting pgaudit..."
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DOW=$(date +%u)
 
-if [[ $DOW == 0 ]]; then
+if [[ $DOW == 7 ]]; then
 	DAY=Sun
 elif [[ $DOW == 1 ]]; then
 	DAY=Mon

--- a/examples/kube/pitr/run-sql.sh
+++ b/examples/kube/pitr/run-sql.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 psql -h primary-pitr -U postgres postgres -f $DIR/cmds.sql

--- a/examples/openshift/backup-job/backup-job.json
+++ b/examples/openshift/backup-job/backup-job.json
@@ -20,7 +20,7 @@
       "name": "DATABASE_HOST",
       "displayName": "Database Host",
       "description": "This is the database the backup will be done for.",
-      "value": "basic"
+      "value": "primary-pvc"
     }, {
       "name": "DATABASE_PORT",
       "displayName": "Database Port",

--- a/examples/openshift/pgaudit/test-pgaudit.sh
+++ b/examples/openshift/pgaudit/test-pgaudit.sh
@@ -18,7 +18,7 @@ echo -e "\nTesting pgaudit..."
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DOW=$(date +%u)
 
-if [[ $DOW == 0 ]]; then
+if [[ $DOW == 7 ]]; then
 	DAY=Sun
 elif [[ $DOW == 1 ]]; then
 	DAY=Mon
@@ -37,7 +37,7 @@ fi
 export PGPASSWORD=password
 
 svc="$(oc get svc audit | grep -v CLUSTER-IP )"
-svcIP="$(echo $svc | awk {'print $2'})"
+svcIP="$(echo $svc | awk {'print $3'})"
 
 psql -h $svcIP -U postgres -f $DIR/test.sql postgres
 echo -e "\nTest SQL written to audit."

--- a/examples/openshift/primary-restore/primary-restore.json
+++ b/examples/openshift/primary-restore/primary-restore.json
@@ -21,9 +21,6 @@
         "name": "CCP_IMAGE_TAG",
         "description": "The image tag to use"
     }, {
-        "name": "CCP_IMAGE_PREFIX",
-        "description": "The image prefix to use"
-    }, {
         "name": "PG_PRIMARY_PASSWORD",
         "description": "The password for the PG primary user",
         "value": "password"

--- a/examples/openshift/vacuum-job/vacuum-job.json
+++ b/examples/openshift/vacuum-job/vacuum-job.json
@@ -46,7 +46,7 @@
                             "value": "testtable"
                         }, {
                             "name": "JOB_HOST",
-                            "value": "basic"
+                            "value": "primary-pvc"
                         }, {
                             "name": "PG_USER",
                             "value": "testuser"


### PR DESCRIPTION
- fix missing $DIR variable - kube/pitr
- DOW Sunday = 7, not 0 - pgaudit
- wrong variable was being grabbed - pgaudit
- primary-pvc should be referenced, not basic - backup-job, vacuum-job
- removed extra CCP_IMAGE_PREFIX clause causing error - primary-restore
- added dba, vacuum, upgrade to push/pull scripts
