### PR TITLE
Remove PGSSL Environment Variables from SSL Examples

### DIFF
--- a/bin/install-deps.sh
+++ b/bin/install-deps.sh
@@ -20,6 +20,7 @@ POSTGRES_EXPORTER_VERSION=0.4.6
 NODE_EXPORTER_VERSION=0.16.0
 PGMONITOR_COMMIT='dffb2b5eb04ba13ee47ae81950410738d15e8c76'
 OPENSHIFT_CLIENT='https://github.com/openshift/origin/releases/download/v3.10.0/openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit.tar.gz'
+CERTSTRAP_VERSION=1.1.1
 
 sudo yum -y install net-tools bind-utils wget unzip git
 
@@ -56,7 +57,11 @@ go get github.com/golang/dep/cmd/dep
 
 # install expenv binary for running examples
 go get github.com/blang/expenv
-go get github.com/square/certstrap
+
+# manually install certstrap into $GOBIN for running the SSL examples
+wget -O $CCPROOT/certstrap https://github.com/square/certstrap/releases/download/v${CERTSTRAP_VERSION}/certstrap-v${CERTSTRAP_VERSION}-linux-amd64 && \
+    mv $CCPROOT/certstrap $GOBIN && \
+    chmod +x $GOBIN/certstrap
 
 # pgMonitor Setup
 if [[ -d ${CCPROOT?}/tools/pgmonitor ]]

--- a/examples/docker/custom-config-ssl/env.sh
+++ b/examples/docker/custom-config-ssl/env.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-export PGSSLROOTCERT=${DIR?}/certs/ca.crt
-export PGSSLCRL=${DIR?}/certs/ca.crl
-export PGSSLCERT=${DIR?}/certs/client.crt
-export PGSSLKEY=${DIR?}/certs/client.key

--- a/examples/docker/custom-config-ssl/run.sh
+++ b/examples/docker/custom-config-ssl/run.sh
@@ -55,6 +55,10 @@ docker run \
 
 echo ""
 echo "To connect via SSL, run the following once the DB is ready: "
-echo "source ./env.sh"
-echo "psql postgresql://0.0.0.0:5432/postgres?sslmode=require -U testuser"
+echo "psql \"postgresql://testuser@${CONTAINER_NAME?}:5432/userdb?\
+sslmode=verify-full&\
+sslrootcert=$CCPROOT/examples/kube/custom-config-ssl/certs/ca.crt&\
+sslcrl=$CCPROOT/examples/kube/custom-config-ssl/certs/ca.crl&\
+sslcert=$CCPROOT/examples/kube/custom-config-ssl/certs/client.crt&\
+sslkey=$CCPROOT/examples/kube/custom-config-ssl/certs/client.key\""
 echo ""

--- a/examples/kube/custom-config-ssl/env.sh
+++ b/examples/kube/custom-config-ssl/env.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-export PGSSLROOTCERT=${DIR?}/certs/ca.crt
-export PGSSLCRL=${DIR?}/certs/ca.crl
-export PGSSLCERT=${DIR?}/certs/client.crt
-export PGSSLKEY=${DIR?}/certs/client.key

--- a/examples/kube/custom-config-ssl/run.sh
+++ b/examples/kube/custom-config-ssl/run.sh
@@ -51,11 +51,10 @@ expenv -f $DIR/custom-config-ssl.json | ${CCP_CLI?} create --namespace=${CCP_NAM
 
 echo ""
 echo "To connect via SSL, run the following once the DB is ready: "
-echo "psql "postgresql://${CONTAINER_NAME?}:5432/postgres?sslmode=verify-full" -U testuser"
+echo "psql \"postgresql://testuser@${CONTAINER_NAME?}:5432/userdb?\
+sslmode=verify-full&\
+sslrootcert=$CCPROOT/examples/kube/custom-config-ssl/certs/ca.crt&\
+sslcrl=$CCPROOT/examples/kube/custom-config-ssl/certs/ca.crl&\
+sslcert=$CCPROOT/examples/kube/custom-config-ssl/certs/client.crt&\
+sslkey=$CCPROOT/examples/kube/custom-config-ssl/certs/client.key\""
 echo ""
-
-echo -e "${YELLOW?}"
-echo "Note: The SSL certificates generated are not in the default location, it is required to "
-echo "source the env.sh script in this directory prior to running psql:"
-echo "source ${CCPROOT?}/examples/kube/custom-config-ssl/env.sh"
-echo -e "${RESET?}"

--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -2103,18 +2103,6 @@ and client) for the example: `$CCPROOT/examples/ssl-creator.sh`.
 The example creates a client certificate for the user `testuser`.  Furthermore,
 the server certificate is created for the server name `custom-config-ssl`.
 
-If as a client it's required to confirm the identity of the server, `verify-full` can be
-specified in the connection string.  This will check if the server and the server certificate
-have the same name:
-....
-psql postgresql://custom-config-ssl:5432/postgres?sslmode=verify-full -U testuser"
-....
-
-To connect via IP, `sslmode` can be changed to `require`.
-....
-psql postgresql://IP_OF_PGSQL:5432/postgres?sslmode=require -U testuser"
-....
-
 This example can be run as follows for the Docker environment:
 ....
 cd $CCPROOT/examples/docker/custom-config-ssl
@@ -2148,26 +2136,35 @@ names to resolve to the PostgreSQL service name and generate
 server certificates using the DNS names instead of the example
 name `custom-config-ssl`.
 
-In order to connect via certificate, environment variables must be set that point
-to the client certificates.  Source the `env.sh` file to set environment varaibles
-for the example:
-
-....
-source env.sh
-....
-
 If as a client it's required to confirm the identity of the server, `verify-full` can be
-specified in the connection string.  This will check if the server and the server certificate
-have the same name:
+specified for `ssl-mode` in the connection string.  This will check if the server and the
+server certificate have the same name.  Additionally, the proper connection parameters 
+must be specified in the connection string for the certificate information required to 
+trust and verify the identity of the server (`sslrootcert` and `sslcrl`), and to 
+authenticate the client using a certificate (`sslcert` and `sslkey`):
 
 ....
-psql postgresql://custom-config-ssl:5432/userdb?sslmode=verify-full -U testuser"
+psql "postgresql://testuser@custom-config-ssl:5432/userdb?\
+sslmode=verify-full&\
+sslrootcert=$CCPROOT/examples/kube/custom-config-ssl/certs/ca.crt&\
+sslcrl=$CCPROOT/examples/kube/custom-config-ssl/certs/ca.crl&\
+sslcert=$CCPROOT/examples/kube/custom-config-ssl/certs/client.crt&\
+sslkey=$CCPROOT/examples/kube/custom-config-ssl/certs/client.key"
 ....
 
-To connect via IP, `sslmode` can be changed to `require`.
+To connect via IP, `sslmode` can be changed to `require`.  This will verify the server 
+by checking the certificate chain up to the trusted certificate authority, but will not
+verify that the hostname matches the certificate, as occurs with `verify-full`.  The same
+connection parameters as above can be then provided for the client and server certificate
+information.
 
 ....
-psql postgresql://IP_OF_PGSQL:5432/userdb?sslmode=require -U testuser"
+psql "postgresql://testuser@IP_OF_PGSQL:5432/userdb?\
+sslmode=require&\
+sslrootcert=$CCPROOT/examples/kube/custom-config-ssl/certs/ca.crt&\
+sslcrl=$CCPROOT/examples/kube/custom-config-ssl/certs/ca.crl&\
+sslcert=$CCPROOT/examples/kube/custom-config-ssl/certs/client.crt&\
+sslkey=$CCPROOT/examples/kube/custom-config-ssl/certs/client.key"
 ....
 
 You should see a connection that looks like the following:

--- a/hugo/content/installation/storage-configuration.adoc
+++ b/hugo/content/installation/storage-configuration.adoc
@@ -53,8 +53,10 @@ export CCP_STORAGE_MODE=ReadWriteMany
 export CCP_STORAGE_CAPACITY=400M
 ....
 
-In this example above the group ownership of the NFS mount is assumed to be
-*nfsnobody* or *65534*.
+In the example above the group ownership of the NFS mount is assumed to be
+*nfsnobody* or *65534*.  Additionally, it is recommended that root not be squashed on 
+the NFS share (`no_root_squash`) in order to ensure the proper directories can be 
+created, modified and removed as needed for the various container examples.
 
 {{% notice warning %}}
 The examples in the Crunchy Container suite need access to the NFS export to create


### PR DESCRIPTION
Removed the PGSSL environment variables from the SSL examples.  This is because these environment variables cannot be cleaned up through the execution of cleanup.sh script, which will not have access to the environment variables of the parent process when executed.  This leads to issues running other examples, since PGSSL environment variables remain set within the users environment.

This PR therefore modifies the SSL examples and all associated documentation to use connection string parameters instead of the environment variables to specify the various certificate information needed for to run these examples.

Also certstrap (required for the SSL examples) is now installed using pre-built releases from Github.com, instead of building from source.  This addresses and incompatibility issue between the current version of Go supported by the CentOS/RHEL (v1.9.4), that prevents a successful build of the current master branch for certstrp, which requires Go v1.11.

Closes CrunchyData/crunchy-containers-test#59

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
As described in CrunchyData/crunchy-containers-test#59, the PGSSL environment variables that are currently set when running the SSL examples are not properly cleaned up after running the example, leading to issues when susequently running the test harness and/or other examples.


**What is the new behavior (if this is a feature change)?**
Connection string parameters are now used instead of the PGSSL environment variables.


**Other information**:
