### PR TITLE
2.1.0-rc3 Minor Fixes

### DIFF
--- a/examples/kube/backrest/async-archiving/backrest-pv.json
+++ b/examples/kube/backrest/async-archiving/backrest-pv.json
@@ -25,7 +25,7 @@
     "metadata": {
         "name": "br-aa-backups",
         "labels": {
-            "name": "br-backups"
+            "name": "br-aa-backups"
         }
     },
     "spec": {

--- a/examples/kube/backrest/async-archiving/backrest-pvc.json
+++ b/examples/kube/backrest/async-archiving/backrest-pvc.json
@@ -30,7 +30,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "br-backups"
+            "name": "br-aa-backups"
           }
         },
         "accessModes": [

--- a/examples/kube/pgaudit/run.sh
+++ b/examples/kube/pgaudit/run.sh
@@ -21,7 +21,7 @@ $DIR/cleanup.sh
 echo_info "Creating the example components.."
 
 expenv -f $DIR/pgaudit.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE} -f -
-echo_info "Sleeping for 20 seconds to allow time for the pod to get into a ready state."
-sleep 20
+echo_info "Sleeping for 50 seconds to allow time for the pod to get into a ready state."
+sleep 50
 
 $DIR/test-pgaudit.sh

--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -1328,12 +1328,14 @@ The storage portions of this example can all be found under `$CCP_STORAGE_PATH`.
 Crunchy pgBouncer is a lightweight connection pooler for PostgreSQL databases.
 
 The following examples create the following containers:
+
   * pgBouncer Primary
   * pgBouncer Replica
   * PostgreSQL Primary
   * PostgreSQL Replica
 
 In Kubernetes and OpenShift, this example will also create:
+
   * pgBouncer Primary Service
   * pgBouncer Replica Service
   * Primary Service

--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -589,13 +589,14 @@ If WAL resides on PGDATA, use: `spool-path=/pgdata/HOSTNAME-spool`
 ==== Restore
 
 There are three options to choose from when performing a restore:
+
  * Delta - only restore missing files from PGDATA
  * Full - restore all files, pgdata must be empty
  * Point in Time Recovery (PITR) - delta restore to a certain point in time
 
 ===== PITR
 
-{{% notice notice %}}
+{{% notice tip %}}
 This example uses the `backrest/backup` example.  It should be left running and a
 pgBackRest backup has been created.
 {{% /notice %}}
@@ -628,7 +629,7 @@ cd $CCPROOT/examples/kube/backrest/pitr
 
 ===== Full
 
-{{% notice notice %}}
+{{% notice tip %}}
 This example uses the `backrest/backup` example.  It does not need to be running but a
 pgBackRest backup is required.
 {{% /notice %}}
@@ -656,7 +657,7 @@ cd $CCPROOT/examples/kube/backrest/full
 
 ===== Delta
 
-{{% notice notice %}}
+{{% notice tip %}}
 This example uses the `backrest/backup` example.  It does not need to be running but a
 pgBackRest backup is required.
 {{% /notice %}}
@@ -746,7 +747,7 @@ If WAL resides on PGDATA, use: `spool-path=/pgdata/HOSTNAME-spool`
 
 ===== PITR
 
-{{% notice notice %}}
+{{% notice tip %}}
 This example uses the `backrest/backup` example.  It should be left running and a
 pgBackRest backup has been created.
 {{% /notice %}}
@@ -778,7 +779,7 @@ cd $CCPROOT/examples/docker/backrest/pitr
 
 ===== Full
 
-{{% notice notice %}}
+{{% notice tip %}}
 This example uses the `backrest/backup` example.  It does not need to be running but a
 pgBackRest backup is required.
 {{% /notice %}}
@@ -805,7 +806,7 @@ cd $CCPROOT/examples/docker/backrest/full
 
 ===== Delta
 
-{{% notice notice %}}
+{{% notice tip %}}
 This example uses the `backrest/backup` example.  It does not need to be running but a
 pgBackRest backup is required.
 {{% /notice %}}

--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -242,8 +242,8 @@ ${CCP_CLI} get pod -a -l job-name=upgrade-job
 ${CCP_CLI} logs -l job-name=upgrade-job
 ....
 
-You can verify the upgraded database by running the `post-upgrade.sh` script in the 
-`examples/kube/upgrade` directory.  This will create a PostgreSQL pod that mounts the 
+You can verify the upgraded database by running the `post-upgrade.sh` script in the
+`examples/kube/upgrade` directory.  This will create a PostgreSQL pod that mounts the
 upgraded volume.
 
 === Cron Scheduler
@@ -2222,7 +2222,7 @@ After execution, the container will run and provide a simple HTTP
 command you can browse to view the report.  As you run queries against
 the database, you can invoke this URL to generate updated reports:
 ....
-curl -L http://badger:10000/api/badgergenerate
+curl -L http://pgbadger:10000/api/badgergenerate
 ....
 
 You can view the database container logs using these commands:

--- a/hugo/themes/docdock/static/theme-original/style.css
+++ b/hugo/themes/docdock/static/theme-original/style.css
@@ -292,7 +292,8 @@ h4 {
   margin: 1.5rem 0 0.75rem 0; }
 
 h5 {
-  font-size: 0.5rem;
+  font-size: 1rem;
+  color: #515151 !important;
   line-height: 110% !important;
   margin: 1rem 0 0.2rem 0; }
 

--- a/hugo/themes/static/theme-original/style.css
+++ b/hugo/themes/static/theme-original/style.css
@@ -292,7 +292,7 @@ h4 {
   margin: 1.5rem 0 0.75rem 0; }
 
 h5 {
-  font-size: 0.5rem;
+  font-size: 1rem;
   line-height: 110% !important;
   margin: 1rem 0 0.2rem 0; }
 


### PR DESCRIPTION
- The font size definition for h5 was too small; increased to 1rem from 0.5rem. Changed color for additional differentiation.
- Changed typo: badger -> pgbadger
- Some lists and shortcodes were improperly formatted
- Labels were being inconsistently and incorrectly assigned both "br-aa-backups" and "br-backups" for the pgBackRest async example. Updated so all are "br-aa-backups".
- Extended the timeout for the pgAudit example from 20s to 50s to avoid the example erroring due to pod not being ready.