### PR TITLE
fix the cleanup script

### DIFF
--- a/examples/kube/custom-config/cleanup.sh
+++ b/examples/kube/custom-config/cleanup.sh
@@ -19,11 +19,15 @@ echo_info "Cleaning up.."
 ${CCP_CLI?} delete service custom-config
 ${CCP_CLI?} delete pod custom-config
 ${CCP_CLI?} delete pvc custom-config-pgdata
+${CCP_CLI?} delete pvc custom-config-backrestrepo
+${CCP_CLI?} delete pvc custom-config-pgwal
 ${CCP_CLI?} delete configmap custom-config-pgconf
 
 if [[ -z "$CCP_STORAGE_CLASS" ]]
 then
     ${CCP_CLI?} delete pv custom-config-pgdata
+    ${CCP_CLI?} delete pv custom-config-pgwal
+    ${CCP_CLI?} delete pv custom-config-backrestrepo
 fi
 
 $CCPROOT/examples/waitforterm.sh custom-config ${CCP_CLI?}


### PR DESCRIPTION
The custom-config example cleanup script was not properly cleaning up all PV and PVCs created.