### PR TITLE
Update prometheus to use namespace

### DIFF
--- a/conf/prometheus/prometheus-kube.yml
+++ b/conf/prometheus/prometheus-kube.yml
@@ -23,7 +23,8 @@ scrape_configs:
     regex: (^[^-]*).*
     target_label: instance
     replacement: '$1'
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_namespace,__meta_kubernetes_pod_name]
     target_label: job
-    regex: (^[^-]*).*
-    replacement: '$1'
+    regex: '(^[^-]*).*'
+    separator: ': '
+    replacement: '$1$2'

--- a/examples/kube/metrics/metrics.json
+++ b/examples/kube/metrics/metrics.json
@@ -72,21 +72,19 @@
                 "name": "prometheus",
                 "protocol": "TCP",
                 "port": 9090,
-                "targetPort": 9090,
-                "nodePort": 30002
+                "targetPort": 9090
             },
             {
                 "name": "grafana",
                 "protocol": "TCP",
                 "port": 3000,
-                "targetPort": 3000,
-                "nodePort": 30001
+                "targetPort": 3000
             }
         ],
         "selector": {
             "name": "metrics"
         },
-        "type": "NodePort",
+        "type": "ClusterIP",
         "sessionAffinity": "None"
     }
 }

--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -2272,11 +2272,16 @@ cd $CCPROOT/examples/kube/metrics
 ./run.sh
 ....
 
-You will be able to access the Grafana and Prometheus services from the following
-web addresses:
+It's required to use `port-forward` to access the Grafana dashboard.  To start the
+port-forward, run the following command:
 
- * Grafana (http://NODE_IP_ADDRESS:30001)
- * Prometheus (http://NODE_IP_ADDRESS:30002)
+....
+${CCP_CLI} port-forward metrics 3000:3000
+${CCP_CLI} port-forward metrics 9090:9090
+....
+
+ * Grafana dashboard can be then accessed from `http://127.0.0.01:3000`
+ * Prometheus dashboard can be then accessed from `http://127.0.0.01:9090`
 
 You can view the container logs using these command:
 ....


### PR DESCRIPTION
This fixes an edge case where collect pods with the same exact podname are running in different namespaces, causing graphs to show duplicate values.  We now concat the namespace + podname to become the job name in Prometheus, making them unique.

It's possible to restrict prometheus to scrape specific pods but that will require some additional code changes to support.

```yml
  kubernetes_sd_configs:
  - api_server: null
    role: pod
    namespaces:
      names: 
        - MY_NAMESPACE
```

Additionally, we can have an env to automatically be set with the namespace using the downward API:

```json
  {
    "name": "MY_POD_NAMESPACE",
    "valueFrom": {
      "fieldRef": {
        "fieldPath": "metadata.namespace"
      }
    }
  }
```