### PR TITLE
Fix bad test about non existence of directory

### DIFF
--- a/bin/common/common_lib.sh
+++ b/bin/common/common_lib.sh
@@ -60,7 +60,7 @@ function env_check_info() {
 }
 
 function dir_check_err() {
-    if [[ -d ${!1} ]]
+    if [[ ! -d ${!1} ]]
     then
         echo_err "The $1 directory does not exist and is required."
         exit 1


### PR DESCRIPTION
The test about the non existence of a directory is invert.
Command like:
```bash
pgo upgrade mycluster --upgrade-type=major --ccp-image-tag=centos7-10.4-1.8.3
```
can't work without this fix.