### PR TITLE
Fix http redirect

### DIFF
--- a/badger/badgerserver.go
+++ b/badger/badgerserver.go
@@ -53,5 +53,5 @@ func BadgerGenerate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Println("Report generated.  Redirecting..")
-	http.Redirect(w, r, "/static", 301)
+	http.Redirect(w, r, "/static", 302)
 }


### PR DESCRIPTION
Pdbadger was sending a 301 so that it would not regenerate the
documentation when hit again in a browser. Instead, the browser would use
their cache and just bring users to static. Switching from 301 to 302
fixes this issue.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?


**Type of Changes:**
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**
Currently, in a given browser, you will only be able to generate the pgbadger report once, as a local cache will cause it to skip that step.

**What is the new behavior (if this is a feature change)?**
You can access /api/badgergenerate again and agian to regenerate the report and it will not be cached.


**Other information**:
I have a screen capture showing this behavior if you would like, but it's an image and I was not going to upload unless requested.