### PR TITLE
Add handler for / in pgbadger http server

### DIFF
--- a/badger/badgerserver.go
+++ b/badger/badgerserver.go
@@ -33,6 +33,7 @@ func init() {
 func main() {
 	http.HandleFunc("/api/badgergenerate", BadgerGenerate)
 	http.Handle("/static/", http.StripPrefix("/static", http.FileServer(http.Dir("/report"))))
+	http.HandleFunc("/", RootPathRedirect)
 	log.Fatal(http.ListenAndServe(":10000", nil))
 }
 
@@ -54,4 +55,12 @@ func BadgerGenerate(w http.ResponseWriter, r *http.Request) {
 
 	log.Println("Report generated.  Redirecting..")
 	http.Redirect(w, r, "/static", 301)
+}
+
+func RootPathRedirect(w http.ResponseWriter, r *http.Request) {
+	redirect_url := "/static/"
+	if _, err := os.Stat(REPORT); os.IsNotExist(err) {
+		redirect_url = "/api/badgergenerate"
+	}
+	http.Redirect(w, r, redirect_url, 302)
 }


### PR DESCRIPTION
Currently you have to remember /api/badgergenerate which is a longer url
than I would like to keep in my head. I added a root handler with two
code paths. If /report/index.html does not exist you get a redirect to
/api/badgergenerate. If it does exist you get a redirect to /static. I
don't believe this change will break anything because there is nothing
listening there currently on this http server.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**
The pgbadger http server does not have a handler on /


**What is the new behavior (if this is a feature change)?**
There is now an intelligent handler on /


**Other information**:
This is a feature add, please let me know if you would prefer this work a different way.