### PR TITLE
Add templating for backrest schedules

### DIFF
--- a/examples/kube/scheduler/add-schedules.sh
+++ b/examples/kube/scheduler/add-schedules.sh
@@ -5,11 +5,13 @@ source ${CCPROOT}/examples/common.sh
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 expenv -f ${DIR?}/configs/schedule-pgbasebackup.json > /tmp/schedule-pgbasebackup.json
+expenv -f ${DIR?}/configs/schedule-backrest-full.json > /tmp/schedule-backrest-full.json
+expenv -f ${DIR?}/configs/schedule-backrest-diff.json > /tmp/schedule-backrest-diff.json
 
 ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} configmap backrest-schedule-full \
-    --from-file=${DIR?}/configs/schedule-backrest-full.json
+    --from-file=/tmp/schedule-backrest-full.json
 ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} configmap backrest-schedule-diff \
-    --from-file=${DIR?}/configs/schedule-backrest-diff.json
+    --from-file=/tmp/schedule-backrest-diff.json
 ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} configmap pgbasebackup-backup \
     --from-file=/tmp/schedule-pgbasebackup.json
 

--- a/examples/kube/scheduler/configs/schedule-backrest-diff.json
+++ b/examples/kube/scheduler/configs/schedule-backrest-diff.json
@@ -3,7 +3,7 @@
     "name": "backrest-diff",
     "created": "2018-09-04T18:25:43.511Z",
     "schedule": "1-59/2 * * * *",
-    "namespace": "demo",
+    "namespace": "${CCP_NAMESPACE}",
     "type": "pgbackrest",
     "pgbackrest": {
         "deployment": "primary-deployment",

--- a/examples/kube/scheduler/configs/schedule-backrest-full.json
+++ b/examples/kube/scheduler/configs/schedule-backrest-full.json
@@ -3,7 +3,7 @@
     "name": "backrest-full",
     "created": "2018-09-04T18:25:43.511Z",
     "schedule": "*/2 * * * *",
-    "namespace": "demo",
+    "namespace": "${CCP_NAMESPACE}",
     "type": "pgbackrest",
     "pgbackrest": {
         "deployment": "primary-deployment",

--- a/examples/kube/scheduler/scheduler-sa.json
+++ b/examples/kube/scheduler/scheduler-sa.json
@@ -2,7 +2,8 @@
     "apiVersion": "rbac.authorization.k8s.io/v1beta1",
     "kind": "ClusterRole",
     "metadata": {
-        "name": "scheduler-sa"
+        "name": "scheduler-sa",
+        "namespace": "$CCP_NAMESPACE"
     },
     "rules": [
         {


### PR DESCRIPTION
Missed environment variables for namespace on backrest schedules.