### PR TITLE
Add log prefix flag to pgBadger

### DIFF
--- a/bin/pgbadger/badger-generate.sh
+++ b/bin/pgbadger/badger-generate.sh
@@ -26,4 +26,12 @@ then
 fi
 
 echo_info "Creating pgBadger output.."
-/bin/pgbadger -f stderr ${BADGER_CUSTOM_OPTS} -o /report/index.html /pgdata/${TARGET?}/pg_log/*.log
+
+if [[ -v BADGER_LOG_PREFIX ]]
+then
+    /bin/pgbadger -f stderr --prefix "${BADGER_LOG_PREFIX?}" ${BADGER_CUSTOM_OPTS} \
+        -o /report/index.html /pgdata/${TARGET?}/pg_log/*.log
+else
+    /bin/pgbadger -f stderr ${BADGER_CUSTOM_OPTS} \
+        -o /report/index.html /pgdata/${TARGET?}/pg_log/*.log
+fi

--- a/examples/kube/pgbadger/pgbadger.json
+++ b/examples/kube/pgbadger/pgbadger.json
@@ -43,8 +43,8 @@
     },
     "spec": {
         "securityContext": {
-           $CCP_SECURITY_CONTEXT
-        	},
+            $CCP_SECURITY_CONTEXT
+        },
         "containers": [
             {
                 "name": "postgres",
@@ -142,7 +142,16 @@
                     "initialDelaySeconds": 15,
                     "periodSeconds": 20
                 },
-                "env": [],
+                "env": [
+                    {
+                        "name": "BADGER_LOG_PREFIX",
+                        "value": "%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h"
+                    },
+                    {
+                        "name": "BADGER_CUSTOM_OPTS",
+                        "value": "--incremental"
+                    }
+                ],
                 "volumeMounts": [
                     {
                         "mountPath": "/pgdata",

--- a/hugo/content/container-specifications/crunchy-pgbadger.md
+++ b/hugo/content/container-specifications/crunchy-pgbadger.md
@@ -26,13 +26,11 @@ The crunchy-badger Docker image contains the following packages:
 
 ## Environment Variables
 
-### Required
+### Optional
+
 **Name**|**Default**|**Description**
 :-----|:-----|:-----
 **BADGER_TARGET**|None|Only used in standalone mode to specify the name of the container. Also used to find the location of the database log files in `/pgdata/$BADGER_TARGET/pg_log/*.log`.
-
-### Optional
-**Name**|**Default**|**Description**
-:-----|:-----|:-----
 **BADGER_CUSTOM_OPTS**|None|For a list of optional flags, see the [official pgBadger documentation](http://dalibo.github.io/pgbadger).
+**BADGER_LOG_PREFIX**|None|Set this value when PostgreSQL has been configured to use a custom `log_line_prefix`.
 **CRUNCHY_DEBUG**|FALSE|Set this to true to enable debugging in logs. Note: this mode can reveal secrets in logs.


### PR DESCRIPTION
This pull request adds a workaround for #701 by specifying a `BADGER_LOG_PREFIX` flag so users can inject custom `log_line_prefix` values.