### PR TITLE
issue #388 & #514 update helm charts

### DIFF
--- a/examples/helm/basic/Chart.yaml
+++ b/examples/helm/basic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: basic
-description: Deploys a basic single PostgreSQL primary database
+description: Deploys a single PostgreSQL primary database
 version: 1
 appVersion: 1.8.2
 keywords:

--- a/examples/helm/basic/README.md
+++ b/examples/helm/basic/README.md
@@ -65,10 +65,10 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install basic --name basic \
-  --set Image.tag=centos7-10.3-1.8.2
+  --set Image.tag=centos7-9.6.8-1.8.2
 ```
 
-The above command changes the image tag of the container from the default of `centos7-9.6.8-1.8.2` to `centos7-10.3-1.8.2`.
+The above command changes the image tag of the container from the default of `centos7-10.3-1.8.2` to `centos7-9.6.8-1.8.2`.
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
@@ -83,7 +83,7 @@ The above command changes the image tag of the container from the default of `ce
 | `.serviceType`      | The type of service      | `ClusterIP`               
 | `.image.repository` | The repository on DockerHub where the images are found.    | `crunchydata`                                           |
 | `.image.container` | The container to be pulled from the repository.    | `crunchy-postgres`                                                    |
-| `.image.tag` | The image tag to be used.    | `centos7-9.6.8-1.8.2`                                                    |
+| `.image.tag` | The image tag to be used.    | `centos7-10.3-1.8.2`                                                    |
 | `.resources.cpu` | Defines a limit for CPU    | `200m`                                                    |
 | `.resources.memory` | Defines a limit for memory    | `512Mi`                                                    |
 

--- a/examples/helm/basic/values.yaml
+++ b/examples/helm/basic/values.yaml
@@ -10,7 +10,7 @@ serviceType: ClusterIP
 image:
   repository: crunchydata
   container: crunchy-postgres
-  tag: centos7-9.6.8-1.8.2
+  tag: centos7-10.3-1.8.2
 resources:
   cpu: 200m
   memory: 512Mi

--- a/examples/helm/custom-config/README.md
+++ b/examples/helm/custom-config/README.md
@@ -66,10 +66,10 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install custom-config --name custom-config \
-  --set Image.tag=centos7-10.3-1.8.2
+  --set Image.tag=centos7-9.6.8-1.8.2
 ```
 
-The above command changes the image tag of the container from the default of `centos7-9.6.8-1.8.2` to `centos7-10.3-1.8.2`.
+The above command changes the image tag of the container from the default of `centos7-10.3-1.8.2` to `centos7-9.6.8-1.8.2`.
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
@@ -84,7 +84,7 @@ The above command changes the image tag of the container from the default of `ce
 | `.serviceType`      | The type of service      | `ClusterIP`               
 | `.image.repository` | The repository on DockerHub where the images are found.    | `crunchydata`                                           |
 | `.image.container` | The container to be pulled from the repository.    | `crunchy-postgres`                                                    |
-| `.image.tag` | The image tag to be used.    | `centos7-9.6.8-1.8.2`                                                    |
+| `.image.tag` | The image tag to be used.    | `centos7-10.3-1.8.2`                                                    |
 | `.resources.cpu` | Defines a limit for CPU    | `200m`                                                    |
 | `.resources.memory` | Defines a limit for memory    | `512Mi`                                                    |
 

--- a/examples/helm/primary-replica/README.md
+++ b/examples/helm/primary-replica/README.md
@@ -102,10 +102,10 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install basic --name basic \
-  --set Image.tag=centos7-10.3-1.8.2
+  --set Image.tag=centos7-9.6.8-1.8.2
 ```
 
-The above command changes the image tag of the container from the default of `centos7-9.6.8-1.8.2` to `centos7-10.3-1.8.2`.
+The above command changes the image tag of the container from the default of `centos7-10.3-1.8.2` to `centos7-9.6.8-1.8.2`.
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
@@ -121,7 +121,7 @@ The above command changes the image tag of the container from the default of `ce
 | `.serviceType`      | The type of service      | `ClusterIP`               
 | `.image.repository` | The repository on DockerHub where the images are found.    | `crunchydata`                                           |
 | `.image.container` | The container to be pulled from the repository.    | `crunchy-postgres`                                                    |
-| `.image.tag` | The image tag to be used.    | `centos7-9.6.8-1.8.2`                                                    |
+| `.image.tag` | The image tag to be used.    | `centos7-10.3-1.8.2`                                                    |
 | `.nfs.serverIP` | The IP address of the NFS server     | 10.0.1.4                                                    |
 | `.nfs.path` | The path of the mounted NFS drive    | `/mnt/nfsfileshare`                                                    |
 | `.pv.storage` | Size of persistent volume     | 400M                                                    |

--- a/examples/helm/primary-replica/values.yaml
+++ b/examples/helm/primary-replica/values.yaml
@@ -12,7 +12,7 @@ serviceType: ClusterIP
 image:
   repository: crunchydata
   container: crunchy-postgres
-  tag: centos7-9.6.8-1.8.2
+  tag: centos7-10.3-1.8.2
 nfs:
   serverIP: 10.0.1.4
   path: /mnt/nfsfileshare

--- a/examples/helm/statefulset/README.md
+++ b/examples/helm/statefulset/README.md
@@ -104,10 +104,10 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install basic --name basic \
-  --set Image.tag=centos7-10.3-1.8.2
+  --set Image.tag=centos7-9.6.8-1.8.2
 ```
 
-The above command changes the image tag of the container from the default of `centos7-9.6.8-1.8.2` to `centos7-10.3-1.8.2`.
+The above command changes the image tag of the container from the default of `centos7-10.3-1.8.2` to `centos7-9.6.8-1.8.2`.
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
@@ -124,7 +124,7 @@ The above command changes the image tag of the container from the default of `ce
 | `.serviceType`      | The type of service      | `ClusterIP`               
 | `.image.repository` | The repository on DockerHub where the images are found.    | `crunchydata`                                           |
 | `.image.container` | The container to be pulled from the repository.    | `crunchy-postgres`                                                    |
-| `.image.tag` | The image tag to be used.    | `centos7-9.6.8-1.8.2`                                                    |
+| `.image.tag` | The image tag to be used.    | `centos7-10.3-1.8.2`                                                    |
 | `.pv.storage` | Size of persistent volume     | 400M                                                    |
 | `.pv.name` | Name of persistent volume    | `pgset-pv`                                                    |
 | `.pvc.name` | Name of persistent volume    | `pgset-pvc`                                                    |

--- a/examples/helm/statefulset/templates/set-replica-service.yaml
+++ b/examples/helm/statefulset/templates/set-replica-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: "{{.Values.container.name.replica}}"
   labels:
-    name: "{{.Values.container.name.primary}}"
+    name: "{{.Values.container.name.replica}}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"

--- a/examples/helm/statefulset/templates/set-service.yaml
+++ b/examples/helm/statefulset/templates/set-service.yaml
@@ -13,4 +13,4 @@ spec:
     name: web
   clusterIP: None
   selector:
-    app: "{{.Values.container.name.primary}}"
+    app: "{{.Values.container.name.default}}"

--- a/examples/helm/statefulset/templates/set.yaml
+++ b/examples/helm/statefulset/templates/set.yaml
@@ -1,28 +1,24 @@
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
-  name: "{{.Values.container.name.primary}}"
+  name: "{{.Values.container.name.default}}"
   labels:
-    name: "{{.Values.container.name.replica}}"
-    app: "{{.Values.container.name.primary}}"
+    name: "{{.Values.container.name.default}}"
+    app: "{{.Values.container.name.default}}"
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
   annotations:
     "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
-  selector:
-    matchLabels:
-      app: "{{.Values.container.name.primary}}"
-  serviceName: "{{.Values.container.name.primary}}"
+  serviceName: "{{.Values.container.name.default}}"
   replicas: 2
   template:
     metadata:
       labels:
-        app: "{{.Values.container.name.primary}}"
+        app: "{{.Values.container.name.default}}"
     spec:
       serviceAccount: "{{.Values.container.serviceAccount}}"
-      terminationGracePeriodSeconds: 10
       containers:
-      - name: {{.Values.container.name.primary}}
+      - name: {{.Values.container.name.default}}
         image: "{{.Values.image.repository}}/{{.Values.image.container}}:{{.Values.image.tag}}"
         ports:
         - containerPort: {{.Values.container.port}}
@@ -36,6 +32,8 @@ spec:
           value: set
         - name: PG_PRIMARY_HOST
           value: "{{.Values.container.name.primary}}"
+        - name: PG_REPLICA_HOST
+          value: "{{.Values.container.name.replica}}"
         - name: PG_PRIMARY_PORT
           value: "{{.Values.container.port}}"
         - name: PG_PRIMARY_PASSWORD

--- a/examples/helm/statefulset/values.yaml
+++ b/examples/helm/statefulset/values.yaml
@@ -14,7 +14,7 @@ serviceType: ClusterIP
 image:
   repository: crunchydata
   container: crunchy-postgres
-  tag: centos7-9.6.8-1.8.2
+  tag: centos7-10.3-1.8.2
 pv:
   storage: 400M
   name: pgset-pv

--- a/examples/helm/template-small/README.md
+++ b/examples/helm/template-small/README.md
@@ -75,10 +75,10 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install basic --name basic \
-  --set Image.tag=centos7-10.3-1.8.2
+  --set Image.tag=centos7-9.6.8-1.8.2
 ```
 
-The above command changes the image tag of the container from the default of `centos7-9.6.8-1.8.2` to `centos7-10.3-1.8.2`.
+The above command changes the image tag of the container from the default of `centos7-10.3-1.8.2` to `centos7-9.6.8-1.8.2`.
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

https://github.com/CrunchyData/crunchy-containers/issues/388
https://github.com/CrunchyData/crunchy-containers/issues/514

**What is the new behavior (if this is a feature change)?**

- Image tags are updated from "centos7-9.6.8-1.8.2" to "centos7-10.3-1.8.2".
- References to the old image tag are updated.
- Fixed the statefulset bug reported by @tomerweisman. Statefulsets are now generated with the name pgset-{x} and it can correctly report which pod is a primary and which is a replica.

**Other information**:
