### PR TITLE
Update pgAdmin4 image

### DIFF
--- a/centos7/10/Dockerfile.pgadmin4.centos7
+++ b/centos7/10/Dockerfile.pgadmin4.centos7
@@ -28,7 +28,7 @@ RUN yum -y update && yum -y install epel-release \
     openssl \
     procps-ng \
     mod_wsgi mod_ssl \
- && yum -y install postgresql10-devel postgresql10-server pgadmin4-v2-web \
+ && yum -y install postgresql10-devel postgresql10-server pgadmin4-web \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/9.5/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.5/Dockerfile.pgadmin4.centos7
@@ -28,7 +28,7 @@ RUN yum -y update && yum -y install epel-release \
         openssl \
         procps-ng \
         mod_wsgi mod_ssl \
- && yum -y install postgresql95-devel postgresql95-server pgadmin4-v2-web \
+ && yum -y install postgresql95-devel postgresql95-server pgadmin4-web \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/9.6/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.6/Dockerfile.pgadmin4.centos7
@@ -28,7 +28,7 @@ RUN yum -y update && yum -y install epel-release \
         openssl \
         procps-ng \
         mod_wsgi mod_ssl \
- && yum -y install postgresql96-devel postgresql96-server pgadmin4-v2-web \
+ && yum -y install postgresql96-devel postgresql96-server pgadmin4-web \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/conf/pgadmin4/config_local.py
+++ b/conf/pgadmin4/config_local.py
@@ -50,8 +50,8 @@ APP_ICON = 'pg-icon'
 #
 
 # Application version number components
-APP_RELEASE = 2
-APP_REVISION = 1
+APP_RELEASE = 3
+APP_REVISION = 0
 
 # Application version suffix, e.g. 'beta1', 'dev'. Usually an empty string
 # for GA releases.
@@ -60,7 +60,7 @@ APP_SUFFIX = ''
 # Numeric application version for upgrade checks. Should be in the format:
 # [X]XYYZZ, where X is the release version, Y is the revision, with a leading
 # zero if needed, and Z represents the suffix, with a leading zero if needed
-APP_VERSION_INT = 20005
+APP_VERSION_INT = 30000
 
 # DO NOT CHANGE!
 # The application version string, constructed from the components
@@ -272,7 +272,9 @@ MAIL_DEBUG = False
 
 # Flask-Security overrides Flask-Mail's MAIL_DEFAULT_SENDER setting, so
 # that should be set as such:
-SECURITY_EMAIL_SENDER = 'no-reply@localhost'
+SECURITY_SEND_REGISTER_EMAIL = False
+SECURITY_SEND_PASSWORD_CHANGE_EMAIL = False
+SECURITY_SEND_PASSWORD_RESET_NOTICE_EMAIL = False
 
 ##########################################################################
 # Mail content settings

--- a/rhel7/10/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/10/Dockerfile.pgadmin4.rhel7
@@ -44,7 +44,7 @@ RUN yum -y update \
     openssl \
     procps-ng \
     mod_wsgi mod_ssl \
- && yum --enablerepo rhel-7-server-extras-rpms -y install pgadmin4-v2-web \
+ && yum --enablerepo rhel-7-server-extras-rpms -y install pgadmin4-web \
  && yum -y install postgresql10-devel postgresql10-server \
  && yum -y clean all
 

--- a/rhel7/9.5/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/9.5/Dockerfile.pgadmin4.rhel7
@@ -44,7 +44,7 @@ RUN yum -y update \
 	openssl \
 	procps-ng \
 	mod_wsgi mod_ssl \
- && yum --enablerepo rhel-7-server-extras-rpms -y install pgadmin4-v2-web \
+ && yum --enablerepo rhel-7-server-extras-rpms -y install pgadmin4-web \
  && yum -y install postgresql95-devel postgresql95-server \
  && yum -y clean all
 

--- a/rhel7/9.6/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/9.6/Dockerfile.pgadmin4.rhel7
@@ -43,7 +43,7 @@ RUN yum -y update \
 	openssl \
 	procps-ng \
 	mod_wsgi mod_ssl \
- && yum --enablerepo rhel-7-server-extras-rpms -y install pgadmin4-v2-web \
+ && yum --enablerepo rhel-7-server-extras-rpms -y install pgadmin4-web \
  && yum -y install postgresql96-devel postgresql96-server \
  && yum -y clean all
 

--- a/tools/test-harness/pgadmin4_http_test.go
+++ b/tools/test-harness/pgadmin4_http_test.go
@@ -11,11 +11,7 @@ func TestPGAdminHTTP(t *testing.T) {
 
 	harness := setup(t, timeout, true)
 
-	// This example does not have the latest image, so we
-	// inject the last image published
-	env := []string{
-		"CCP_IMAGE_TAG=$CCP_BASEOS-10.3-1.8.2",
-	}
+	env := []string{}
 	_, err := harness.runExample("examples/kube/pgadmin4-http/run.sh", env, t)
 	if err != nil {
 		t.Fatalf("Could not run example: %s", err)

--- a/tools/test-harness/pgadmin4_https_test.go
+++ b/tools/test-harness/pgadmin4_https_test.go
@@ -10,9 +10,7 @@ func TestPGAdminHTTPS(t *testing.T) {
 	t.Log("Testing the 'pgadmin4-http' example...")
 
 	harness := setup(t, timeout, true)
-	env := []string{
-		"CCP_IMAGE_TAG=$CCP_BASEOS-10.3-1.8.2",
-	}
+	env := []string{}
 	_, err := harness.runExample("examples/kube/pgadmin4-https/run.sh", env, t)
 	if err != nil {
 		t.Fatalf("Could not run example: %s", err)


### PR DESCRIPTION
This updates the pgAdmin4 image for the newest versions of pgAdmin4 (change in package names in pgdg broke centos builds).  #631 also addressed in this patch.