### PR TITLE
Added Requirement to Run 'make setup' When Using Pre-built Containers

### DIFF
--- a/hugo/content/installation/build-the-containers.adoc
+++ b/hugo/content/installation/build-the-containers.adoc
@@ -13,12 +13,14 @@ Latest Release: 2.2.0 {docdate}
 At this point, you have a decision to make - either download prebuilt
 containers from link:https://hub.docker.com/[Dockerhub], *or* build the containers on your local host.
 
-To download the prebuilt containers, make sure you can login to
-link:https://hub.docker.com/[Dockerhub], and then run the following:
+To download the prebuilt containers and install the dependencies required to run the 
+container examples, make sure you can login to link:https://hub.docker.com/[Dockerhub],
+and then run the following:
 ....
 docker login
 cd $CCPROOT
 ./bin/pull-from-dockerhub.sh
+make setup
 ....
 
 Or if you'd rather build the containers from source, perform a container


### PR DESCRIPTION
Updated the **Build the Containers** section of the docs to specify that `make setup` should be run even when using pre-built containers.  This will ensure any dependencies required to run the container examples are installed, e.g. **certstrap** for the **Custom Config SSL** examples.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The **Build the Containers** section of the docs does not specify that `make setup` should be run when using the pre-built containers.  This leads to errors/issues when running any examples that require any of the dependencies installed via `make setup`, e.g. **certstrap** for the **Custom Config SSL** examples.


**What is the new behavior (if this is a feature change)?**
The docs specify that `make setup` should be run to install the dependencies required for the examples, even when using the pre-built containers.
