### PR TITLE
Remove nodeport doc from pgAdmin4 examples

### DIFF
--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -116,16 +116,22 @@ This example deploys the pgadmin4 v2 web user interface
 for PostgreSQL without TLS.
 
 After running the example, you should be able to browse to http://127.0.0.1:5050
-and log into the web application using a user ID of *admin@admin.com*
-and password of *password*.
+and log into the web application with the following configured credentials:
+
+ * Username : *admin@admin.com*
+ * Password: *password*
 
 If you are running this example using Kubernetes or
-OpenShift, replace *127.0.0.1:5050* with the <NODE_IP>:30000.
+OpenShift, it is required to use a port-forward proxy to access the dashboard.
 
-To get the node IP, run the following:
+To start the port-forward proxy run the following:
+
 ....
-${CCP_CLI} describe pod pgadmin4-http | grep Node:
+${CCP_CLI} port-forward pgadmin4-http 5050:5050
 ....
+
+To access the pgAdmin4 dashboard through the proxy, navigate to *http://127.0.0.1:5050*
+in a browser.
 
 See the link:http://pgadmin.org[pgAdmin4 documentation] for more details.
 
@@ -160,17 +166,22 @@ This example deploys the pgadmin4 v2 web user interface
 for PostgreSQL with TLS.
 
 After running the example, you should be able to browse to https://127.0.0.1:5050
-and log into the web application using a user ID of *admin@admin.com*
-and password of *password*.
+and log into the web application with the following configured credentials:
+
+ * Username : *admin@admin.com*
+ * Password: *password*
 
 If you are running this example using Kubernetes or
-OpenShift, replace *127.0.0.1:5050* with the <NODE_IP>:30000.
+OpenShift, it is required to use a port-forward proxy to access the dashboard.
 
-To get the node IP, run the following:
+To start the port-forward proxy run the following:
 
 ....
-${CCP_CLI} describe pod pgadmin4-https | grep Node:
+${CCP_CLI} port-forward pgadmin4-https 5050:5050
 ....
+
+To access the pgAdmin4 dashboard through the proxy, navigate to *https://127.0.0.1:5050*
+in a browser.
 
 See the link:http://pgadmin.org[pgadmin4 documentation] for more details.
 


### PR DESCRIPTION
We moved to ClusterIP for pgAdmin4 examples, updating doc to reflect this change.