### PR TITLE
Add redirect follow to pgbadger doc

### DIFF
--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -1898,7 +1898,7 @@ After execution, the container will run and provide a simple HTTP
 command you can browse to view the report.  As you run queries against
 the database, you can invoke this URL to generate updated reports:
 ....
-curl http://127.0.0.1:14000/api/badgergenerate
+curl -L http://127.0.0.1:14000/api/badgergenerate
 ....
 
 ==== Kubernetes and OpenShift
@@ -1913,7 +1913,7 @@ After execution, the container will run and provide a simple HTTP
 command you can browse to view the report.  As you run queries against
 the database, you can invoke this URL to generate updated reports:
 ....
-curl http://badger:10000/api/badgergenerate
+curl -L http://badger:10000/api/badgergenerate
 ....
 
 You can view the database container logs using these commands:


### PR DESCRIPTION
pgBadger container redirects to the generated report, which curl does not follow by default.  This adds the `-L` flag to tell curl to follow redirects.