### PR TITLE
Fix hostname in primary example

### DIFF
--- a/examples/docker/pgdump/cleanup.sh
+++ b/examples/docker/pgdump/cleanup.sh
@@ -18,3 +18,4 @@ echo "Cleaning up..."
 docker stop pgdump
 docker rm -v pgdump
 docker volume rm pgdump
+docker network rm pgnet

--- a/examples/docker/pgdump/run.sh
+++ b/examples/docker/pgdump/run.sh
@@ -16,9 +16,11 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 $DIR/cleanup.sh
 
+docker network create --driver bridge pgnet
+
 docker run \
     -v backups:/pgdata \
-    -e PGDUMP_HOST=pgsql \
+    -e PGDUMP_HOST=primary \
     -e PGDUMP_DB=postgres \
     -e PGDUMP_USER=postgres\
     -e PGDUMP_PASS=password \

--- a/examples/docker/pgrestore/cleanup.sh
+++ b/examples/docker/pgrestore/cleanup.sh
@@ -17,3 +17,4 @@ echo "Cleaning up..."
 
 docker stop pgrestore
 docker rm pgrestore
+docker network rm pgnet

--- a/examples/docker/pgrestore/run.sh
+++ b/examples/docker/pgrestore/run.sh
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 $DIR/cleanup.sh
 
+docker network create --driver bridge pgnet
+
 docker run \
     -v backups:/pgdata \
-    -e PGRESTORE_HOST=pgsql \
+    -e PGRESTORE_HOST=primary \
     -e PGRESTORE_DB=postgres \
     -e PGRESTORE_USER=postgres\
     -e PGRESTORE_PASS=password \

--- a/examples/docker/primary/cleanup.sh
+++ b/examples/docker/primary/cleanup.sh
@@ -21,3 +21,4 @@ VOLUME_NAME=$CONTAINER_NAME-pgdata
 docker stop $CONTAINER_NAME
 docker rm -v $CONTAINER_NAME
 docker volume rm $VOLUME_NAME
+docker network rm pgnet

--- a/examples/docker/primary/run.sh
+++ b/examples/docker/primary/run.sh
@@ -18,9 +18,11 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
+docker network create --driver bridge pgnet
+
 docker run \
     -p 5432:5432 \
-    -v pgsql:/pgdata \
+    -v primary-pgdata:/pgdata \
     -e PG_MODE=primary \
     -e PG_USER=testuser \
     -e PG_PASSWORD=password \
@@ -29,7 +31,7 @@ docker run \
     -e PG_PRIMARY_PORT=5432 \
     -e PG_PRIMARY_PASSWORD=password \
     -e PG_ROOT_PASSWORD=password \
-    --name=pgsql \
-    --hostname=pgsql \
+    --name=primary \
+    --hostname=primary \
     --network=pgnet \
     -d $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

#598 

Hostname was incorrect in cleanup script, causing a failure in the run script for the `primary` example.

**What is the new behavior (if this is a feature change)?**

Correct hostname is used and `pgdump`/`pgrestore` have been updated to reflect this change.
