### PR TITLE
Remove nss from test-harness/scheduler

### DIFF
--- a/tools/scheduler/cron/pgbackrest.go
+++ b/tools/scheduler/cron/pgbackrest.go
@@ -39,12 +39,11 @@ func (b BackRestBackupJob) Run() {
 
 	contextLogger.Info("Running pgBackRest backup")
 
-	backup := []string{
+	cmd := []string{
 		"/usr/bin/pgbackrest",
 		fmt.Sprintf("--stanza=%s", b.stanza),
 		"backup", fmt.Sprintf("--type=%s", b.backupType),
 	}
-	cmd := append(nsswrapper, backup...)
 
 	if b.label != "" {
 		deployments, err := b.client.ListDeployments(b.namespace, b.label)

--- a/tools/scheduler/cron/types.go
+++ b/tools/scheduler/cron/types.go
@@ -7,12 +7,6 @@ import (
 	cv2 "gopkg.in/robfig/cron.v2"
 )
 
-var nsswrapper = []string{"env",
-	"LD_PRELOAD=/usr/lib64/libnss_wrapper.so",
-	"NSS_WRAPPER_PASSWD=/tmp/passwd",
-	"NSS_WRAPPER_GROUP=/tmp/group",
-}
-
 type Cron struct {
 	entries       map[string]cv2.EntryID
 	kubeClient    *kubeapi.KubeAPI

--- a/tools/test-harness/backrest_test.go
+++ b/tools/test-harness/backrest_test.go
@@ -27,10 +27,8 @@ func TestBackrestAsyncArchive(t *testing.T) {
 	t.Log("Running full backup...")
 	// Required for OCP - backrest gets confused when random UIDs aren't found in PAM.
 	// Exec doesn't load bashrc or bash_profile, so we need to set this explicitly.
-	nsswrapper := []string{"env", "LD_PRELOAD=/usr/lib64/libnss_wrapper.so", "NSS_WRAPPER_PASSWD=/tmp/passwd", "NSS_WRAPPER_GROUP=/tmp/group"}
 	fullBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
-	cmd := append(nsswrapper, fullBackup...)
-	_, stderr, err := harness.Client.Exec(harness.Namespace, "backrest-async-archive", "backrest", cmd)
+	_, stderr, err := harness.Client.Exec(harness.Namespace, "backrest-async-archive", "backrest", fullBackup)
 	if err != nil {
 		t.Logf("\n%s", stderr)
 		t.Fatalf("Error execing into container: %s", err)
@@ -38,8 +36,7 @@ func TestBackrestAsyncArchive(t *testing.T) {
 
 	t.Log("Running diff backup...")
 	diffBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
-	cmd = append(nsswrapper, diffBackup...)
-	_, stderr, err = harness.Client.Exec(harness.Namespace, "backrest-async-archive", "backrest", cmd)
+	_, stderr, err = harness.Client.Exec(harness.Namespace, "backrest-async-archive", "backrest", diffBackup)
 	if err != nil {
 		t.Logf("\n%s", stderr)
 		t.Fatalf("Error execing into container: %s", err)
@@ -76,10 +73,8 @@ func TestBackrestDeltaRestore(t *testing.T) {
 	t.Log("Running full backup...")
 	// Required for OCP - backrest gets confused when random UIDs aren't found in PAM.
 	// Exec doesn't load bashrc or bash_profile, so we need to set this explicitly.
-	nsswrapper := []string{"env", "LD_PRELOAD=/usr/lib64/libnss_wrapper.so", "NSS_WRAPPER_PASSWD=/tmp/passwd", "NSS_WRAPPER_GROUP=/tmp/group"}
 	fullBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
-	cmd := append(nsswrapper, fullBackup...)
-	_, stderr, err := harness.Client.Exec(harness.Namespace, "backrest", "backrest", cmd)
+	_, stderr, err := harness.Client.Exec(harness.Namespace, "backrest", "backrest", fullBackup)
 	if err != nil {
 		t.Logf("\n%s", stderr)
 		t.Fatalf("Error execing into container: %s", err)
@@ -145,10 +140,8 @@ func TestBackrestFullRestore(t *testing.T) {
 	t.Log("Running full backup...")
 	// Required for OCP - backrest gets confused when random UIDs aren't found in PAM.
 	// Exec doesn't load bashrc or bash_profile, so we need to set this explicitly.
-	nsswrapper := []string{"env", "LD_PRELOAD=/usr/lib64/libnss_wrapper.so", "NSS_WRAPPER_PASSWD=/tmp/passwd", "NSS_WRAPPER_GROUP=/tmp/group"}
 	fullBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
-	cmd := append(nsswrapper, fullBackup...)
-	_, stderr, err := harness.Client.Exec(harness.Namespace, "backrest", "backrest", cmd)
+	_, stderr, err := harness.Client.Exec(harness.Namespace, "backrest", "backrest", fullBackup)
 	if err != nil {
 		t.Logf("\n%s", stderr)
 		t.Fatalf("Error execing into container: %s", err)
@@ -215,10 +208,8 @@ func TestBackrestPITRRestore(t *testing.T) {
 	t.Log("Running full backup...")
 	// Required for OCP - backrest gets confused when random UIDs aren't found in PAM.
 	// Exec doesn't load bashrc or bash_profile, so we need to set this explicitly.
-	nsswrapper := []string{"env", "LD_PRELOAD=/usr/lib64/libnss_wrapper.so", "NSS_WRAPPER_PASSWD=/tmp/passwd", "NSS_WRAPPER_GROUP=/tmp/group"}
 	fullBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
-	cmd := append(nsswrapper, fullBackup...)
-	_, stderr, err := harness.Client.Exec(harness.Namespace, "backrest", "backrest", cmd)
+	_, stderr, err := harness.Client.Exec(harness.Namespace, "backrest", "backrest", fullBackup)
 	if err != nil {
 		t.Logf("\n%s", stderr)
 		t.Fatalf("Error execing into container: %s", err)

--- a/tools/test-harness/custom_config_test.go
+++ b/tools/test-harness/custom_config_test.go
@@ -28,17 +28,15 @@ func TestCustomConfig(t *testing.T) {
 	t.Log("Running full backup...")
 	// Required for OCP - backrest gets confused when random UIDs aren't found in PAM.
 	// Exec doesn't load bashrc or bash_profile, so we need to set this explicitly.
-	nsswrapper := []string{"env", "LD_PRELOAD=/usr/lib64/libnss_wrapper.so", "NSS_WRAPPER_PASSWD=/tmp/passwd", "NSS_WRAPPER_GROUP=/tmp/group"}
 	fullBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
-	cmd := append(nsswrapper, fullBackup...)
-	_, stderr, err := harness.Client.Exec(harness.Namespace, "custom-config", "postgres", cmd)
+	_, stderr, err := harness.Client.Exec(harness.Namespace, "custom-config", "postgres", fullBackup)
 	if err != nil {
 		t.Logf("\n%s", stderr)
 		t.Fatalf("Error execing into container: %s", err)
 	}
 
 	t.Log("Checking PGWAL...")
-	cmd = []string{"test", "-d", "/pgwal/custom-config-wal"}
+	cmd := []string{"test", "-d", "/pgwal/custom-config-wal"}
 	_, stderr, err = harness.Client.Exec(harness.Namespace, "custom-config", "postgres", cmd)
 	if err != nil {
 		t.Logf("\n%s", stderr)


### PR DESCRIPTION
Since we dropped nss-wrapper support, the nss env injection in the test-harness is causing errors.  Removing them as they aren't needed anymore.