### PR TITLE
Update OpenShift references to 3.10

### DIFF
--- a/bin/install-deps.sh
+++ b/bin/install-deps.sh
@@ -20,6 +20,7 @@ POSTGRES_EXPORTER_VERSION=0.4.6
 NODE_EXPORTER_VERSION=0.16.0
 MERCURIAL_RPM='https://www.mercurial-scm.org/release/centos7/RPMS/x86_64/mercurial-4.6.1-1.x86_64.rpm'
 PGMONITOR_COMMIT='dffb2b5eb04ba13ee47ae81950410738d15e8c76'
+OPENSHIFT_CLIENT='https://github.com/openshift/origin/releases/download/v3.10.0/openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit.tar.gz'
 
 sudo yum -y install net-tools bind-utils wget unzip git
 
@@ -39,12 +40,11 @@ if [ $? -ne 0 ]; then
     if [ $? -ne 0 ]; then
         echo atomic-openshift-clients package is NOT found
         sudo yum -y install kubernetes-client
-        FILE=openshift-origin-client-tools-v3.7.0-7ed6862-linux-64bit.tar.gz
-        wget -O /tmp/$FILE \
-        https://github.com/openshift/origin/releases/download/v3.7.0/$FILE
 
-        tar xvzf /tmp/$FILE  -C /tmp
-        sudo cp /tmp/openshift-origin-client-tools-v3.7.0-7ed6862-linux-64bit/oc /usr/bin/oc
+        FILE='openshift-origin-client.tgz'
+        wget -O /tmp/${FILE?} ${OPENSHIFT_CLIENT?}
+        tar xvzf /tmp/${FILE?} -C /tmp
+        sudo cp /tmp/openshift-*/oc /usr/bin/oc
     else
         echo atomic-openshift-clients package IS found
         sudo yum -y install atomic-openshift-clients

--- a/hugo/content/_index.adoc
+++ b/hugo/content/_index.adoc
@@ -27,9 +27,9 @@ are supported.
 
 The containers will execute in the following environments:
 
- * Docker 1.12 and above
- * Openshift 3.4 and above
- * Kubernetes 1.5 and above
+ * Docker 1.13+
+ * Openshift 3.10+
+ * Kubernetes 1.8+
 
 === Containers
 

--- a/hugo/content/container-specifications/_index.adoc
+++ b/hugo/content/container-specifications/_index.adoc
@@ -881,4 +881,3 @@ queries over a specified interval range.
 === Restrictions
 
 * Only one connection is created for all queries.
->>>>>>> aae224745f5caf481c142b4ccbf3332ab4f45f8e

--- a/hugo/content/installation/environment-setup.adoc
+++ b/hugo/content/installation/environment-setup.adoc
@@ -12,8 +12,8 @@ Latest Release: 2.1.0 {docdate}
 
 The Crunchy Container Suite can run on different environments including:
 
- * *Docker 1.12+*
- * *OpenShift Container Platform 3.6+*
+ * *Docker 1.13+*
+ * *OpenShift Container Platform 3.10+*
  * *Kubernetes 1.8+*
 
 In this document we list the basic installation steps required for these
@@ -301,7 +301,7 @@ oc login -u someuser
 For our development purposes only, we typically specify the OCP
 Authorization policy of `AllowAll` as documented here:
 
-https://docs.openshift.com/container-platform/3.7/install_config/configuring_authentication.html#AllowAllPasswordIdentityProvider
+https://docs.openshift.com/container-platform/3.10/install_config/configuring_authentication.html#AllowAllPasswordIdentityProvider
 
 We do not recommend this authentication policy for a production
 deployment of OCP.


### PR DESCRIPTION
This pull request updates OpenShift references to 3.10 as per #763.

Updated the `oc` client to 3.10 and Docker requirements to `1.13+` (default version of docker being installed on CentOS7/RHEL7).