### PR TITLE
Fix issue with incorrect link in pgpool image for PG11

### DIFF
--- a/rhel7/11/Dockerfile.pgpool.rhel7
+++ b/rhel7/11/Dockerfile.pgpool.rhel7
@@ -50,8 +50,8 @@ ADD bin/pgpool /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/pgpool /opt/cpm/conf
 
-RUN ln -sf /opt/cpm/conf/pool_hba.conf /etc/pgpool-II-10/pool_hba.conf \
-  && ln -sf /opt/cpm/conf/pgpool/pool_passwd /etc/pgpool-II-10/pool_passwd
+RUN ln -sf /opt/cpm/conf/pool_hba.conf /etc/pgpool-II-11/pool_hba.conf \
+  && ln -sf /opt/cpm/conf/pgpool/pool_passwd /etc/pgpool-II-11/pool_passwd
 
 RUN chgrp -R 0 /opt/cpm && \
     chmod -R g=u /opt/cpm


### PR DESCRIPTION
**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
pgpool image for PG11 RHEL7 does not properly build due to error in Dockerfile


**What is the new behavior (if this is a feature change)?**
image builds successfully. 


**Other information**:
