### PR TITLE
RHEL PG10 Fixes for permissions, pgdump, backrestrestore issues.

### DIFF
--- a/bin/backrest_restore/common_lib.sh
+++ b/bin/backrest_restore/common_lib.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+# Copyright 2018 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+export NSS_WRAPPER_PASSWD=/tmp/passwd
+export NSS_WRAPPER_GROUP=/tmp/group
+
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+YELLOW="\033[0;33m"
+RESET="\033[0m"
+
+function enable_debugging() {
+    if [[ ${CRUNCHY_DEBUG:-false} == "true" ]]
+    then
+        echo_info "Turning debugging on.."
+        export PS4='+(${BASH_SOURCE}:${LINENO})> ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+        set -x
+    fi
+}
+
+function ose_hack() {
+    export USER_ID=$(id -u)
+    export GROUP_ID=$(id -g)
+    envsubst < /opt/cpm/conf/passwd.template > /tmp/passwd
+    envsubst < /opt/cpm/conf/group.template > /tmp/group
+}
+
+function env_check_err() {
+    if [[ -z ${!1} ]]
+    then
+        echo_err "$1 environment variable is not set, aborting."
+        exit 1
+    fi
+}
+
+function env_check_warn() {
+    if [[ -z ${!1} ]]
+    then
+        echo_warn "$1 environment variable is not set."
+    fi
+}
+
+function env_check_info() {
+    if [[ ! -z ${!1} ]]
+    then
+        echo_info "$2"
+    fi
+}
+
+function dir_check_err() {
+    if [[ ! -d ${1} ]]
+    then
+        echo_err "The $1 directory does not exist and is required."
+        exit 1
+    fi
+}
+
+function echo_err() {
+    echo -e "${RED?}$(date) ERROR: ${1?}${RESET?}"
+}
+
+function echo_info() {
+    echo -e "${GREEN?}$(date) INFO: ${1?}${RESET?}"
+}
+
+function echo_warn() {
+    echo -e "${YELLOW?}$(date) WARN: ${1?}${RESET?}"
+}
+
+function pgisready() {
+    export PGROOT=$(find /usr/ -type d -name 'pgsql-*')
+    local dbname=${1?}
+    local dbhost=${2?}
+    local dbport=${3?}
+    local dbuser=${4?}
+    local max_attempts=${5:-5}
+    local timeout=${6:-2}
+    test_server ${dbname?} ${dbhost?} ${dbport?} ${dbuser?} ${max_attempts?} ${timeout?}
+    test_query ${dbname?} ${dbhost?} ${dbport?} ${dbuser?} ${max_attempts?} ${timeout?}
+}
+
+# Check if PostgreSQL is ready with exponential backoffs on attempts
+function test_server() {
+    local dbname=${1?}
+    local dbhost=${2?}
+    local dbport=${3?}
+    local dbuser=${4?}
+    local max_attempts=${5:-5}
+    local timeout=${6:-2}
+    local attempt=0
+    local error='false'
+
+    echo_info "Waiting for PostgreSQL to be ready.."
+    while [[ ${attempt?} < ${max_attempts?} ]]
+    do
+        ${PGROOT?}/bin/pg_isready \
+            --dbname=${dbname?} --host=${dbhost?} \
+            --port=${dbport?} --username=${dbuser?}
+        if [[ $? -eq 0 ]]
+        then
+            error='false'
+            break
+        fi
+        error='true'
+        sleep ${timeout?}
+        attempt=$(( attempt + 1 ))
+        timeout=$(( timeout * 2 ))
+    done
+
+    if [[ ${error?} == 'true' ]]
+    then
+        echo_err "Could not connect to PostgreSQL: Host=${dbhost?}:${dbport?} DB=${dbname?} User=${dbuser?}"
+        exit 1
+    fi
+}
+
+# Check if PostgreSQL is ready with exponential backoffs on attempts
+function test_query {
+    local dbname=${1?}
+    local dbhost=${2?}
+    local dbport=${3?}
+    local dbuser=${4?}
+    local max_attempts=${5:-5}
+    local timeout=${6:-2}
+    local attempt=0
+    local error='false'
+
+    echo_info "Checking if PostgreSQL is accepting queries.."
+    while [[ ${attempt?} < ${max_attempts?} ]]
+    do
+        ${PGROOT?}/bin/psql \
+            --dbname=${dbname?} --host=${dbhost?} \
+            --port=${dbport?} --username=${dbuser?} \
+            --command="SELECT now();"
+        if [[ $? -eq 0 ]]
+        then 
+            error='false'
+            break
+        fi
+        error='true'
+        sleep ${timeout?}
+        attempt=$(( attempt + 1 ))
+        timeout=$(( timeout * 2 ))
+    done
+
+    if [[ ${error?} == 'true' ]]
+    then
+        echo_err "Could not run query against PostgreSQL: Host=${dbhost?}:${dbport?} DB=${dbname?} User=${dbuser?}"
+        exit 1
+    fi
+}

--- a/bin/backrest_restore/start.sh
+++ b/bin/backrest_restore/start.sh
@@ -17,6 +17,7 @@ set -e
 
 source /opt/cpm/bin/common_lib.sh
 enable_debugging
+ose_hack
 
 env_check_err "STANZA"
 

--- a/bin/common/uid_postgres.sh
+++ b/bin/common/uid_postgres.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
 if ! whoami &> /dev/null; then
   if [ -w /etc/passwd ]; then
-    echo "${USER_NAME:-postgres}:x:$(id -u):0:${USER_NAME:-postgres} user:${HOME}:/bin/bash" >> /etc/passwd
+    echo "${USER_NAME:-postgres}:x:$(id -u):26:${USER_NAME:-postgres} user:${HOME}:/bin/bash" >> /etc/passwd
+  fi
+  
+  if [ -w /etc/group ]; then
+    echo "nfsnobody:x:65534:" >> /etc/group
+    echo "postgres:x:$(id -u):postgres" >> /etc/group
   fi
 fi
 exec "$@"
+ 

--- a/bin/postgres/setenv.sh
+++ b/bin/postgres/setenv.sh
@@ -32,10 +32,10 @@ fi
 export PATH=/opt/cpm/bin:$PGROOT/bin:$PATH
 export LD_LIBRARY_PATH=$PGROOT/lib
 
-# if [[ -d ${PGDATA} ]]; then
-#     chown postgres:postgres ${PGDATA?}
-# fi
+if [[ -d ${PGDATA} ]]; then
+    chown postgres:postgres ${PGDATA?}
+fi
 
-# if [[ -d ${PGWAL} ]]; then
-#     chown postgres:postgres ${PGWAL?}
-# fi
+if [[ -d ${PGWAL} ]]; then
+    chown postgres:postgres ${PGWAL?}
+fi

--- a/bin/remove-all-images.sh
+++ b/bin/remove-all-images.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 for i in \
-restore pgdump postgres-gis prometheus grafana collect pgbadger pgpool \
+restore pgdump pgrestore postgres-gis prometheus grafana collect pgbadger pgpool \
 watch backup postgres pgbouncer pgadmin4 vacuum scheduler upgrade backrest-restore
 do
 	docker rmi -f  $CCP_IMAGE_PREFIX/crunchy-$i:$CCP_IMAGE_TAG

--- a/conf/.bash_profile
+++ b/conf/.bash_profile
@@ -3,3 +3,7 @@
 export PGHOST=/tmp
 export PATH=/usr/pgsql-${PGVERSION}/bin:/opt/cpm/bin:$PATH
 export LD_LIBRARY_PATH=/usr/pgsql-${PGVERSION}/lib
+
+# export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+# export NSS_WRAPPER_PASSWD=/tmp/passwd
+# export NSS_WRAPPER_GROUP=/tmp/group

--- a/conf/.bashrc
+++ b/conf/.bashrc
@@ -3,3 +3,7 @@
 export PGHOST=/tmp
 export PATH=/usr/pgsql-${PGVERSION}/bin:/opt/cpm/bin:$PATH
 export LD_LIBRARY_PATH=/usr/pgsql-${PGVERSION}/lib
+
+# export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+# export NSS_WRAPPER_PASSWD=/tmp/passwd
+# export NSS_WRAPPER_GROUP=/tmp/group

--- a/rhel7/10/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/10/Dockerfile.backrest-restore.rhel7
@@ -34,11 +34,13 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y update && yum -y install  \
 	hostname \
 	gettext \
+	nss_wrapper \
  	procps-ng  \
  && yum -y clean all
 
-RUN yum -y install postgresql10-server  \
-        crunchy-backrest \
+# Doing these separately so postgres user exists when crunchy-backrest is installed.
+RUN yum -y install postgresql10-server  && \
+    yum -y install crunchy-backrest \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"
@@ -50,12 +52,16 @@ ADD conf/.bash_profile /var/lib/pgsql/
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgconf /backrestrepo \
 	/var/lib/pgsql /var/log/pgbackrest
 
-RUN chgrp -R 0 /opt/cpm  \
-	/pgdata /pgconf /backrestrepo  \
-	/var/lib/pgsql /var/log/pgbackrest && \
-    chmod -R g=u /opt/cpm  \
+RUN chown -R postgres:postgres /opt/cpm  \
 	/pgdata /pgconf /backrestrepo  \
 	/var/lib/pgsql /var/log/pgbackrest
+
+#RUN chgrp -R 0 /opt/cpm  \
+#	/pgdata /pgconf /backrestrepo  \
+#	/var/lib/pgsql /var/log/pgbackrest && \
+#    chmod -R g=u /opt/cpm  \
+#	/pgdata /pgconf /backrestrepo  \
+#	/var/lib/pgsql /var/log/pgbackrest
 
 
 # volume pgconf to store pgbackrest.conf
@@ -64,11 +70,17 @@ RUN chgrp -R 0 /opt/cpm  \
 VOLUME /pgconf /pgdata /backrestrepo
 
 ADD bin/backrest_restore /opt/cpm/bin
-ADD bin/common /opt/cpm/bin
+
+#removed to allow separate version of common_lib.sh for this container only. Its in
+# the bin/backrest_restore directory.
+#ADD bin/common /opt/cpm/bin
+
 ADD conf/backrest_restore /opt/cpm/conf
 
-RUN chmod g=u /etc/passwd
-ENTRYPOINT ["opt/cpm/bin/uid_entrypoint.sh"]
+#RUN chmod g=u /etc/passwd && \
+#	chmod g=u /etc/group
+#
+#ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 
 USER 26

--- a/rhel7/10/Dockerfile.postgres.rhel7
+++ b/rhel7/10/Dockerfile.postgres.rhel7
@@ -62,10 +62,11 @@ ADD conf/.bashrc /
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo /sshd
 
 
-RUN chgrp -R 0 /opt/cpm /var/lib/pgsql \
+RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
     /pgdata /pgwal /pgconf /backup /recover /backrestrepo &&  \
     chmod -R g=u /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo
+    /pgdata /pgwal /pgconf /backup /recover /backrestrepo 
+
 
 # Link pgbackrest.conf to default location for convenience
 # Remove nologin file to prevent sshd from being blocked
@@ -90,7 +91,9 @@ ADD bin/common /opt/cpm/bin
 ADD conf/postgres /opt/cpm/conf
 ADD tools/pgmonitor/exporter/postgres /opt/cpm/bin/pgmonitor
 
-RUN chmod g=u /etc/passwd
+RUN chmod g=u /etc/passwd && \
+	chmod g=u /etc/group
+	
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 
 


### PR DESCRIPTION
- Fix missing entry point in backrest restore
- Fix pgdump permissions issue
- Fix issues with password and group files after removing nss_wrapper
- Put nss_wrapper back for backrestrestore container only.
- Fixes are isolated to RHEL PG10 containers only in this PR

Closes CrunchyData/crunchy-containers-test#70
Closes CrunchyData/crunchy-containers-test#98
