### PR TITLE
Clarify docs

### DIFF
--- a/hugo/content/container-specifications/crunchy-postgres-gis.md
+++ b/hugo/content/container-specifications/crunchy-postgres-gis.md
@@ -33,12 +33,13 @@ The crunchy-postgres-gis Docker image contains the following packages (versions 
 **Name**|**Default**|**Description**
 :-----|:-----|:-----
 **PG_DATABASE**|None|Set this value to create an initial database
+**PG_PORT**|None|Set this value to specify the container port postgres will start on
 **PG_MODE**|None|Set to `primary`, `replica` or `set` to specify the mode of the database
-**PG_PASSWORD**|None|Set this value to specify the password of the user role
-**PG_PRIMARY_PASSWORD**|None|Set this value to specify the password of the replication user
-**PG_PRIMARY_USER**|None|Set this value to specify the username of the replication user
-**PG_ROOT_PASSWORD**|None|Set this value to specify the password of the superuser role
 **PG_USER**|None|Set this value to specify the username of the general user account
+**PG_PASSWORD**|None|Set this value to specify the password of the user role
+**PG_PRIMARY_USER**|None|Set this value to specify the username of the replication user
+**PG_PRIMARY_PASSWORD**|None|Set this value to specify the password of the replication user
+**PG_ROOT_PASSWORD**|None|Set this value to specify the password of the superuser role
 
 ### Optional
 **Name**|**Default**|**Description**

--- a/hugo/content/container-specifications/crunchy-postgres.md
+++ b/hugo/content/container-specifications/crunchy-postgres.md
@@ -31,12 +31,13 @@ The crunchy-postgres Docker image contains the following packages (versions vary
 **Name**|**Default**|**Description**
 :-----|:-----|:-----
 **PG_DATABASE**|None|Set this value to create an initial database
+**PG_PORT**|None|Set this value to specify the container port postgres will start on
 **PG_MODE**|None|Set to `primary`, `replica` or `set` to specify the mode of the database
-**PG_PASSWORD**|None|Set this value to specify the password of the user role
-**PG_PRIMARY_PASSWORD**|None|Set this value to specify the password of the replication user
-**PG_PRIMARY_USER**|None|Set this value to specify the username of the replication user
-**PG_ROOT_PASSWORD**|None|Set this value to specify the password of the superuser role
 **PG_USER**|None|Set this value to specify the username of the general user account
+**PG_PASSWORD**|None|Set this value to specify the password of the user role
+**PG_PRIMARY_USER**|None|Set this value to specify the username of the replication user
+**PG_PRIMARY_PASSWORD**|None|Set this value to specify the password of the replication user
+**PG_ROOT_PASSWORD**|None|Set this value to specify the password of the superuser role
 
 ### Optional
 **Name**|**Default**|**Description**

--- a/hugo/content/container-specifications/crunchy-vacuum.md
+++ b/hugo/content/container-specifications/crunchy-vacuum.md
@@ -26,10 +26,10 @@ The crunchy-vacuum Docker image contains the following packages:
 **Name**|**Default**|**Description**
 :-----|:-----|:-----
 **JOB_HOST**|None|The PostgreSQL host the VACUUM should be performed against.
-**PG_USER**|None|Username for the PostgreSQL role being used.
 **PG_DATABASE**|None|The PostgreSQL database the VACUUM should be performed against.
-**PG_PASSWORD**|None|Password for the PostgreSQL role being used.
 **PG_PORT**|5432|Allows you to override the default value of 5432.
+**PG_USER**|None|Username for the PostgreSQL role being used.
+**PG_PASSWORD**|None|Password for the PostgreSQL role being used.
 
 ### Optional
 **Name**|**Default**|**Description**


### PR DESCRIPTION
postgres and postgres-gis were missing PG_PRIMARY_PORT which is a
required argument. In a few places PG_USER, PG_PASSWORD,
PG_PRIMARY_USER, PG_PRIMARY_PASSWORD were ordered in a confusing
way. They are now ordered so that password will follow the username they
are assocaiated with.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**Other information**:
I could not generate the docs because the makefile references docs/build-docs.sh which does not seem to be present. Also, I have a modified HTML version locally if you prefer, but I was told by Jeff to modify a different file. 
