### PR TITLE
Fix PITR NFS example

### DIFF
--- a/examples/kube/pitr/backup-pitr-pv-nfs.json
+++ b/examples/kube/pitr/backup-pitr-pv-nfs.json
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/pitr",
+            "path": "$CCP_STORAGE_PATH/backup-pitr",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/pitr/backup-pitr-pv.json
+++ b/examples/kube/pitr/backup-pitr-pv.json
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/pitr"
+            "path": "$CCP_STORAGE_PATH/backup-pitr"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/pitr/cleanup.sh
+++ b/examples/kube/pitr/cleanup.sh
@@ -30,3 +30,5 @@ if [ -z "$CCP_STORAGE_CLASS" ]; then
 fi
 
 dir_check_rm "pitr"
+dir_check_rm "backup-pitr"
+dir_check_rm "restore-pitr"

--- a/examples/kube/pitr/restore-pitr-pv-nfs.json
+++ b/examples/kube/pitr/restore-pitr-pv-nfs.json
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/pitr",
+            "path": "$CCP_STORAGE_PATH/restore-pitr",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -35,7 +35,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/pitr",
+            "path": "$CCP_STORAGE_PATH/restore-pitr",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/pitr/restore-pitr-pv.json
+++ b/examples/kube/pitr/restore-pitr-pv.json
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/pitr"
+            "path": "$CCP_STORAGE_PATH/restore-pitr"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -34,7 +34,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/pitr"
+            "path": "$CCP_STORAGE_PATH/restore-pitr"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/pitr/restore-pitr.json
+++ b/examples/kube/pitr/restore-pitr.json
@@ -113,11 +113,11 @@
                     },
                     {
                         "name": "BACKUP_PATH",
-                        "value": "pitr-backups/2018-05-05-00-50-49"
+                        "value": "pitr-backups/TIMESTAMP_HERE"
                     },
                     {
                         "name": "RECOVERY_TARGET_NAME",
-                        "value": "afterchanges"
+                        "value": "beforechanges"
                     },
                     {
                         "name": "PGHOST",

--- a/examples/kube/pitr/run-backup-pitr.sh
+++ b/examples/kube/pitr/run-backup-pitr.sh
@@ -18,12 +18,14 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc backup-pitr-pgdata
-if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv backup-pitr-pgdata
-fi
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job backup-pitr
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc backup-pitr-pgdata
+if [[ -z "$CCP_STORAGE_CLASS" ]]
+then
+    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv backup-pitr-pgdata
+fi
 
+dir_check_rm "backup-pitr"
 create_storage "backup-pitr"
 if [[ $? -ne 0 ]]
 then

--- a/examples/kube/pitr/run-restore-pitr.sh
+++ b/examples/kube/pitr/run-restore-pitr.sh
@@ -18,16 +18,19 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod restore-pitr
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod pitr
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} svc restore-pitr
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod restore-pitr pitr
+
 $CCPROOT/examples/waitforterm.sh pitr ${CCP_CLI?}
 $CCPROOT/examples/waitforterm.sh restore-pitr ${CCP_CLI?}
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc recover-pvc restore-pitr-pgdata
-if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv recover-pv restore-pitr-pgdata
-fi
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} svc restore-pitr
 
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc recover-pvc restore-pitr-pgdata
+if [[ -z "$CCP_STORAGE_CLASS" ]]
+then
+    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv recover-pv restore-pitr-pgdata
+fi
+
+dir_check_rm "restore-pitr"
 create_storage "restore-pitr"
 if [[ $? -ne 0 ]]
 then


### PR DESCRIPTION
PITR example wasn't mounting proper directories causing cleanup scripts to delete needed data (such as backups and WAL).

Closes CrunchyData/crunchy-containers-test#126