### PR TITLE
Update RPM variables to be consistent

### DIFF
--- a/centos7/10/Dockerfile.backrest-restore.centos7
+++ b/centos7/10/Dockerfile.backrest-restore.centos7
@@ -16,8 +16,7 @@ LABEL name="crunchydata/postgres" \
 
 ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
 
-#RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install epel-release \
  && yum -y install  \

--- a/centos7/10/Dockerfile.backup.centos7
+++ b/centos7/10/Dockerfile.backup.centos7
@@ -16,7 +16,7 @@ LABEL name="crunchydata/backup" \
 
 ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum install -y epel-release \
  && yum -y update glibc-common \

--- a/centos7/10/Dockerfile.collect.centos7
+++ b/centos7/10/Dockerfile.collect.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/collect" \
 ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
 
 # Install the PGDG yum repo
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 # Install postgres client tools and libraries
 RUN yum install -y epel-release \

--- a/centos7/10/Dockerfile.pgadmin4.centos7
+++ b/centos7/10/Dockerfile.pgadmin4.centos7
@@ -16,7 +16,7 @@ LABEL name="crunchydata/pgadmin4" \
 
 ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install epel-release \
  && yum -y install glibc-common-*2.17* \

--- a/centos7/10/Dockerfile.postgres-gis.centos7
+++ b/centos7/10/Dockerfile.postgres-gis.centos7
@@ -16,7 +16,7 @@ LABEL name="crunchydata/postgres-gis" \
 
 ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install epel-release \
  && yum -y update glibc-common \

--- a/centos7/10/Dockerfile.postgres.centos7
+++ b/centos7/10/Dockerfile.postgres.centos7
@@ -16,7 +16,7 @@ LABEL name="crunchydata/postgres" \
 
 ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update \
  && yum -y install epel-release \

--- a/centos7/10/Dockerfile.upgrade.centos7
+++ b/centos7/10/Dockerfile.upgrade.centos7
@@ -14,9 +14,13 @@ LABEL name="crunchydata/upgrade" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/pgdg-centos95-9.5-3.noarch.rpm
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/pgdg-centos10-10-2.noarch.rpm
+ENV PGDG_95_REPO="pgdg-centos95-9.5-3.noarch.rpm" \
+    PGDG_96_REPO="pgdg-centos96-9.6-3.noarch.rpm" \
+    PGDG_10_REPO="pgdg-centos10-10-2.noarch.rpm"
+
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/${PGDG_95_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/${PGDG_96_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/${PGDG_10_REPO}
 
 RUN yum -y update && yum install -y epel-release \
  && yum -y update glibc-common \

--- a/centos7/9.6/Dockerfile.collect.centos7
+++ b/centos7/9.6/Dockerfile.collect.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/collect" \
 ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
 
 # Install the PGDG yum repo
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 # Install postgres client tools and libraries
 RUN yum install -y epel-release \

--- a/centos7/9.6/Dockerfile.upgrade.centos7
+++ b/centos7/9.6/Dockerfile.upgrade.centos7
@@ -14,8 +14,11 @@ LABEL name="crunchydata/upgrade" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/pgdg-centos95-9.5-3.noarch.rpm
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm
+ENV PGDG_95_REPO="pgdg-centos95-9.5-3.noarch.rpm" \
+    PGDG_96_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/${PGDG_95_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/${PGDG_96_REPO}
 
 RUN yum -y update && yum install -y epel-release \
  && yum -y update glibc-common \


### PR DESCRIPTION
#380 Updated RPM variables to consistently use variables.  There is one exception to this being the upgrade container for 9.6 and 10.   The PGDG repo might change, however, using variables for PGVERSION is unneeded since they will not change (and would add more PGVERSION variables to the dockerfile, thus breaking the consistency with other images).