### PR TITLE
Remove path override from statefulset

### DIFF
--- a/examples/kube/primary-deployment/replica-statefulset-sc.json
+++ b/examples/kube/primary-deployment/replica-statefulset-sc.json
@@ -146,10 +146,6 @@
                             {
                                 "name": "PGHOST",
                                 "value": "/tmp"
-                            },
-                            {
-                                "name": "PGDATA_PATH_OVERRIDE",
-                                "value": "replica-deployment"
                             }
                         ],
                         "resources": {},

--- a/examples/kube/primary-deployment/replica-statefulset.json
+++ b/examples/kube/primary-deployment/replica-statefulset.json
@@ -146,10 +146,6 @@
                             {
                                 "name": "PGHOST",
                                 "value": "/tmp"
-                            },
-                            {
-                                "name": "PGDATA_PATH_OVERRIDE",
-                                "value": "replica-deployment"
                             }
                         ],
                         "resources": {},


### PR DESCRIPTION
`PG_PATH_OVERRIDE` was being set on NFS/Hostpath examples which caused corruption when trying to scale replicas (they were binding to the same directory).  Removed from storage class example as well for consistency.