### PR TITLE
Fix metrics example namespacing collision

### DIFF
--- a/examples/kube/metrics/cleanup.sh
+++ b/examples/kube/metrics/cleanup.sh
@@ -20,8 +20,8 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} clusterrolebinding prometheus-s
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} clusterrole prometheus-sa
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} sa prometheus-sa
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod metrics
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment primary replica
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service metrics primary replica
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment primary-metrics replica-metrics
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service metrics primary-metrics replica-metrics
 
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc metrics-prometheusdata metrics-grafanadata
 
@@ -30,7 +30,7 @@ if [ -z "$CCP_STORAGE_CLASS" ]; then
 fi
 
 $CCPROOT/examples/waitforterm.sh metrics ${CCP_CLI?}
-$CCPROOT/examples/waitforterm.sh primary ${CCP_CLI?}
-$CCPROOT/examples/waitforterm.sh replica ${CCP_CLI?}
+$CCPROOT/examples/waitforterm.sh primary-metrics ${CCP_CLI?}
+$CCPROOT/examples/waitforterm.sh replica-metrics ${CCP_CLI?}
 
 dir_check_rm "metrics"

--- a/examples/kube/metrics/primary.json
+++ b/examples/kube/metrics/primary.json
@@ -2,15 +2,15 @@
     "kind": "Service",
     "apiVersion": "v1",
     "metadata": {
-        "name": "primary",
+        "name": "primary-metrics",
         "labels": {
-            "name": "primary"
+            "name": "primary-metrics"
         }
     },
     "spec": {
         "ports": [
             {
-                "name": "primary",
+                "name": "primary-metrics",
                 "protocol": "TCP",
                 "port": 5432,
                 "targetPort": 5432,
@@ -32,7 +32,7 @@
             }
         ],
         "selector": {
-            "name": "primary"
+            "name": "primary-metrics"
         },
         "type": "ClusterIP",
         "sessionAffinity": "None"
@@ -43,9 +43,9 @@
     "kind": "Deployment",
     "apiVersion": "extensions/v1beta1",
     "metadata": {
-        "name": "primary",
+        "name": "primary-metrics",
         "labels": {
-            "name": "primary"
+            "name": "primary-metrics"
         }
     },
     "spec": {
@@ -53,7 +53,7 @@
         "template": {
             "metadata": {
                 "labels": {
-                    "name": "primary",
+                    "name": "primary-metrics",
                     "crunchy_collect": "true"
                 }
             },
@@ -93,7 +93,7 @@
                             },
                             {
                                 "name": "JOB_NAME",
-                                "value": "primary"
+                                "value": "primary-metrics"
                             }
                         ]
                     },
@@ -161,7 +161,7 @@
                             },
                             {
                                 "name": "PGDATA_PATH_OVERRIDE",
-                                "value": "primary"
+                                "value": "primary-metrics"
                             }
                         ],
                         "volumeMounts": [

--- a/examples/kube/metrics/replica.json
+++ b/examples/kube/metrics/replica.json
@@ -2,15 +2,15 @@
     "kind": "Service",
     "apiVersion": "v1",
     "metadata": {
-        "name": "replica",
+        "name": "replica-metrics",
         "labels": {
-            "name": "replica"
+            "name": "replica-metrics"
         }
     },
     "spec": {
         "ports": [
             {
-                "name": "replica",
+                "name": "replica-metrics",
                 "protocol": "TCP",
                 "port": 5432,
                 "targetPort": 5432,
@@ -32,7 +32,7 @@
             }
         ],
         "selector": {
-            "name": "replica"
+            "name": "replica-metrics"
         },
         "type": "ClusterIP",
         "sessionAffinity": "None"
@@ -43,9 +43,9 @@
     "kind": "Deployment",
     "apiVersion": "extensions/v1beta1",
     "metadata": {
-        "name": "replica",
+        "name": "replica-metrics",
         "labels": {
-            "name": "replica"
+            "name": "replica-metrics"
         }
     },
     "spec": {
@@ -53,7 +53,7 @@
         "template": {
             "metadata": {
                 "labels": {
-                    "name": "replica",
+                    "name": "replica-metrics",
                     "crunchy_collect": "true"
                 }
             },
@@ -133,7 +133,7 @@
                             },
                             {
                                 "name": "PG_PRIMARY_HOST",
-                                "value": "primary"
+                                "value": "primary-metrics"
                             },
                             {
                                 "name": "PG_USER",
@@ -161,7 +161,7 @@
                             },
                             {
                                 "name": "PGDATA_PATH_OVERRIDE",
-                                "value": "replica"
+                                "value": "replica-metrics"
                             }
                         ],
                         "volumeMounts": [

--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -2405,10 +2405,10 @@ You can view the container logs using these command:
 ....
 ${CCP_CLI} logs -c grafana metrics
 ${CCP_CLI} logs -c prometheus metrics
-${CCP_CLI} logs -c collect primary
-${CCP_CLI} logs -c postgres primary
-${CCP_CLI} logs -c collect replica
-${CCP_CLI} logs -c postgres replica
+${CCP_CLI} logs -c collect primary-metrics
+${CCP_CLI} logs -c postgres primary-metrics
+${CCP_CLI} logs -c collect replica-metrics
+${CCP_CLI} logs -c postgres replica-metrics
 ....
 
 === pg_audit

--- a/tools/test-harness/metrics_test.go
+++ b/tools/test-harness/metrics_test.go
@@ -21,21 +21,21 @@ func TestMetrics(t *testing.T) {
 	}
 
 	t.Log("Checking if primary deployment is ready...")
-	if ok, err := harness.Client.IsDeploymentReady(harness.Namespace, "primary"); !ok {
+	if ok, err := harness.Client.IsDeploymentReady(harness.Namespace, "primary-metrics"); !ok {
 		t.Fatal(err)
 	}
 
 	t.Log("Checking if replica deployment is ready...")
-	if ok, err := harness.Client.IsDeploymentReady(harness.Namespace, "replica"); !ok {
+	if ok, err := harness.Client.IsDeploymentReady(harness.Namespace, "replica-metrics"); !ok {
 		t.Fatal(err)
 	}
 
-	primary, err := harness.Client.GetDeploymentPods(harness.Namespace, "primary")
+	primary, err := harness.Client.GetDeploymentPods(harness.Namespace, "primary-metrics")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	replica, err := harness.Client.GetDeploymentPods(harness.Namespace, "replica")
+	replica, err := harness.Client.GetDeploymentPods(harness.Namespace, "replica-metrics")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The databases included in the metrics example caused a collision with other examples due to similar naming conventions.  Changed their names to be more explicit: `primary-metrics` and `replica-metrics`.

Closes CrunchyData/crunchy-containers-test#87.