### PR TITLE
Update liveliness probe to use PGHOST

### DIFF
--- a/bin/postgres/liveness.sh
+++ b/bin/postgres/liveness.sh
@@ -17,5 +17,11 @@ source /opt/cpm/bin/common_lib.sh
 enable_debugging
 
 source /opt/cpm/bin/setenv.sh
+hostname=${HOSTNAME?}
 
-$PGROOT/bin/pg_isready -h $HOSTNAME --dbname=postgres --username=$PG_USER
+if [[ -v PGHOST ]]
+then
+    hostname=${PGHOST}
+fi
+
+$PGROOT/bin/pg_isready -h ${hostname?} --dbname=postgres --username=$PG_USER


### PR DESCRIPTION
Updated liveliness probe to consider `PGHOST` when making liveliness checks (bug where probes would fail when TCP connections are locked down on the host - custom-config-ssl).