### PR TITLE
Fix replication query on 9.5

### DIFF
--- a/tools/test-harness/data/replication.go
+++ b/tools/test-harness/data/replication.go
@@ -9,16 +9,13 @@ import (
 type Replication struct {
 	Name      string
 	State     string
-	SentLSN   string
-	WriteLSN  string
-	ReplayLSN string
 	SyncState string
 }
 
 // Replication returns the state of replicas from the primary.
 func (db *DB) Replication() ([]Replication, error) {
-	statement := "SELECT application_name, state, sent_lsn, " +
-		"write_lsn, replay_lsn, sync_state FROM pg_catalog.pg_stat_replication"
+	statement := "SELECT application_name, state, " +
+		"sync_state FROM pg_catalog.pg_stat_replication"
 
 	rows, err := db.Query(statement)
 	if err != nil {
@@ -28,16 +25,13 @@ func (db *DB) Replication() ([]Replication, error) {
 
 	replication := []Replication{}
 	for rows.Next() {
-		var name, state, sent, write, replay, syncState sql.NullString
-		if err := rows.Scan(&name, &state, &sent, &write, &replay, &syncState); err != nil {
+		var name, state, syncState sql.NullString
+		if err := rows.Scan(&name, &state, &syncState); err != nil {
 			return nil, err
 		}
 		r := Replication{
 			Name:      name.String,
 			State:     state.String,
-			SentLSN:   sent.String,
-			WriteLSN:  write.String,
-			ReplayLSN: replay.String,
 			SyncState: syncState.String,
 		}
 		replication = append(replication, r)


### PR DESCRIPTION
Replication methods were causing errors on 9.5 due to columns not existing in that version.  I've removed them because they aren't currently being used in any way - we can add support for this later.