### PR TITLE
Add pgbouncer variable to postgres doc

### DIFF
--- a/hugo/content/container-specifications/crunchy-postgres-gis.md
+++ b/hugo/content/container-specifications/crunchy-postgres-gis.md
@@ -54,6 +54,7 @@ The crunchy-postgres-gis Docker image contains the following packages (versions 
 **PG_PRIMARY_HOST**|None|Set this value to specify primary host.  Note: only used when `PG_MODE != primary`
 **PG_REPLICA_HOST**|None|Set this value to specify the replica host label.  Note; used when `PG_MODE` is `set`
 **PGAUDIT_ANALYZE**|None|Set this to enable `pgaudit_analyze`
+**PGBOUNCER_PASSWORD**|None|Set this to enable `pgBouncer` support by creating a special `pgbouncer` user for authentication through the connection pooler.
 **PGDATA_PATH_OVERRIDE**|None|Set this value to override the `/pgdata` directory name.  By default `/pgdata` uses `hostname` of the container.  In some cases it may be required to override this with a custom name (such as in a Statefulset)
 **SHARED_BUFFERS**|128MB|Set this value to configure `shared_buffers` in `postgresql.conf`
 **SYNC_REPLICA**|None|Set this value to specify the names of replicas that should use synchronized replication

--- a/hugo/content/container-specifications/crunchy-postgres.md
+++ b/hugo/content/container-specifications/crunchy-postgres.md
@@ -52,6 +52,7 @@ The crunchy-postgres Docker image contains the following packages (versions vary
 **PG_PRIMARY_HOST**|None|Set this value to specify primary host.  Note: only used when `PG_MODE != primary`
 **PG_REPLICA_HOST**|None|Set this value to specify the replica host label.  Note; used when `PG_MODE` is `set`
 **PGAUDIT_ANALYZE**|None|Set this to enable `pgaudit_analyze`
+**PGBOUNCER_PASSWORD**|None|Set this to enable `pgBouncer` support by creating a special `pgbouncer` user for authentication through the connection pooler.
 **PGDATA_PATH_OVERRIDE**|None|Set this value to override the `/pgdata` directory name.  By default `/pgdata` uses `hostname` of the container.  In some cases it may be required to override this with a custom name (such as in a Statefulset)
 **SHARED_BUFFERS**|128MB|Set this value to configure `shared_buffers` in `postgresql.conf`
 **SYNC_REPLICA**|None|Set this value to specify the names of replicas that should use synchronized replication


### PR DESCRIPTION
Added missing variable for pgBouncer in the PostgreSQL container documentation.