### PR TITLE
Correcting Docker docker-vg Instructions

### DIFF
--- a/hugo/content/installation/environment-setup.adoc
+++ b/hugo/content/installation/environment-setup.adoc
@@ -202,18 +202,6 @@ These steps are illustrative of a typical process for setting up Docker storage.
 
 First, add an extra virtual hard disk to your virtual machine (see link:http://catlingmindswipe.blogspot.com/2012/02/how-to-create-new-virtual-disks-in.html[this blog post] for tips on how to do so).
 
-Run this command to format the drive, where `/dev/sd?` is the new hard drive that was added:
-
-....
-fdisk /dev/sd?
-....
-
-Next, create a volume group on the new drive partition within the `fdisk` utility:
-
-....
-vgcreate docker-vg /dev/sd?
-....
-
 Then, you'll need to edit the `docker-storage-setup` configuration file in order to override default options. Add these two lines to `/etc/sysconfig/docker-storage-setup`:
 
 ....
@@ -221,7 +209,9 @@ DEVS=/dev/sd?
 VG=docker-vg
 ....
 
-Finally, run the command `docker-storage-setup` to use that new volume group. The results should state that the physical volume `/dev/sd?` and the volume group `docker-vg` have both been successfully created.
+Be sure to REMOVE the `STORAGE_DRIVER="overlay2"` line from any stock file that may have been in place.
+
+Finally, run the command `docker-storage-setup` to use that new volume group. The results should state that the physical volume `/dev/sd?` and the volume group `docker-vg` have both been successfully created. You should see `docker-vg` listed in the output of `lvs`.
 
 Next, we enable and start up Docker:
 ....


### PR DESCRIPTION
We shouldn't be using fdisk or vgcreate manually prior to running docker-storage-setup. Doing so causes docker-storage-setup to complain and exit. We also need to make sure they remove existing STORAGE_DRIVER settings in the setup file. Old instructions said to "add" the lines, meaning if the user left STORAGE_DRIVER="overlay2" in place (it's there on CentOS7) then their storage will be screwed up.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

This is a documentation correction.
