### PR TITLE
Fix run script in OCP templates

### DIFF
--- a/examples/ocp-templates/create-all.sh
+++ b/examples/ocp-templates/create-all.sh
@@ -15,20 +15,18 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-$DIR/backup/run.sh
-$DIR/badger/run.sh
-$DIR/collect/run.sh
-$DIR/primary-collect-badger/run.sh
-$DIR/primary-replica-dc/run.sh
-$DIR/primary-replica/run.sh
-$DIR/primary-restore/run.sh
-$DIR/metrics/run.sh
-$DIR/pgadmin4/run.sh
-$DIR/pgbouncer/run.sh
-$DIR/pgpool/run.sh
-$DIR/replica-dc/run.sh
-$DIR/secret/run.sh
-$DIR/single-primary/run.sh
-$DIR/single-replica/run.sh
-$DIR/sync/run.sh
-$DIR/watch/run.sh
+${DIR?}/pgadmin4/run.sh
+${DIR?}/pgbadger/run.sh
+${DIR?}/pgbouncer/run.sh
+${DIR?}/pgpool/run.sh
+${DIR?}/plans/create-all.sh
+${DIR?}/postgis-replicated/run.sh
+${DIR?}/postgres-replicated/run.sh
+${DIR?}/postgres-replicated-sync/run.sh
+${DIR?}/primary-backup/run.sh
+${DIR?}/primary-backup-secret/run.sh
+${DIR?}/primary-restore/run.sh
+${DIR?}/primary-restore-secret/run.sh
+${DIR?}/replica-statefulset/run.sh
+${DIR?}/replica-statefulset-secret/run.sh
+${DIR?}/single-primary/run.sh

--- a/examples/ocp-templates/pgadmin4/cleanup.sh
+++ b/examples/ocp-templates/pgadmin4/cleanup.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-pgadmin4
+oc delete template crunchy-pgadmin4 --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/pgadmin4/run.sh
+++ b/examples/ocp-templates/pgadmin4/run.sh
@@ -16,4 +16,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/pgadmin4.json 
+oc create -f $DIR/pgadmin4.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/pgbadger/cleanup.sh
+++ b/examples/ocp-templates/pgbadger/cleanup.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-pgbadger-template
+oc delete template crunchy-postgres-database-with-pgbadger --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/pgbadger/run.sh
+++ b/examples/ocp-templates/pgbadger/run.sh
@@ -17,4 +17,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/badger.json 
+oc create -f $DIR/badger.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/pgbouncer/cleanup.sh
+++ b/examples/ocp-templates/pgbouncer/cleanup.sh
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-postgres-with-pgbouncer-template
+oc delete template crunchy-postgres-with-pgbouncer-template --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/pgbouncer/run.sh
+++ b/examples/ocp-templates/pgbouncer/run.sh
@@ -17,4 +17,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/pgbouncer.json
+oc create -f $DIR/pgbouncer.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/pgpool/cleanup.sh
+++ b/examples/ocp-templates/pgpool/cleanup.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-postgres-with-pgpool-template
+oc delete template crunchy-postgres-with-pgpool-template --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/pgpool/run.sh
+++ b/examples/ocp-templates/pgpool/run.sh
@@ -16,4 +16,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/pgpool.json
+oc create -f $DIR/pgpool.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/plans/crunchy-large/cleanup.sh
+++ b/examples/ocp-templates/plans/crunchy-large/cleanup.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-large-config
+oc delete template crunchy-large-config --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/plans/crunchy-large/run.sh
+++ b/examples/ocp-templates/plans/crunchy-large/run.sh
@@ -17,4 +17,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/large.json 
+oc create -f $DIR/large.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/plans/crunchy-medium/cleanup.sh
+++ b/examples/ocp-templates/plans/crunchy-medium/cleanup.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-medium-config
+oc delete template crunchy-medium-config --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/plans/crunchy-medium/run.sh
+++ b/examples/ocp-templates/plans/crunchy-medium/run.sh
@@ -17,4 +17,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/medium.json 
+oc create -f $DIR/medium.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/plans/crunchy-small/cleanup.sh
+++ b/examples/ocp-templates/plans/crunchy-small/cleanup.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-small-config
+oc delete template crunchy-small-config --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/plans/crunchy-small/run.sh
+++ b/examples/ocp-templates/plans/crunchy-small/run.sh
@@ -17,4 +17,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/small.json 
+oc create -f $DIR/small.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/plans/metrics/cleanup.sh
+++ b/examples/ocp-templates/plans/metrics/cleanup.sh
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-metrics
+oc delete template crunchy-metrics --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/plans/metrics/run.sh
+++ b/examples/ocp-templates/plans/metrics/run.sh
@@ -21,5 +21,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/metrics.json 
-
+oc create -f $DIR/metrics.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/plans/pgweb/cleanup.sh
+++ b/examples/ocp-templates/plans/pgweb/cleanup.sh
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-pgweb-app
-
+oc delete template crunchy-pgweb-app --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/plans/pgweb/run.sh
+++ b/examples/ocp-templates/plans/pgweb/run.sh
@@ -17,5 +17,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/pgweb.json
-
+oc create -f $DIR/pgweb.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/postgis-replicated/cleanup.sh
+++ b/examples/ocp-templates/postgis-replicated/cleanup.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-postgis-replicated-template
+oc delete template crunchy-postgis-replicated-template --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/postgis-replicated/run.sh
+++ b/examples/ocp-templates/postgis-replicated/run.sh
@@ -16,4 +16,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/postgis-replicated.json
+oc create -f $DIR/postgis-replicated.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/postgres-replicated-sync/cleanup.sh
+++ b/examples/ocp-templates/postgres-replicated-sync/cleanup.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-postgres-primary-sync-replica-template
+oc delete template crunchy-postgres-primary-sync-replica-template --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/postgres-replicated-sync/run.sh
+++ b/examples/ocp-templates/postgres-replicated-sync/run.sh
@@ -16,4 +16,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/postgres-replicated-sync.json
+oc create -f $DIR/postgres-replicated-sync.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/postgres-replicated/cleanup.sh
+++ b/examples/ocp-templates/postgres-replicated/cleanup.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-postgres-primary-replica-template
+oc delete template crunchy-postgres-primary-replica-template --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/postgres-replicated/run.sh
+++ b/examples/ocp-templates/postgres-replicated/run.sh
@@ -16,4 +16,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/postgres-replicated.json
+oc create -f $DIR/postgres-replicated.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/primary-backup-secret/cleanup.sh
+++ b/examples/ocp-templates/primary-backup-secret/cleanup.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-postgres-backup-template
+oc delete template crunchy-postgres-backup-secret-template --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/primary-backup-secret/run.sh
+++ b/examples/ocp-templates/primary-backup-secret/run.sh
@@ -16,4 +16,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/backup-job.json
+oc create -f $DIR/backup-job.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/primary-backup/cleanup.sh
+++ b/examples/ocp-templates/primary-backup/cleanup.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-postgres-backup-template
+oc delete template crunchy-postgres-backup-template --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/primary-backup/run.sh
+++ b/examples/ocp-templates/primary-backup/run.sh
@@ -16,4 +16,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/backup-job.json
+oc create -f $DIR/backup-job.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/primary-restore-secret/cleanup.sh
+++ b/examples/ocp-templates/primary-restore-secret/cleanup.sh
@@ -11,5 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
- 
-oc delete template crunchy-postgres-primary-restore-secrets-template
+
+oc delete template crunchy-postgres-primary-restore-secrets-template --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/primary-restore-secret/run.sh
+++ b/examples/ocp-templates/primary-restore-secret/run.sh
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/primary-restore.json 
+oc create -f $DIR/primary-restore.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/primary-restore/cleanup.sh
+++ b/examples/ocp-templates/primary-restore/cleanup.sh
@@ -11,5 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
- 
-oc delete template crunchy-postgres-primary-restore-template
+
+oc delete template crunchy-postgres-primary-restore-template --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/primary-restore/run.sh
+++ b/examples/ocp-templates/primary-restore/run.sh
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/primary-restore.json 
+oc create -f $DIR/primary-restore.json  --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/replica-statefulset-secret/cleanup.sh
+++ b/examples/ocp-templates/replica-statefulset-secret/cleanup.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-postgres-replica-template
+oc delete template crunchy-postgres-replica-secrets-template --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/replica-statefulset-secret/run.sh
+++ b/examples/ocp-templates/replica-statefulset-secret/run.sh
@@ -16,4 +16,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/replica.json
+oc create -f $DIR/replica.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/replica-statefulset/cleanup.sh
+++ b/examples/ocp-templates/replica-statefulset/cleanup.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-postgres-replica-template
+oc delete template crunchy-postgres-replica-template --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/replica-statefulset/run.sh
+++ b/examples/ocp-templates/replica-statefulset/run.sh
@@ -16,4 +16,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/replica.json
+oc create -f $DIR/replica.json --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/single-primary/cleanup.sh
+++ b/examples/ocp-templates/single-primary/cleanup.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oc delete template crunchy-postgres-primary-template
+oc delete template crunchy-postgres-primary-template --namespace=${CCP_NAMESPACE?}

--- a/examples/ocp-templates/single-primary/run.sh
+++ b/examples/ocp-templates/single-primary/run.sh
@@ -16,4 +16,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $DIR/cleanup.sh
 
-oc create -f $DIR/primary.json
+oc create -f $DIR/primary.json --namespace=${CCP_NAMESPACE?}


### PR DESCRIPTION
Old `create-all.sh` script didn't work with templates.