### PR TITLE
Add path override to metrics example

### DIFF
--- a/examples/kube/metrics/primary.json
+++ b/examples/kube/metrics/primary.json
@@ -158,6 +158,10 @@
                             {
                                 "name": "PGHOST",
                                 "value": "/tmp"
+                            },
+                            {
+                                "name": "PGDATA_PATH_OVERRIDE",
+                                "value": "primary"
                             }
                         ],
                         "volumeMounts": [

--- a/examples/kube/metrics/replica.json
+++ b/examples/kube/metrics/replica.json
@@ -158,6 +158,10 @@
                             {
                                 "name": "PGHOST",
                                 "value": "/tmp"
+                            },
+                            {
+                                "name": "PGDATA_PATH_OVERRIDE",
+                                "value": "replica"
                             }
                         ],
                         "volumeMounts": [


### PR DESCRIPTION
Added `PG_PATH_OVERRIDE` to metric deployment examples so they use the same data directories if the pods are recreated.