### PR TITLE
Add GCP support and cleanup script

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -7,6 +7,11 @@
 	],
 	"Deps": [
 		{
+			"ImportPath": "cloud.google.com/go/compute/metadata",
+			"Comment": "v0.25.0-10-g24ff62b",
+			"Rev": "24ff62bdf36b8c3c10021d8ffb46ef6f2d82da9c"
+		},
+		{
 			"ImportPath": "github.com/Azure/go-ansiterm",
 			"Rev": "d6e3b3328b783f23731bc4d058875b0371ff8109"
 		},
@@ -22,6 +27,14 @@
 		{
 			"ImportPath": "github.com/Nvveen/Gotty",
 			"Rev": "cd527374f1e5bff4938207604a14f2e38a9cf512"
+		},
+		{
+			"ImportPath": "github.com/PuerkitoBio/purell",
+			"Rev": "8a290539e2e8629dbc4e6bad948158f790ec31f4"
+		},
+		{
+			"ImportPath": "github.com/PuerkitoBio/urlesc",
+			"Rev": "5bd2802263f21d8788851d5305584c82a5c75d7e"
 		},
 		{
 			"ImportPath": "github.com/cenkalti/backoff",
@@ -168,6 +181,22 @@
 			"Rev": "47565b4f722fb6ceae66b95f853feed578a4a51c"
 		},
 		{
+			"ImportPath": "github.com/docker/spdystream",
+			"Rev": "bc6354cbbc295e925e4c611ffe90c1f287ee54db"
+		},
+		{
+			"ImportPath": "github.com/docker/spdystream/spdy",
+			"Rev": "bc6354cbbc295e925e4c611ffe90c1f287ee54db"
+		},
+		{
+			"ImportPath": "github.com/emicklei/go-restful",
+			"Rev": "ff4f55a206334ef123e4f79bbf348980da81ca46"
+		},
+		{
+			"ImportPath": "github.com/emicklei/go-restful/log",
+			"Rev": "ff4f55a206334ef123e4f79bbf348980da81ca46"
+		},
+		{
 			"ImportPath": "github.com/fsnotify/fsnotify",
 			"Comment": "v1.4.2-6-g4da3e2c",
 			"Rev": "4da3e2cfbabc9f751898f250b49f2439785783a1"
@@ -178,9 +207,89 @@
 			"Rev": "ad1213cc21543085ce0c97f4291994e02b95e459"
 		},
 		{
+			"ImportPath": "github.com/ghodss/yaml",
+			"Rev": "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
+		},
+		{
+			"ImportPath": "github.com/go-openapi/jsonpointer",
+			"Rev": "46af16f9f7b149af66e5d1bd010e3574dc06de98"
+		},
+		{
+			"ImportPath": "github.com/go-openapi/jsonreference",
+			"Rev": "13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272"
+		},
+		{
+			"ImportPath": "github.com/go-openapi/spec",
+			"Rev": "7abd5745472fff5eb3685386d5fb8bf38683154d"
+		},
+		{
+			"ImportPath": "github.com/go-openapi/swag",
+			"Rev": "f3f9494671f93fcff853e3c6e9e948b3eb71e590"
+		},
+		{
 			"ImportPath": "github.com/gogo/protobuf/proto",
 			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
+		},
+		{
+			"ImportPath": "github.com/gogo/protobuf/sortkeys",
+			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
+		},
+		{
+			"ImportPath": "github.com/golang/glog",
+			"Rev": "44145f04b68cf362d9c4df2182967c2275eaefed"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/proto",
+			"Rev": "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/ptypes",
+			"Rev": "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/ptypes/any",
+			"Rev": "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/ptypes/duration",
+			"Rev": "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/ptypes/timestamp",
+			"Rev": "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
+		},
+		{
+			"ImportPath": "github.com/google/btree",
+			"Rev": "7d79101e329e5a3adf994758c578dab82b90c017"
+		},
+		{
+			"ImportPath": "github.com/google/gofuzz",
+			"Rev": "44d81051d367757e1c7c6a5a86423ece9afcf63c"
+		},
+		{
+			"ImportPath": "github.com/googleapis/gnostic/OpenAPIv2",
+			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
+		},
+		{
+			"ImportPath": "github.com/googleapis/gnostic/compiler",
+			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
+		},
+		{
+			"ImportPath": "github.com/googleapis/gnostic/extensions",
+			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
+		},
+		{
+			"ImportPath": "github.com/gorilla/mux",
+			"Rev": "53c1911da2b537f792e7cafcb446b05ffe33b996"
+		},
+		{
+			"ImportPath": "github.com/gregjones/httpcache",
+			"Rev": "787624de3eb7bd915c329cba748687a3b22666a6"
+		},
+		{
+			"ImportPath": "github.com/gregjones/httpcache/diskcache",
+			"Rev": "787624de3eb7bd915c329cba748687a3b22666a6"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/hcl",
@@ -219,9 +328,25 @@
 			"Rev": "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 		},
 		{
+			"ImportPath": "github.com/howeyc/gopass",
+			"Rev": "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
+		},
+		{
+			"ImportPath": "github.com/imdario/mergo",
+			"Rev": "6633656539c1639d9d78127b7d47c622b5d7b6dc"
+		},
+		{
 			"ImportPath": "github.com/inconshreveable/mousetrap",
 			"Comment": "v1.0",
 			"Rev": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+		},
+		{
+			"ImportPath": "github.com/json-iterator/go",
+			"Rev": "36b14963da70d11297d313183d7e6388c8510e1e"
+		},
+		{
+			"ImportPath": "github.com/juju/ratelimit",
+			"Rev": "5b9ff866471762aa2ab2dced63c9fb6f53921342"
 		},
 		{
 			"ImportPath": "github.com/lib/pq",
@@ -237,6 +362,18 @@
 			"ImportPath": "github.com/magiconair/properties",
 			"Comment": "v1.7.3-4-g8d7837e",
 			"Rev": "8d7837e64d3c1ee4e54a880c5a920ab4316fc90a"
+		},
+		{
+			"ImportPath": "github.com/mailru/easyjson/buffer",
+			"Rev": "2f5df55504ebc322e4d52d34df6a1f5b503bf26d"
+		},
+		{
+			"ImportPath": "github.com/mailru/easyjson/jlexer",
+			"Rev": "2f5df55504ebc322e4d52d34df6a1f5b503bf26d"
+		},
+		{
+			"ImportPath": "github.com/mailru/easyjson/jwriter",
+			"Rev": "2f5df55504ebc322e4d52d34df6a1f5b503bf26d"
 		},
 		{
 			"ImportPath": "github.com/mitchellh/mapstructure",
@@ -273,6 +410,10 @@
 			"Rev": "2009e44b6f182e34d8ce081ac2767622937ea3d4"
 		},
 		{
+			"ImportPath": "github.com/peterbourgon/diskv",
+			"Rev": "5f041e8faa004a95c88a202771f4cc3e991971e6"
+		},
+		{
 			"ImportPath": "github.com/pkg/errors",
 			"Comment": "v0.8.0-12-g816c908",
 			"Rev": "816c9085562cd7ee03e7f8188a1cfd942858cded"
@@ -301,6 +442,10 @@
 			"Rev": "acbeb36b902d72a7a4c18e8f3241075e7ab763e4"
 		},
 		{
+			"ImportPath": "github.com/spf13/cobra",
+			"Rev": "f62e98d28ab7ad31d707ba837a966378465c7b57"
+		},
+		{
 			"ImportPath": "github.com/spf13/jwalterweatherman",
 			"Rev": "12bd96e66386c1960ab0f74ced1362f66f552f7b"
 		},
@@ -314,397 +459,20 @@
 			"Rev": "d9cca5ef33035202efb1586825bdbb15ff9ec3ba"
 		},
 		{
-			"ImportPath": "golang.org/x/crypto/ssh/terminal",
+			"ImportPath": "golang.org/x/crypto/curve25519",
 			"Rev": "81e90905daefcd6fd217b62423c0908922eadb30"
 		},
 		{
-			"ImportPath": "golang.org/x/net/context",
-			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
+			"ImportPath": "golang.org/x/crypto/ed25519",
+			"Rev": "81e90905daefcd6fd217b62423c0908922eadb30"
 		},
 		{
-			"ImportPath": "golang.org/x/sys/unix",
-			"Rev": "95c6576299259db960f6c5b9b69ea52422860fce"
+			"ImportPath": "golang.org/x/crypto/ed25519/internal/edwards25519",
+			"Rev": "81e90905daefcd6fd217b62423c0908922eadb30"
 		},
 		{
-			"ImportPath": "golang.org/x/sys/windows",
-			"Rev": "95c6576299259db960f6c5b9b69ea52422860fce"
-		},
-		{
-			"ImportPath": "golang.org/x/text/transform",
-			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
-		},
-		{
-			"ImportPath": "golang.org/x/text/unicode/norm",
-			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
-		},
-		{
-			"ImportPath": "gopkg.in/ory-am/dockertest.v3",
-			"Comment": "v3.1.6",
-			"Rev": "15c8e8835bba04e0d7c2b57958ffe294d5e643dc"
-		},
-		{
-			"ImportPath": "gopkg.in/yaml.v2",
-			"Rev": "53feefa2559fb8dfa8d81baad31be332c97d6c77"
-		},
-		{
-			"ImportPath": "github.com/docker/spdystream",
-			"Rev": "bc6354cbbc295e925e4c611ffe90c1f287ee54db"
-		},
-		{
-			"ImportPath": "github.com/gorilla/mux",
-			"Rev": "53c1911da2b537f792e7cafcb446b05ffe33b996"
-		},
-		{
-			"ImportPath": "github.com/gorilla/websocket",
-			"Rev": "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
-		},
-		{
-			"ImportPath": "github.com/fatih/color",
-			"Rev": "507f6050b8568533fb3f5504de8e5205fa62a114"
-		},
-		{
-			"ImportPath": "github.com/Sirupsen/logrus",
-			"Rev": "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
-		},
-		{
-			"ImportPath": "bitbucket.org/ww/goautoneg",
-			"Rev": "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
-		},
-		{
-			"ImportPath": "github.com/NYTimes/gziphandler",
-			"Rev": "56545f4a5d46df9a6648819d1664c3a03a13ffdb"
-		},
-		{
-			"ImportPath": "github.com/PuerkitoBio/purell",
-			"Rev": "8a290539e2e8629dbc4e6bad948158f790ec31f4"
-		},
-		{
-			"ImportPath": "github.com/PuerkitoBio/urlesc",
-			"Rev": "5bd2802263f21d8788851d5305584c82a5c75d7e"
-		},
-		{
-			"ImportPath": "github.com/asaskevich/govalidator",
-			"Rev": "593d64559f7600f29581a3ee42177f5dbded27a9"
-		},
-		{
-			"ImportPath": "github.com/beorn7/perks/quantile",
-			"Rev": "3ac7bf7a47d159a033b107610db8a1b6575507a4"
-		},
-		{
-			"ImportPath": "github.com/coreos/etcd/auth/authpb",
-			"Rev": "960f4604bc821241b94906da5fe7f66306a77472"
-		},
-		{
-			"ImportPath": "github.com/coreos/etcd/client",
-			"Rev": "960f4604bc821241b94906da5fe7f66306a77472"
-		},
-		{
-			"ImportPath": "github.com/coreos/etcd/clientv3",
-			"Rev": "960f4604bc821241b94906da5fe7f66306a77472"
-		},
-		{
-			"ImportPath": "github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes",
-			"Rev": "960f4604bc821241b94906da5fe7f66306a77472"
-		},
-		{
-			"ImportPath": "github.com/coreos/etcd/etcdserver/etcdserverpb",
-			"Rev": "960f4604bc821241b94906da5fe7f66306a77472"
-		},
-		{
-			"ImportPath": "github.com/coreos/etcd/mvcc/mvccpb",
-			"Rev": "960f4604bc821241b94906da5fe7f66306a77472"
-		},
-		{
-			"ImportPath": "github.com/coreos/etcd/pkg/fileutil",
-			"Rev": "960f4604bc821241b94906da5fe7f66306a77472"
-		},
-		{
-			"ImportPath": "github.com/coreos/etcd/pkg/pathutil",
-			"Rev": "960f4604bc821241b94906da5fe7f66306a77472"
-		},
-		{
-			"ImportPath": "github.com/coreos/etcd/pkg/tlsutil",
-			"Rev": "960f4604bc821241b94906da5fe7f66306a77472"
-		},
-		{
-			"ImportPath": "github.com/coreos/etcd/pkg/transport",
-			"Rev": "960f4604bc821241b94906da5fe7f66306a77472"
-		},
-		{
-			"ImportPath": "github.com/coreos/etcd/pkg/types",
-			"Rev": "960f4604bc821241b94906da5fe7f66306a77472"
-		},
-		{
-			"ImportPath": "github.com/coreos/go-systemd/daemon",
-			"Rev": "48702e0da86bd25e76cfef347e2adeb434a0d0a6"
-		},
-		{
-			"ImportPath": "github.com/coreos/go-systemd/journal",
-			"Rev": "48702e0da86bd25e76cfef347e2adeb434a0d0a6"
-		},
-		{
-			"ImportPath": "github.com/coreos/pkg/capnslog",
-			"Rev": "fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8"
-		},
-		{
-			"ImportPath": "github.com/davecgh/go-spew/spew",
-			"Rev": "782f4967f2dc4564575ca782fe2d04090b5faca8"
-		},
-		{
-			"ImportPath": "github.com/elazarl/go-bindata-assetfs",
-			"Rev": "3dcc96556217539f50599357fb481ac0dc7439b9"
-		},
-		{
-			"ImportPath": "github.com/emicklei/go-restful",
-			"Rev": "ff4f55a206334ef123e4f79bbf348980da81ca46"
-		},
-		{
-			"ImportPath": "github.com/emicklei/go-restful-swagger12",
-			"Rev": "dcef7f55730566d41eae5db10e7d6981829720f6"
-		},
-		{
-			"ImportPath": "github.com/emicklei/go-restful/log",
-			"Rev": "ff4f55a206334ef123e4f79bbf348980da81ca46"
-		},
-		{
-			"ImportPath": "github.com/evanphx/json-patch",
-			"Rev": "944e07253867aacae43c04b2e6a239005443f33a"
-		},
-		{
-			"ImportPath": "github.com/ghodss/yaml",
-			"Rev": "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
-		},
-		{
-			"ImportPath": "github.com/go-openapi/analysis",
-			"Rev": "b44dc874b601d9e4e2f6e19140e794ba24bead3b"
-		},
-		{
-			"ImportPath": "github.com/go-openapi/errors",
-			"Rev": "d24ebc2075bad502fac3a8ae27aa6dd58e1952dc"
-		},
-		{
-			"ImportPath": "github.com/go-openapi/jsonpointer",
-			"Rev": "46af16f9f7b149af66e5d1bd010e3574dc06de98"
-		},
-		{
-			"ImportPath": "github.com/go-openapi/jsonreference",
-			"Rev": "13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272"
-		},
-		{
-			"ImportPath": "github.com/go-openapi/loads",
-			"Rev": "a80dea3052f00e5f032e860dd7355cd0cc67e24d"
-		},
-		{
-			"ImportPath": "github.com/go-openapi/runtime",
-			"Rev": "11e322eeecc1032d5a0a96c566ed53f2b5c26e22"
-		},
-		{
-			"ImportPath": "github.com/go-openapi/spec",
-			"Rev": "7abd5745472fff5eb3685386d5fb8bf38683154d"
-		},
-		{
-			"ImportPath": "github.com/go-openapi/strfmt",
-			"Rev": "d65c7fdb29eca313476e529628176fe17e58c488"
-		},
-		{
-			"ImportPath": "github.com/go-openapi/swag",
-			"Rev": "f3f9494671f93fcff853e3c6e9e948b3eb71e590"
-		},
-		{
-			"ImportPath": "github.com/go-openapi/validate",
-			"Rev": "deaf2c9013bc1a7f4c774662259a506ba874d80f"
-		},
-		{
-			"ImportPath": "github.com/gogo/protobuf/proto",
-			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
-		},
-		{
-			"ImportPath": "github.com/gogo/protobuf/sortkeys",
-			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
-		},
-		{
-			"ImportPath": "github.com/golang/glog",
-			"Rev": "44145f04b68cf362d9c4df2182967c2275eaefed"
-		},
-		{
-			"ImportPath": "github.com/golang/protobuf/jsonpb",
-			"Rev": "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
-		},
-		{
-			"ImportPath": "github.com/golang/protobuf/proto",
-			"Rev": "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
-		},
-		{
-			"ImportPath": "github.com/golang/protobuf/ptypes",
-			"Rev": "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
-		},
-		{
-			"ImportPath": "github.com/golang/protobuf/ptypes/any",
-			"Rev": "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
-		},
-		{
-			"ImportPath": "github.com/golang/protobuf/ptypes/duration",
-			"Rev": "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
-		},
-		{
-			"ImportPath": "github.com/golang/protobuf/ptypes/struct",
-			"Rev": "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
-		},
-		{
-			"ImportPath": "github.com/golang/protobuf/ptypes/timestamp",
-			"Rev": "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
-		},
-		{
-			"ImportPath": "github.com/google/btree",
-			"Rev": "7d79101e329e5a3adf994758c578dab82b90c017"
-		},
-		{
-			"ImportPath": "github.com/google/gofuzz",
-			"Rev": "44d81051d367757e1c7c6a5a86423ece9afcf63c"
-		},
-		{
-			"ImportPath": "github.com/googleapis/gnostic/OpenAPIv2",
-			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
-		},
-		{
-			"ImportPath": "github.com/googleapis/gnostic/compiler",
-			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
-		},
-		{
-			"ImportPath": "github.com/googleapis/gnostic/extensions",
-			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
-		},
-		{
-			"ImportPath": "github.com/gregjones/httpcache",
-			"Rev": "787624de3eb7bd915c329cba748687a3b22666a6"
-		},
-		{
-			"ImportPath": "github.com/gregjones/httpcache/diskcache",
-			"Rev": "787624de3eb7bd915c329cba748687a3b22666a6"
-		},
-		{
-			"ImportPath": "github.com/grpc-ecosystem/go-grpc-prometheus",
-			"Rev": "2500245aa6110c562d17020fb31a2c133d737799"
-		},
-		{
-			"ImportPath": "github.com/grpc-ecosystem/grpc-gateway/runtime",
-			"Rev": "84398b94e188ee336f307779b57b3aa91af7063c"
-		},
-		{
-			"ImportPath": "github.com/grpc-ecosystem/grpc-gateway/runtime/internal",
-			"Rev": "84398b94e188ee336f307779b57b3aa91af7063c"
-		},
-		{
-			"ImportPath": "github.com/grpc-ecosystem/grpc-gateway/utilities",
-			"Rev": "84398b94e188ee336f307779b57b3aa91af7063c"
-		},
-		{
-			"ImportPath": "github.com/hashicorp/golang-lru",
-			"Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
-		},
-		{
-			"ImportPath": "github.com/hashicorp/golang-lru/simplelru",
-			"Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
-		},
-		{
-			"ImportPath": "github.com/howeyc/gopass",
-			"Rev": "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
-		},
-		{
-			"ImportPath": "github.com/imdario/mergo",
-			"Rev": "6633656539c1639d9d78127b7d47c622b5d7b6dc"
-		},
-		{
-			"ImportPath": "github.com/inconshreveable/mousetrap",
-			"Rev": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
-		},
-		{
-			"ImportPath": "github.com/json-iterator/go",
-			"Rev": "36b14963da70d11297d313183d7e6388c8510e1e"
-		},
-		{
-			"ImportPath": "github.com/juju/ratelimit",
-			"Rev": "5b9ff866471762aa2ab2dced63c9fb6f53921342"
-		},
-		{
-			"ImportPath": "github.com/mailru/easyjson/buffer",
-			"Rev": "2f5df55504ebc322e4d52d34df6a1f5b503bf26d"
-		},
-		{
-			"ImportPath": "github.com/mailru/easyjson/jlexer",
-			"Rev": "2f5df55504ebc322e4d52d34df6a1f5b503bf26d"
-		},
-		{
-			"ImportPath": "github.com/mailru/easyjson/jwriter",
-			"Rev": "2f5df55504ebc322e4d52d34df6a1f5b503bf26d"
-		},
-		{
-			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/pbutil",
-			"Rev": "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a"
-		},
-		{
-			"ImportPath": "github.com/mxk/go-flowrate/flowrate",
-			"Rev": "cca7078d478f8520f85629ad7c68962d31ed7682"
-		},
-		{
-			"ImportPath": "github.com/pborman/uuid",
-			"Rev": "ca53cad383cad2479bbba7f7a1a05797ec1386e4"
-		},
-		{
-			"ImportPath": "github.com/peterbourgon/diskv",
-			"Rev": "5f041e8faa004a95c88a202771f4cc3e991971e6"
-		},
-		{
-			"ImportPath": "github.com/pmezard/go-difflib/difflib",
-			"Rev": "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
-		},
-		{
-			"ImportPath": "github.com/prometheus/client_golang/prometheus",
-			"Rev": "e7e903064f5e9eb5da98208bae10b475d4db0f8c"
-		},
-		{
-			"ImportPath": "github.com/prometheus/client_model/go",
-			"Rev": "fa8ad6fec33561be4280a8f0514318c79d7f6cb6"
-		},
-		{
-			"ImportPath": "github.com/prometheus/common/expfmt",
-			"Rev": "13ba4ddd0caa9c28ca7b7bffe1dfa9ed8d5ef207"
-		},
-		{
-			"ImportPath": "github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg",
-			"Rev": "13ba4ddd0caa9c28ca7b7bffe1dfa9ed8d5ef207"
-		},
-		{
-			"ImportPath": "github.com/prometheus/common/model",
-			"Rev": "13ba4ddd0caa9c28ca7b7bffe1dfa9ed8d5ef207"
-		},
-		{
-			"ImportPath": "github.com/prometheus/procfs",
-			"Rev": "65c1f6f8f0fc1e2185eb9863a3bc751496404259"
-		},
-		{
-			"ImportPath": "github.com/prometheus/procfs/xfs",
-			"Rev": "65c1f6f8f0fc1e2185eb9863a3bc751496404259"
-		},
-		{
-			"ImportPath": "github.com/spf13/cobra",
-			"Rev": "f62e98d28ab7ad31d707ba837a966378465c7b57"
-		},
-		{
-			"ImportPath": "github.com/spf13/pflag",
-			"Rev": "9ff6c6923cfffbcd502984b8e0c80539a94968b7"
-		},
-		{
-			"ImportPath": "github.com/stretchr/testify/assert",
-			"Rev": "f6abca593680b2315d2075e0f5e2a9751e3f431a"
-		},
-		{
-			"ImportPath": "github.com/stretchr/testify/require",
-			"Rev": "f6abca593680b2315d2075e0f5e2a9751e3f431a"
-		},
-		{
-			"ImportPath": "github.com/ugorji/go/codec",
-			"Rev": "ded73eae5db7e7a0ef6f55aace87a2873c5d2b74"
+			"ImportPath": "golang.org/x/crypto/ssh",
+			"Rev": "81e90905daefcd6fd217b62423c0908922eadb30"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/ssh/terminal",
@@ -715,11 +483,7 @@
 			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
 		},
 		{
-			"ImportPath": "golang.org/x/net/html",
-			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
-		},
-		{
-			"ImportPath": "golang.org/x/net/html/atom",
+			"ImportPath": "golang.org/x/net/context/ctxhttp",
 			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
 		},
 		{
@@ -735,20 +499,28 @@
 			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
 		},
 		{
-			"ImportPath": "golang.org/x/net/internal/timeseries",
-			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
-		},
-		{
 			"ImportPath": "golang.org/x/net/lex/httplex",
 			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
 		},
 		{
-			"ImportPath": "golang.org/x/net/trace",
-			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
+			"ImportPath": "golang.org/x/oauth2",
+			"Rev": "ef147856a6ddbb60760db74283d2424e98c87bff"
 		},
 		{
-			"ImportPath": "golang.org/x/net/websocket",
-			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
+			"ImportPath": "golang.org/x/oauth2/google",
+			"Rev": "ef147856a6ddbb60760db74283d2424e98c87bff"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/internal",
+			"Rev": "ef147856a6ddbb60760db74283d2424e98c87bff"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/jws",
+			"Rev": "ef147856a6ddbb60760db74283d2424e98c87bff"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/jwt",
+			"Rev": "ef147856a6ddbb60760db74283d2424e98c87bff"
 		},
 		{
 			"ImportPath": "golang.org/x/sys/unix",
@@ -803,80 +575,17 @@
 			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
 		},
 		{
-			"ImportPath": "google.golang.org/genproto/googleapis/rpc/status",
-			"Rev": "09f6ed296fc66555a25fe4ce95173148778dfa85"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc",
-			"Rev": "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/codes",
-			"Rev": "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/credentials",
-			"Rev": "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/grpclb/grpc_lb_v1",
-			"Rev": "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/grpclog",
-			"Rev": "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/internal",
-			"Rev": "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/keepalive",
-			"Rev": "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/metadata",
-			"Rev": "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/naming",
-			"Rev": "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/peer",
-			"Rev": "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/stats",
-			"Rev": "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/status",
-			"Rev": "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/tap",
-			"Rev": "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/transport",
-			"Rev": "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-		},
-		{
 			"ImportPath": "gopkg.in/inf.v0",
 			"Rev": "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
 		},
 		{
-			"ImportPath": "gopkg.in/natefinch/lumberjack.v2",
-			"Rev": "20b71e5b60d756d3d2f80def009790325acc2b23"
+			"ImportPath": "gopkg.in/ory-am/dockertest.v3",
+			"Comment": "v3.1.6",
+			"Rev": "15c8e8835bba04e0d7c2b57958ffe294d5e643dc"
 		},
 		{
 			"ImportPath": "gopkg.in/yaml.v2",
 			"Rev": "53feefa2559fb8dfa8d81baad31be332c97d6c77"
-		},
-		{
-			"ImportPath": "k8s.io/api/admission/v1beta1",
-			"Rev": "acf347b865f29325eb61f4cd2df11e86e073a5ee"
 		},
 		{
 			"ImportPath": "k8s.io/api/admissionregistration/v1alpha1",
@@ -991,10 +700,6 @@
 			"Rev": "acf347b865f29325eb61f4cd2df11e86e073a5ee"
 		},
 		{
-			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/errors",
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
@@ -1007,55 +712,11 @@
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
 		{
-			"ImportPath": "k8s.io/apimachinery/pkg/api/testing",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/api/testing/fuzzer",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/api/testing/roundtrip",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/api/validation",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/api/validation/path",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/apimachinery",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/apimachinery/announced",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/apimachinery/registered",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/fuzzer",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/internalversion",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/validation",
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
 		{
@@ -1119,15 +780,7 @@
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
 		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/cache",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/clock",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/diff",
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
 		{
@@ -1143,6 +796,11 @@
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/httpstream/spdy",
+			"Comment": "kubernetes-1.9.8-beta.0",
+			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/intstr",
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
@@ -1151,19 +809,12 @@
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
 		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/mergepatch",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
 		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/proxy",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/rand",
+			"ImportPath": "k8s.io/apimachinery/pkg/util/remotecommand",
+			"Comment": "kubernetes-1.9.8-beta.0",
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
 		{
@@ -1172,14 +823,6 @@
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/sets",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/strategicpatch",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/uuid",
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
 		{
@@ -1195,10 +838,6 @@
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
 		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/waitgroup",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/yaml",
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
@@ -1211,10 +850,6 @@
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
 		{
-			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/json",
-			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-		},
-		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/netutil",
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
@@ -1223,515 +858,7 @@
 			"Rev": "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
 		},
 		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/configuration",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/initializer",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/metrics",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/initialization",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/config",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/errors",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/mutating",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/namespace",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/request",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/rules",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/validating",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/versioned",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/apis/apiserver",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/apis/apiserver/install",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/apis/audit",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/install",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/v1alpha1",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/v1beta1",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/validation",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/audit",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/audit/policy",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authentication/authenticator",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authentication/authenticatorfactory",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authentication/group",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/anonymous",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/bearertoken",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/headerrequest",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/union",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/websocket",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/x509",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authentication/serviceaccount",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authentication/token/tokenfile",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authentication/user",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authorization/authorizer",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authorization/authorizerfactory",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/authorization/union",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/endpoints",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/endpoints/discovery",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/endpoints/filters",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/endpoints/handlers",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/endpoints/handlers/negotiation",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/endpoints/handlers/responsewriters",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/endpoints/metrics",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/endpoints/openapi",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/endpoints/request",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/features",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/registry/generic",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/registry/generic/registry",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/registry/rest",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/server",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/server/filters",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/server/healthz",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/server/httplog",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/server/mux",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/server/options",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/server/routes",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/server/routes/data/swagger",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/server/storage",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/storage",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/storage/errors",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd/metrics",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd/util",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd3",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd3/preflight",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/storage/names",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/storage/storagebackend",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/storage/storagebackend/factory",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/storage/value",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/util/feature",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/util/flag",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/util/flushwriter",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/util/logs",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/util/trace",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/util/webhook",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/pkg/util/wsstream",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/log",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/webhook",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/plugin/pkg/authenticator/token/webhook",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
-			"ImportPath": "k8s.io/apiserver/plugin/pkg/authorizer/webhook",
-			"Rev": "af217a9674d2396f0d63139ee604128f41a8f464"
-		},
-		{
 			"ImportPath": "k8s.io/client-go/discovery",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/discovery/fake",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/dynamic",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/admissionregistration",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/admissionregistration/v1alpha1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/admissionregistration/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/apps",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/apps/v1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/apps/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/apps/v1beta2",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/autoscaling",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/autoscaling/v1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/autoscaling/v2beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/batch",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/batch/v1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/batch/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/batch/v2alpha1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/certificates",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/certificates/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/core",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/core/v1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/events",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/events/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/extensions",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/extensions/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/internalinterfaces",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/networking",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/networking/v1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/policy",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/policy/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/rbac",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/rbac/v1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/rbac/v1alpha1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/rbac/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/scheduling",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/scheduling/v1alpha1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/settings",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/settings/v1alpha1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/storage",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/storage/v1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/storage/v1alpha1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/informers/storage/v1beta1",
 			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
 		},
 		{
@@ -1855,103 +982,11 @@
 			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/listers/admissionregistration/v1alpha1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/admissionregistration/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/apps/v1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/apps/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/apps/v1beta2",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/autoscaling/v1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/autoscaling/v2beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/batch/v1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/batch/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/batch/v2alpha1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/certificates/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/core/v1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/events/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/extensions/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/networking/v1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/policy/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/rbac/v1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/rbac/v1alpha1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/rbac/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/scheduling/v1alpha1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/settings/v1alpha1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/storage/v1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/storage/v1alpha1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/listers/storage/v1beta1",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
 			"ImportPath": "k8s.io/client-go/pkg/version",
+			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/plugin/pkg/client/auth/gcp",
 			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
 		},
 		{
@@ -1963,15 +998,12 @@
 			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/testing",
+			"ImportPath": "k8s.io/client-go/third_party/forked/golang/template",
+			"Comment": "kubernetes-1.9.8-beta.0",
 			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/auth",
-			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/tools/cache",
 			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
 		},
 		{
@@ -1995,7 +1027,8 @@
 			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/tools/pager",
+			"ImportPath": "k8s.io/client-go/tools/portforward",
+			"Comment": "kubernetes-1.9.8-beta.0",
 			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
 		},
 		{
@@ -2003,15 +1036,26 @@
 			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
 		},
 		{
+			"ImportPath": "k8s.io/client-go/tools/remotecommand",
+			"Comment": "kubernetes-1.9.8-beta.0",
+			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
+		},
+		{
 			"ImportPath": "k8s.io/client-go/transport",
 			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/util/buffer",
+			"ImportPath": "k8s.io/client-go/transport/spdy",
+			"Comment": "kubernetes-1.9.8-beta.0",
 			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/cert",
+			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/util/exec",
+			"Comment": "kubernetes-1.9.8-beta.0",
 			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
 		},
 		{
@@ -2027,27 +1071,12 @@
 			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/util/workqueue",
+			"ImportPath": "k8s.io/client-go/util/jsonpath",
+			"Comment": "kubernetes-1.9.8-beta.0",
 			"Rev": "90539b4e75a8daaf7f67c3874c6180bfb1a63936"
 		},
 		{
-			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
-		},
-		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
-		},
-		{
-			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
-		},
-		{
-			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
-		},
-		{
-			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
 			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
 		}
 	]

--- a/tools/test-harness/README.md
+++ b/tools/test-harness/README.md
@@ -34,6 +34,12 @@ godep restore ./...
 *Note*: It's recommended to disable the `go test` timeout (it defaults to 10 minutes which 
 is not enough time to run all tests):
 
+#### Go `1.9`
+
+`go test -timeout 100m` (100 minutes)
+
+#### Go `1.10+`
+
 `go test -timeout 0`
 
 ### All Tests
@@ -53,4 +59,14 @@ meaning it won't match on say `TestPrimaryReplica`)
 ```bash
 cd $CCPROOT/tools/test-harness
 go test -v -run TestPrimary$
+```
+
+### Manual Cleanup
+
+If for some reason the test-harness crashes, it's possible the test-harness namespaces 
+have not been cleaned up correctly.  To manually delete the test harness namespaces, 
+run the following script:
+
+```bash
+${CCPROOT?}/tools/test-harness/test-harness-manual-cleanup.sh
 ```

--- a/tools/test-harness/kubeapi/kubeapi.go
+++ b/tools/test-harness/kubeapi/kubeapi.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+    _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 // KubeAPI is the main data structure containing

--- a/tools/test-harness/test-harness-manual-cleanup.sh
+++ b/tools/test-harness/test-harness-manual-cleanup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e -u
+
+function echo_green() {
+    echo -e "\033[0;32m"
+    echo "=> $1"
+    echo -e "\033[0m"
+}
+
+${CCP_CLI?} get namespaces | grep -v NAME | grep 'test-harness' | awk '{print $1}' | while read line
+do
+    echo_green "Deleting namespace ${line?}"
+    ${CCP_CLI?} delete namespace ${line?} --cascade=true
+done
+
+echo_green "=> Done!"
+
+exit 0


### PR DESCRIPTION
Needed to add GCP authentication support to the harness, update deps for this new dependency.

Additionally I added extra documentation for older versions of Golang and a manual cleanup script in case the harness panics.