### PR TITLE
Fixes the grouping of separate instances

### DIFF
--- a/examples/ocp-templates/postgis-replicated/postgis-replicated.json
+++ b/examples/ocp-templates/postgis-replicated/postgis-replicated.json
@@ -3,9 +3,7 @@
     "apiVersion": "v1",
     "message": "The following service(s) have been created in your project: ${SERVICE_NAME}.\n\nPG Database: ${PG_DATABASE}\nPG Username: ${PG_USER}\nPG Password: ${PG_PASSWORD}\nPG Primary User: ${PG_PRIMARY_USER}\nPG Primary Password: ${PG_PRIMARY_PASSWORD}",
     "name": "crunchy-postgis-replicated-template",
-    "labels": {
-        "template": "crunchy-postgis-replicated-template"
-    },
+
     "metadata": {
         "name": "crunchy-postgis-replicated-template",
         "creationTimestamp": null,
@@ -24,11 +22,11 @@
         {
             "apiVersion": "v1",
             "kind": "Secret",
-            "labels": {
-                "app": "${SERVICE_NAME}"
-            },
             "metadata": {
                 "name": "${SERVICE_NAME}",
+                "labels": {
+                    "app": "${SERVICE_NAME}"
+                },
                 "annotations": {
                     "template.openshift.io/expose-db_name": "{.data['PG_DATABASE']}",
                     "template.openshift.io/expose-db_password": "{.data['PG_PASSWORD']}",
@@ -47,10 +45,10 @@
         {
             "kind": "PersistentVolumeClaim",
             "apiVersion": "v1",
-            "labels": {
-                "app": "${SERVICE_NAME}"
-            },
             "metadata": {
+              "labels": {
+                  "app": "${SERVICE_NAME}"
+              },
                 "name": "${PVC_NAME}"
             },
             "spec": {
@@ -67,13 +65,11 @@
         {
             "kind": "Service",
             "apiVersion": "v1",
-            "labels": {
-                "app": "${SERVICE_NAME}"
-            },
             "metadata": {
                 "name": "${SERVICE_NAME}-primary",
                 "labels": {
-                    "name": "${SERVICE_NAME}-primary"
+                    "name": "${SERVICE_NAME}-primary",
+                    "app": "${SERVICE_NAME}"
                 },
                 "annotations": {
                     "template.openshift.io/expose-uri": "postgres://{.spec.clusterIP}:{.spec.ports[?(.name==\"postgresql-primary\")].port}"
@@ -106,7 +102,8 @@
             "metadata": {
                 "name": "${SERVICE_NAME}-replica",
                 "labels": {
-                    "name": "${SERVICE_NAME}-replica"
+                    "name": "${SERVICE_NAME}-replica",
+                    "app": "${SERVICE_NAME}"
                 },
                 "annotations": {
                     "template.openshift.io/expose-uri": "postgres://{.spec.clusterIP}:{.spec.ports[?(.name==\"postgresql-replica\")].port}"
@@ -133,13 +130,11 @@
         {
             "kind": "Pod",
             "apiVersion": "v1",
-            "labels": {
-                "app": "${SERVICE_NAME}"
-            },
             "metadata": {
                 "name": "${SERVICE_NAME}-primary",
                 "labels": {
-                    "name": "${SERVICE_NAME}-primary"
+                    "name": "${SERVICE_NAME}-primary",
+                    "app": "${SERVICE_NAME}"
                 }
             },
             "spec": {
@@ -354,11 +349,9 @@
         {
             "kind": "StatefulSet",
             "apiVersion": "apps/v1beta1",
-            "labels": {
-                "app": "${SERVICE_NAME}"
-            },
             "metadata": {
                 "name": "${SERVICE_NAME}-replica",
+                "app": "${SERVICE_NAME}",
                 "creationTimestamp": null
             },
             "spec": {

--- a/examples/ocp-templates/postgis-replicated/postgis-replicated.json
+++ b/examples/ocp-templates/postgis-replicated/postgis-replicated.json
@@ -24,6 +24,9 @@
         {
             "apiVersion": "v1",
             "kind": "Secret",
+            "labels": {
+                "app": "${SERVICE_NAME}"
+            },
             "metadata": {
                 "name": "${SERVICE_NAME}",
                 "annotations": {
@@ -44,6 +47,9 @@
         {
             "kind": "PersistentVolumeClaim",
             "apiVersion": "v1",
+            "labels": {
+                "app": "${SERVICE_NAME}"
+            },
             "metadata": {
                 "name": "${PVC_NAME}"
             },
@@ -61,6 +67,9 @@
         {
             "kind": "Service",
             "apiVersion": "v1",
+            "labels": {
+                "app": "${SERVICE_NAME}"
+            },
             "metadata": {
                 "name": "${SERVICE_NAME}-primary",
                 "labels": {
@@ -91,6 +100,9 @@
         {
             "kind": "Service",
             "apiVersion": "v1",
+            "labels": {
+                "app": "${SERVICE_NAME}"
+            },
             "metadata": {
                 "name": "${SERVICE_NAME}-replica",
                 "labels": {
@@ -121,6 +133,9 @@
         {
             "kind": "Pod",
             "apiVersion": "v1",
+            "labels": {
+                "app": "${SERVICE_NAME}"
+            },
             "metadata": {
                 "name": "${SERVICE_NAME}-primary",
                 "labels": {
@@ -339,6 +354,9 @@
         {
             "kind": "StatefulSet",
             "apiVersion": "apps/v1beta1",
+            "labels": {
+                "app": "${SERVICE_NAME}"
+            },
             "metadata": {
                 "name": "${SERVICE_NAME}-replica",
                 "creationTimestamp": null

--- a/examples/ocp-templates/postgis-replicated/postgis-replicated.json
+++ b/examples/ocp-templates/postgis-replicated/postgis-replicated.json
@@ -381,7 +381,8 @@
                     "metadata": {
                         "creationTimestamp": null,
                         "labels": {
-                            "name": "${SERVICE_NAME}-replica"
+                            "name": "${SERVICE_NAME}-replica",
+                            "app": "${SERVICE_NAME}"
                         }
                     },
                     "spec": {


### PR DESCRIPTION
Now when they instantiate multiple instances from the same template they are grouped by the service name. 

![screenshot-2018-4-13 openshift web console](https://user-images.githubusercontent.com/1404099/38754664-9a697f1e-3f17-11e8-8d79-c34ce9be6a00.png)


**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ NONE] Have you updated or added documentation for the change, as applicable?
 - [ X] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
