### PR TITLE
Fix formatting in scheduler doc

### DIFF
--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -268,6 +268,7 @@ The Crunchy Scheduler container implements a cronlike microservice within a name
 to automate backups of a PostgreSQL database.
 
 Currently Crunchy Scheduler only supports two types of tasks:
+
 * pgBackRest
 * pgBaseBackup
 
@@ -277,6 +278,7 @@ convert it to a scheduled task.  If the config map is removed, the scheduler wil
 delete the task.
 
 See the following examples for creating config maps that Crunchy Scheduler can parse:
+
 * link:https://github.com/CrunchyData/crunchy-containers/blob/scheduler/examples/kube/scheduler/configs/schedule-backrest-diff.json[pgBackRest Diff Backup]
 * link:https://github.com/CrunchyData/crunchy-containers/blob/scheduler/examples/kube/scheduler/configs/schedule-backrest-full.json[pgBackRest Full Backup]
 * link:https://github.com/CrunchyData/crunchy-containers/blob/scheduler/examples/kube/scheduler/configs/schedule-pgbasebackup.json[pgBaseBackup Backup]
@@ -288,15 +290,17 @@ for the required permissions on this account.
 ==== pgBackRest Schedules
 
 To configure Crunchy Scheduler to create pgBackRest backups the following is required:
-  * pgBackRest schedule definition requires a deployment name.  The PostgreSQL pod should be created by a deployment.
+
+* pgBackRest schedule definition requires a deployment name.  The PostgreSQL pod should be created by a deployment.
 
 ==== pgBaseBackup Schedules
 
 To configure Crunchy Scheduler to create pgBaseBackup scheduled backups, the following is required:
-  * The name of the secret that contains the username and password the Scheduler will use to
-    configure the job template.  See link:https://github.com/CrunchyData/crunchy-containers/blob/scheduler/examples/kube/scheduler/primary/secret.json[the primary secret example].
-    for the structure required by the Scheduler.
-  * The name of the PVC created for the backups.  This should be created by the user prior to scheduling the task.
+
+* The name of the secret that contains the username and password the Scheduler will use to
+  configure the job template.  See link:https://github.com/CrunchyData/crunchy-containers/blob/scheduler/examples/kube/scheduler/primary/secret.json[the primary secret example].
+  for the structure required by the Scheduler.
+* The name of the PVC created for the backups.  This should be created by the user prior to scheduling the task.
 
 ==== Kubernetes and OpenShift
 
@@ -327,9 +331,10 @@ cd $CCPROOT/examples/kube/scheduler
 ....
 
 The scheduled tasks will (these are just for fast results, not recommended for production):
-  * take a backup every minute using pgBaseBackup
-  * take a full pgBackRest backup every even minute
-  * take a diff pgBackRest backup every odd minute
+
+* take a backup every minute using pgBaseBackup
+* take a full pgBackRest backup every even minute
+* take a diff pgBackRest backup every odd minute
 
 View the logs for the `scheduler` pod until the tasks run:
 


### PR DESCRIPTION
Bullets weren't formatted correctly in the scheduler documentation.