### PR TITLE
Fix pgbadger docker example

### DIFF
--- a/examples/docker/pgbadger/run.sh
+++ b/examples/docker/pgbadger/run.sh
@@ -18,6 +18,9 @@ ${DIR?}/cleanup.sh
 
 docker network create --driver bridge pgnet
 
+docker volume create --driver local --name=pg-primary
+docker volume create --driver local --name=report
+
 docker run \
     -p 5432:5432 \
     -v pg-primary:/pgdata \


### PR DESCRIPTION
Adding volume creation to support installations of docker that don't automatically make volumes.

Closes CrunchyData/crunchy-containers-test#113