### PR TITLE
Remove shard allocation from EFK example

### DIFF
--- a/examples/kube/centralized-logging/efk/run.sh
+++ b/examples/kube/centralized-logging/efk/run.sh
@@ -22,16 +22,3 @@ ${CCP_CLI?} create -f ${DIR?}/elasticsearch-statefulset.yaml
 ${CCP_CLI?} create -f ${DIR?}/fluentd-configmap.yaml
 ${CCP_CLI?} create -f ${DIR?}/fluentd-daemonset.yaml
 ${CCP_CLI?} create -f ${DIR?}/kibana-deployment.yaml
-
-echo_info "Sleeping until EFK stack is ready.."
-sleep 45
-
-# Replicate shards to all hosts
-URL='http://localhost:9200'
-${CCP_CLI?} exec -ti elasticsearch-logging-0 -n kube-system \
-  -- curl -XPUT "${URL?}/_cluster/settings" -H 'Content-Type: application/json' -d'
-{
-    "transient": {
-        "cluster.routing.allocation.enable": "all"
-    }
-}'


### PR DESCRIPTION
Removed unneeded post-deployment configuration that was causing errors when the elasticsearch pod wasn't ready to accept curl commands.