### PR TITLE
Add length check for pods in statefulset

### DIFF
--- a/tools/test-harness/backrest_restore_test.go
+++ b/tools/test-harness/backrest_restore_test.go
@@ -28,7 +28,11 @@ func TestBackrestDeltaRestore(t *testing.T) {
 	}
 
 	t.Log("Running full backup...")
-	cmd := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
+	// Required for OCP - backrest gets confused when random UIDs aren't found in PAM.
+	// Exec doesn't load bashrc or bash_profile, so we need to set this explicitly.
+	nsswrapper := []string{"env", "LD_PRELOAD=/usr/lib64/libnss_wrapper.so", "NSS_WRAPPER_PASSWD=/tmp/passwd", "NSS_WRAPPER_GROUP=/tmp/group"}
+	fullBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
+	cmd := append(nsswrapper, fullBackup...)
 	_, stderr, err := harness.Client.Exec(harness.Namespace, "backrest", "backrest", cmd)
 	if err != nil {
 		t.Logf("\n%s", stderr)

--- a/tools/test-harness/backrest_test.go
+++ b/tools/test-harness/backrest_test.go
@@ -25,7 +25,11 @@ func TestBackrest(t *testing.T) {
 	}
 
 	t.Log("Running full backup...")
-	cmd := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
+	// Required for OCP - backrest gets confused when random UIDs aren't found in PAM.
+	// Exec doesn't load bashrc or bash_profile, so we need to set this explicitly.
+	nsswrapper := []string{"env", "LD_PRELOAD=/usr/lib64/libnss_wrapper.so", "NSS_WRAPPER_PASSWD=/tmp/passwd", "NSS_WRAPPER_GROUP=/tmp/group"}
+	fullBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
+	cmd := append(nsswrapper, fullBackup...)
 	_, stderr, err := harness.Client.Exec(harness.Namespace, "backrest", "backrest", cmd)
 	if err != nil {
 		t.Logf("\n%s", stderr)
@@ -33,7 +37,8 @@ func TestBackrest(t *testing.T) {
 	}
 
 	t.Log("Running diff backup...")
-	cmd = []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=diff"}
+	diffBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
+	cmd = append(nsswrapper, diffBackup...)
 	_, stderr, err = harness.Client.Exec(harness.Namespace, "backrest", "backrest", cmd)
 	if err != nil {
 		t.Logf("\n%s", stderr)

--- a/tools/test-harness/setup_test.go
+++ b/tools/test-harness/setup_test.go
@@ -27,7 +27,7 @@ func setup(t *testing.T, timeout time.Duration, cleanup bool) *harness {
 	t.Log("Running Initialization Checks...")
 	envs := []string{
 		"CCPROOT", "CCP_BASEOS", "CCP_PGVERSION",
-		"CCP_IMAGE_PREFIX", "CCP_IMAGE_TAG", "CCP_STORAGE_CLASS",
+		"CCP_IMAGE_PREFIX", "CCP_IMAGE_TAG",
 		"CCP_STORAGE_MODE", "CCP_STORAGE_CAPACITY", "CCP_CLI"}
 	if err := runner.GetEnv(envs); err != nil {
 		t.Fatal(err)

--- a/tools/test-harness/statefulset_test.go
+++ b/tools/test-harness/statefulset_test.go
@@ -33,6 +33,10 @@ func TestStatefulSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
+    if len(pods) == 0 {
+        t.Fatal("No pods found in stateful set")
+    }
+
 	t.Log("Checking if pods are ready to use...")
 	if err := harness.Client.CheckPods(harness.Namespace, pods); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Fixing a small bug where statefulset may not have returned any pods causing the harness to crash.