### PR TITLE
examples clean up data directory on cleanup

### DIFF
--- a/examples/common.sh
+++ b/examples/common.sh
@@ -37,6 +37,20 @@ function env_check_err() {
     fi
 }
 
+function dir_check_rm() {
+    if [[ -d ${CCP_STORAGE_PATH?}/${1?} ]]
+    then
+        rm -rf ${CCP_STORAGE_PATH?}/${1?} && echo_info "Deleted ${1?} from the data directory." || echo_err "${1?} was not successfully deleted from the data directory."
+    fi
+}
+
+function file_check_rm() {
+    if [[ -f ${CCP_STORAGE_PATH?}/${1?} ]]
+    then
+        rm -f ${CCP_STORAGE_PATH?}/${1?} && echo_info "Deleted ${1?} from the data directory." || echo_err "${1?} was not successfully deleted from the data directory."
+    fi
+}
+
 function create_storage {
     env_check_err "CCP_STORAGE_CAPACITY"
     env_check_err "CCP_STORAGE_MODE"

--- a/examples/kube/custom-config-ssl/cleanup.sh
+++ b/examples/kube/custom-config-ssl/cleanup.sh
@@ -22,12 +22,19 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service custom-config-ssl
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod custom-config-ssl
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret custom-config-ssl-secrets
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc custom-config-ssl-pgdata
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc custom-config-ssl-backrestrepo
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv custom-config-ssl-pgdata
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv custom-config-ssl-backrestrepo
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc custom-config-ssl-pgdata custom-config-ssl-backrestrepo
+
+if [[ -z "$CCP_STORAGE_CLASS" ]]
+then
+    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv custom-config-ssl-pgdata custom-config-pgwal custom-config-ssl-backrestrepo
+fi
 
 $CCPROOT/examples/waitforterm.sh custom-config-ssl ${CCP_CLI?}
+
+dir_check_rm "archive"
+dir_check_rm "backup"
+dir_check_rm "custom-config-ssl"
+file_check_rm "db-stanza-create.log"
 
 rm -rf ${DIR?}/certs
 rm -rf ${DIR?}/out

--- a/examples/kube/custom-config/cleanup.sh
+++ b/examples/kube/custom-config/cleanup.sh
@@ -16,12 +16,10 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service custom-config
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod custom-config
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc custom-config-pgdata custom-config-pgwal custom-config-br
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap custom-config-pgconf
-
 
 if [[ -z "$CCP_STORAGE_CLASS" ]]
 then
@@ -29,3 +27,9 @@ then
 fi
 
 $CCPROOT/examples/waitforterm.sh custom-config ${CCP_CLI?}
+
+dir_check_rm "archive"
+dir_check_rm "backup"
+dir_check_rm "custom-config"
+dir_check_rm "custom-config-wal"
+file_check_rm "db-stanza-create.log"

--- a/examples/kube/metrics/cleanup.sh
+++ b/examples/kube/metrics/cleanup.sh
@@ -24,11 +24,17 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod pgsql
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service metrics
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service pgsql
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc metrics-prometheusdata
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc metrics-grafanadata
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc metrics-prometheusdata metrics-grafanadata
+
 if [ -z "$CCP_STORAGE_CLASS" ]; then
   ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv metrics-prometheusdata metrics-grafanadata
 fi
 
 $CCPROOT/examples/waitforterm.sh metrics ${CCP_CLI?}
 $CCPROOT/examples/waitforterm.sh pgsql ${CCP_CLI?}
+
+dir_check_rm "grafana"
+dir_check_rm "wal"
+file_check_rm "defaults.ini"
+file_check_rm "lock"
+file_check_rm "prometheus.yml"

--- a/examples/kube/pgadmin4-http/cleanup.sh
+++ b/examples/kube/pgadmin4-http/cleanup.sh
@@ -19,8 +19,18 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service pgadmin4-http
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod pgadmin4-http
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pgadmin4-http-secrets
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc pgadmin4-http-data
+
 if [ -z "$CCP_STORAGE_CLASS" ]; then
   ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv pgadmin4-http-data
 fi
 
 $CCPROOT/examples/waitforterm.sh pgadmin4-http ${CCP_CLI?}
+
+dir_check_rm "sessions"
+dir_check_rm "storage"
+file_check_rm "access_log"
+file_check_rm "config_local.py"
+file_check_rm "error_log"
+file_check_rm "pgadmin4.db"
+file_check_rm "pgadmin4.conf"
+file_check_rm "pgadmin.log"

--- a/examples/kube/pgadmin4-https/cleanup.sh
+++ b/examples/kube/pgadmin4-https/cleanup.sh
@@ -23,6 +23,7 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pgadmin4-https-secrets
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pgadmin4-https-tls
 
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc pgadmin4-https-data
+
 if [ -z "$CCP_STORAGE_CLASS" ]; then
   ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv pgadmin4-https-data
 fi
@@ -30,3 +31,12 @@ fi
 rm -f ${DIR?}/server.crt ${DIR?}/server.key ${DIR?}/privkey.pem
 
 $CCPROOT/examples/waitforterm.sh pgadmin4-https ${CCP_CLI?}
+
+file_check_rm "access_log"
+file_check_rm "config_local.py"
+file_check_rm "error_log"
+file_check_rm "pgadmin4.db"
+file_check_rm "pgadmin4.conf"
+file_check_rm "pgadmin.log"
+file_check_rm "sessions"
+file_check_rm "storage"

--- a/examples/kube/pitr/cleanup.sh
+++ b/examples/kube/pitr/cleanup.sh
@@ -29,6 +29,7 @@ if [ -z "$CCP_STORAGE_CLASS" ]; then
   ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv pitr-pgdata pitr-pgwal backup-pitr-pgdata restore-pitr-pgdata recover-pv
 fi
 
-sudo CCP_STORAGE_PATH=$CCP_STORAGE_PATH rm -rf $CCP_STORAGE_PATH/pitr
-sudo CCP_STORAGE_PATH=$CCP_STORAGE_PATH rm -rf $CCP_STORAGE_PATH/pitr-backups
-sudo CCP_STORAGE_PATH=$CCP_STORAGE_PATH rm -rf $CCP_STORAGE_PATH/pitr-wal
+dir_check_rm "pitr"
+dir_check_rm "pitr-wal"
+dir_check_rm "pitr-backups"
+dir_check_rm "restore-pitr"

--- a/examples/kube/postgres-sshd/cleanup.sh
+++ b/examples/kube/postgres-sshd/cleanup.sh
@@ -30,3 +30,8 @@ fi
 
 $CCPROOT/examples/waitforterm.sh postgres-sshd ${CCP_CLI?}
 rm -rf ${DIR?}/keys
+
+dir_check_rm "archive"
+dir_check_rm "backup"
+dir_check_rm "postgres-sshd"
+file_check_rm "db-stanza-create.log"

--- a/examples/kube/primary-deployment/cleanup.sh
+++ b/examples/kube/primary-deployment/cleanup.sh
@@ -15,7 +15,7 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment primary-deployment 
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment primary-deployment
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} statefulsets replica-deployment
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap primary-deployment-pgconf
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pgprimary-secret
@@ -26,3 +26,6 @@ if [ -z "$CCP_STORAGE_CLASS" ]
 then
   ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv primary-deployment-pgdata replica-deployment-pgdata
 fi
+
+dir_check_rm "primary-deployment"
+dir_check_rm "replica-deployment"

--- a/examples/kube/primary-upgrade/cleanup.sh
+++ b/examples/kube/primary-upgrade/cleanup.sh
@@ -18,6 +18,9 @@ echo_info "Cleaning up.."
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service primary-upgrade
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod primary-upgrade
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc primary-upgrade-pgdata
+
 if [ -z "$CCP_STORAGE_CLASS" ]; then
   ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv primary-upgrade-pgdata
 fi
+
+dir_check_rm "primary-upgrade"

--- a/examples/kube/primary/cleanup.sh
+++ b/examples/kube/primary/cleanup.sh
@@ -24,3 +24,5 @@ if [ -z "$CCP_STORAGE_CLASS" ]; then
 fi
 
 $CCPROOT/examples/waitforterm.sh primary ${CCP_CLI?}
+
+dir_check_rm "primary"

--- a/examples/kube/restore/cleanup.sh
+++ b/examples/kube/restore/cleanup.sh
@@ -18,7 +18,11 @@ echo_info "Cleaning up.."
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod restore
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service restore
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc restore-pgdata
+
 if [ -z "$CCP_STORAGE_CLASS" ]; then
   ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv restore-pgdata
 fi
+
 $CCPROOT/examples/waitforterm.sh restore ${CCP_CLI?}
+
+dir_check_rm "restore"

--- a/examples/kube/statefulset/cleanup.sh
+++ b/examples/kube/statefulset/cleanup.sh
@@ -19,8 +19,13 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} statefulset statefulset
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} sa statefulset-sa
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} clusterrolebinding statefulset-sa
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc statefulset-pgdata
+
 if [ -z "$CCP_STORAGE_CLASS" ]; then
   ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv statefulset-pgdata
 fi
+
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service statefulset statefulset-primary statefulset-replica
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod statefulset-0 statefulset-1
+
+dir_check_rm "statefulset-0"
+dir_check_rm "statefulset-1"


### PR DESCRIPTION
Address issues 12, 22, 24, 25, and #557 by removing the following files using two newly created functions (dir_check_rm and file_check_rm) defined in examples/common.sh:

Custom-config - 

- 	/archive
- 	/backup
- 	/custom-config
- 	/custom-config-wal
- 	/db-stanza-create.log

Custom-config-ssl - 

- 	/archive
- 	/backup
- 	/custom-config-ssl
- 	/db-stanza-create.log

Metrics - 

- 	/defaults.ini
- 	/grafana
- 	/lock
- 	/prometheus.yml
- 	/wal

Pgadmin4-http - 

- 	/access_log
- 	/config_local.py
- 	/error_log
- 	/pgadmin4.db
- 	/pgadmin.conf
- 	/pgadmin.log
- 	/sessions
- 	/storage

Pgadmin4-https -

- /access_log
- 	/config_local.py
- 	/error_log
- 	/pgadmin4.db
- 	/pgadmin.conf
- 	/pgadmin.log
- 	/sessions
- 	/storage

Pitr - 

- 	/pitr
- 	/pitr-wal
- 	/pitr-backups
- 	/restore-pitr

Postgres-sshd - 

- 	/archive
- 	/backup
- 	/db-stanza-create.log
- 	/postgres-sshd

Primary - 

- /primary

Primary-deployment - 

- 	/primary-deployment
- 	/replica-deployment

Primary-upgrade -

- 	/primary-upgrade

Restore - 

- 	/restore

Statefulset - 

- 	/statefulset-0
- 	/statefulset-1
