### PR TITLE
issue #494 remove hardcoded backup string, primary-restore -> restore

### DIFF
--- a/docs/examples.adoc
+++ b/docs/examples.adoc
@@ -630,7 +630,7 @@ data to this new container and then launch PostgreSQL using the original backed-
 
 The restore script will do the following:
 
-* Start up a container named *primary-restore*
+* Start up a container named *restore*
 * Copy the backup files from the previous backup example into `/pgdata`
 * Start up the container using the backup files
 * Map the PostgreSQL port of 5432 in the container to your local host port of 12001
@@ -648,7 +648,7 @@ cd $CCPROOT/examples/docker/backup
 ./run.sh
 ....
 
-*primary-restore*
+*restore*
 
 When you are ready to restore from the backup created, run the following example:
 ....
@@ -675,25 +675,26 @@ You should find the backup archive in this location:
 ls $CCP_STORAGE_PATH/primary-backups
 ....
 
-*primary-restore*
+*restore*
 
-When ready to restore, you will need the timestamped directory path under
-`$CCP_STORAGE_PATH/primary-backups` in order to locate the backup to use. Edit the `primary-restore.json`
-file and update the `BACKUP_PATH` setting to specify the backup path you want to restore with.
+By default, the example will automatically restore from the most recent backup
+created by the backup example, located under `$CCP_STORAGE_PATH/$BACKUP_HOST-backups`.
+If you want to restore to a specific backup, edit the `restore.json` file and update the
+`BACKUP_PATH` setting to specify the backup path you want to restore with. For example:
 ....
 "name": "BACKUP_PATH",
-"value": "primary-backups/2016-05-27-14-35-33"
+"value": "primary-backups/2018-03-27-14-35-33"
 ....
 
 Running the example:
 ....
-cd $CCPROOT/examples/kube/primary-restore
+cd $CCPROOT/examples/kube/restore
 ./run.sh
 ....
 
 Test the restored database as follows:
 ....
-psql -h primary-restore -U postgres postgres
+psql -h restore -U postgres postgres
 ....
 
 === pgbackrest
@@ -1897,13 +1898,22 @@ To shutdown the instance and remove the container for each example, run the foll
 
 ==== Docker
 
-Run the backup with this command:
+Run the restore with this command:
 ....
 cd $CCPROOT/examples/docker/pgrestore
 ./run.sh
 ....
 
 ==== Kubernetes and OpenShift
+
+By default, the example will automatically restore from the most recent backup
+created by the backup example, located under `$CCP_STORAGE_PATH/$PGDUMP_HOST-dumps`.
+If you want to restore to a specific backup, edit the `pgrestore.json` file and update the
+`PGRESTORE_VOLUMEPATH` setting to specify the backup path you want to restore with. For example:
+....
+"name":"PGRESTORE_VOLUMEPATH",
+"value":"/pgdata/primary-dumps/2018-03-27-14-35-33"
+....
 
 Running the example:
 ....

--- a/examples/kube/pgrestore/pgrestore.json
+++ b/examples/kube/pgrestore/pgrestore.json
@@ -76,7 +76,7 @@
                        },
                        {
                           "name":"PGRESTORE_VOLUMEPATH",
-                          "value":"/pgdata/primary-dumps/2018-03-09-16-35-27"
+                          "value":"/pgdata/$PGDUMP_HOST-dumps/$PGDUMP_PATH"
                        },
                        {
                           "name":"PGRESTORE_FILE",

--- a/examples/kube/pgrestore/run.sh
+++ b/examples/kube/pgrestore/run.sh
@@ -18,4 +18,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
+export PGDUMP_HOST=$($CCP_CLI describe job pgdump | grep PGDUMP_HOST | awk '{print $NF}')
+export PGDUMP_PATH=$(ls -tc "$CCP_STORAGE_PATH/$PGDUMP_HOST-dumps/" | head -n1)
+
 expenv -f $DIR/pgrestore.json | ${CCP_CLI?} create -f -

--- a/examples/kube/restore/cleanup.sh
+++ b/examples/kube/restore/cleanup.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-${CCP_CLI?} delete pod primary-restore
-${CCP_CLI?} delete service primary-restore
-${CCP_CLI?} delete pvc primary-restore-backup
-$CCPROOT/examples/waitforterm.sh primary-restore ${CCP_CLI?}
+${CCP_CLI?} delete pod restore
+${CCP_CLI?} delete service restore
+${CCP_CLI?} delete pvc restore-backup
+$CCPROOT/examples/waitforterm.sh restore ${CCP_CLI?}

--- a/examples/kube/restore/restore.json
+++ b/examples/kube/restore/restore.json
@@ -2,7 +2,7 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "primary-restore-backup"
+        "name": "restore-backup"
     },
     "spec": {
         "accessModes": [
@@ -20,9 +20,9 @@
     "kind": "Service",
     "apiVersion": "v1",
     "metadata": {
-        "name": "primary-restore",
+        "name": "restore",
         "labels": {
-            "name": "primary-restore"
+            "name": "restore"
         }
     },
     "spec": {
@@ -33,7 +33,7 @@
             "nodePort": 0
         }],
         "selector": {
-            "name": "primary-restore"
+            "name": "restore"
         },
         "type": "ClusterIP",
         "sessionAffinity": "None"
@@ -44,9 +44,9 @@
     "kind": "Pod",
     "apiVersion": "v1",
     "metadata": {
-        "name": "primary-restore",
+        "name": "restore",
         "labels": {
-            "name": "primary-restore"
+            "name": "restore"
         }
     },
     "spec": {
@@ -71,7 +71,7 @@
                 "value": "primary"
             }, {
                 "name": "BACKUP_PATH",
-                "value": "primary-backups/2018-03-02-18-55-49"
+                "value": "$BACKUP_HOST-backups/$BACKUP_PATH"
             }, {
                 "name": "PG_PRIMARY_PASSWORD",
                 "value": "password"
@@ -104,7 +104,7 @@
         }, {
             "name": "backup",
             "persistentVolumeClaim": {
-                "claimName": "primary-restore-backup"
+                "claimName": "restore-backup"
             }
 
         }]

--- a/examples/kube/restore/run.sh
+++ b/examples/kube/restore/run.sh
@@ -18,4 +18,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-expenv -f $DIR/primary-restore.json | ${CCP_CLI?} create -f -
+export BACKUP_HOST=$($CCP_CLI describe job backup | grep BACKUP_HOST | awk '{print $NF}')
+export BACKUP_PATH=$(ls -tc "$CCP_STORAGE_PATH/$BACKUP_HOST-backups/" | head -n1)
+
+expenv -f $DIR/restore.json | ${CCP_CLI?} create -f -


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)



**What is the current behavior? (link to any open issues here)**

https://github.com/CrunchyData/crunchy-containers/issues/494

**What is the new behavior (if this is a feature change)?**

- Changed primary-restore example to be consistent with the "backup" naming and the Docker example name of "restore" - this applies to filenames and resource names
- Removed hardcoded backup path from pgrestore
- Removed hardcoded backup path from restore
- Updated documentation relating to this change
- Tested both examples and ensured they pull the latest backup when repeatedly running the examples