### PR TITLE
Update rhel references

### DIFF
--- a/rhel7/10/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/10/Dockerfile.backrest-restore.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/10/Dockerfile.backup.rhel7
+++ b/rhel7/10/Dockerfile.backup.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/10/Dockerfile.collect.rhel7
+++ b/rhel7/10/Dockerfile.collect.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/10/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/10/Dockerfile.pgadmin4.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/10/Dockerfile.pgbadger.rhel7
+++ b/rhel7/10/Dockerfile.pgbadger.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/10/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/10/Dockerfile.pgbouncer.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/10/Dockerfile.pgdump.rhel7
+++ b/rhel7/10/Dockerfile.pgdump.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/10/Dockerfile.pgpool.rhel7
+++ b/rhel7/10/Dockerfile.pgpool.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/10/Dockerfile.pgrestore.rhel7
+++ b/rhel7/10/Dockerfile.pgrestore.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/10/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/10/Dockerfile.postgres-gis.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/10/Dockerfile.postgres.rhel7
+++ b/rhel7/10/Dockerfile.postgres.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/10/Dockerfile.upgrade.rhel7
+++ b/rhel7/10/Dockerfile.upgrade.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.5/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.5/Dockerfile.backrest-restore.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.5/Dockerfile.backup.rhel7
+++ b/rhel7/9.5/Dockerfile.backup.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.5/Dockerfile.collect.rhel7
+++ b/rhel7/9.5/Dockerfile.collect.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.5/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/9.5/Dockerfile.pgadmin4.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.5/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbadger.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.5/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbouncer.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.5/Dockerfile.pgdump.rhel7
+++ b/rhel7/9.5/Dockerfile.pgdump.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.5/Dockerfile.pgpool.rhel7
+++ b/rhel7/9.5/Dockerfile.pgpool.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.5/Dockerfile.pgrestore.rhel7
+++ b/rhel7/9.5/Dockerfile.pgrestore.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.5/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres-gis.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.5/Dockerfile.postgres.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.6/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.6/Dockerfile.backrest-restore.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.6/Dockerfile.backup.rhel7
+++ b/rhel7/9.6/Dockerfile.backup.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.6/Dockerfile.collect.rhel7
+++ b/rhel7/9.6/Dockerfile.collect.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.6/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/9.6/Dockerfile.pgadmin4.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.6/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbadger.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.6/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbouncer.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.6/Dockerfile.pgdump.rhel7
+++ b/rhel7/9.6/Dockerfile.pgdump.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.6/Dockerfile.pgpool.rhel7
+++ b/rhel7/9.6/Dockerfile.pgpool.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.6/Dockerfile.pgrestore.rhel7
+++ b/rhel7/9.6/Dockerfile.pgrestore.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.6/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres-gis.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.6/Dockerfile.postgres.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.6/Dockerfile.upgrade.rhel7
+++ b/rhel7/9.6/Dockerfile.upgrade.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/Dockerfile.dba.rhel7
+++ b/rhel7/Dockerfile.dba.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 MAINTAINER Crunchy Data <support@crunchydata.com>
 
 LABEL name="crunchydata/dba" \

--- a/rhel7/Dockerfile.grafana.rhel7
+++ b/rhel7/Dockerfile.grafana.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/Dockerfile.prometheus.rhel7
+++ b/rhel7/Dockerfile.prometheus.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/Dockerfile.vacuum.rhel7
+++ b/rhel7/Dockerfile.vacuum.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 


### PR DESCRIPTION
It appears that a rhel7.5 base image has become available.
However, if you look at the documentation, Red Hat has modified their base image naming strategy.

The old naming convention image can be found here:
https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/rhel
Unfortunately, this image seems to be capped at 7.4 in favor of a new base image:
https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/rhel7
As you can see, this new image uses 7.5 as a default.

I do not believe this to be a breaking change, as it is a patch to the underlying container packages.