### PR TITLE
Fix primary docker example

### DIFF
--- a/examples/docker/primary/run.sh
+++ b/examples/docker/primary/run.sh
@@ -19,6 +19,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 $DIR/cleanup.sh
 
 docker network create --driver bridge pgnet
+docker volume create --driver local --name=primary-pgdata
 
 docker run \
     -p 5432:5432 \


### PR DESCRIPTION
Adding volume creation to support installations of docker that don't automatically make volumes.

Closes CrunchyData/crunchy-containers-test#112.