### PR TITLE
Switch pgMonitor clone to https

### DIFF
--- a/bin/install-deps.sh
+++ b/bin/install-deps.sh
@@ -67,6 +67,6 @@ if [[ -d ${CCPROOT?}/tools/pgmonitor ]]
 then
     rm -rf ${CCPROOT?}/tools/pgmonitor
 fi
-git clone git@github.com:crunchydata/pgmonitor.git ${CCPROOT?}/tools/pgmonitor
+git clone https://github.com/CrunchyData/pgmonitor.git ${CCPROOT?}/tools/pgmonitor
 cd ${CCPROOT?}/tools/pgmonitor
 git checkout ${PGMONITOR_COMMIT?}


### PR DESCRIPTION
To avoid requiring an SSH key in `install-deps.sh`, switching the clone for pgMonitor to HTTPS.