### PR TITLE
Update readiness probe

### DIFF
--- a/examples/kube/postgres-gis/postgres-gis.json
+++ b/examples/kube/postgres-gis/postgres-gis.json
@@ -46,6 +46,24 @@
                   "protocol":"TCP"
                }
             ],
+            "readinessProbe": {
+                "exec": {
+                    "command": [
+                        "/opt/cpm/bin/readiness.sh"
+                    ]
+                },
+                "initialDelaySeconds": 40,
+                "timeoutSeconds": 1
+            },
+            "livenessProbe": {
+                "exec": {
+                    "command": [
+                        "/opt/cpm/bin/liveness.sh"
+                    ]
+                },
+                "initialDelaySeconds": 40,
+                "timeoutSeconds": 1
+            },
             "env":[
                {
                   "name":"VOLUME_NAME",


### PR DESCRIPTION
Added a readiness probe to `postgis` example to prevent a race condition with the test harness.