### PR TITLE
Fix backup cleanup script, add backrest fix

### DIFF
--- a/examples/kube/backup/cleanup.sh
+++ b/examples/kube/backup/cleanup.sh
@@ -17,7 +17,6 @@ echo_info "Cleaning up.."
 
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job backup
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc backup-pgdata
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc primary-pgdata
 if [ -z "$CCP_STORAGE_CLASS" ]; then
   ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv backup-pgdata
 fi

--- a/tools/test-harness/custom_config_test.go
+++ b/tools/test-harness/custom_config_test.go
@@ -26,7 +26,11 @@ func TestCustomConfig(t *testing.T) {
 	}
 
 	t.Log("Running full backup...")
-	cmd := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
+	// Required for OCP - backrest gets confused when random UIDs aren't found in PAM.
+	// Exec doesn't load bashrc or bash_profile, so we need to set this explicitly.
+	nsswrapper := []string{"env", "LD_PRELOAD=/usr/lib64/libnss_wrapper.so", "NSS_WRAPPER_PASSWD=/tmp/passwd", "NSS_WRAPPER_GROUP=/tmp/group"}
+	fullBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
+	cmd := append(nsswrapper, fullBackup...)
 	_, stderr, err := harness.Client.Exec(harness.Namespace, "custom-config", "postgres", cmd)
 	if err != nil {
 		t.Logf("\n%s", stderr)


### PR DESCRIPTION
Backup `cleanup.sh` script deletes the pgdata volume, which causes a failure during the backup.

Missed a backrest backup in `custom_config_test.go` earlier - added that.