### PR TITLE
Removed pgBadger Instructions for golang & Enabling the 'server optional' repository on RHEL 7

### DIFF
--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -2278,13 +2278,6 @@ illustrates how to view the generated reports.
 The port utilized for this tool is port 14000 for Docker environments and port 10000
 for Kubernetes and OpenShift environments.
 
-A requirement to build this container from source is *golang*. On RHEL 7.2, golang
-is found in the 'server optional' repository which needs to be enabled in order to install
-this dependency.
-....
-sudo subscription-manager repos --enable=rhel-7-server-optional-rpms
-....
-
 The container creates a default database called *userdb*, a default user called
 *testuser* and a default password of *password*.
 


### PR DESCRIPTION
Removed the instructions under the **pgBadger** example for installing **golang** and enabling the **server optional** repository on RHEL 7 since these steps are already covered under section **Installing Requirements** on the **Environment Setup** page.

Closes  CrunchyData/crunchy-containers-test#92 

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Despite already being covered under section **Installing Requirements** on the **Environment Setup** page, the pgBadger example has instructions for enabling the **server optional** repository on RHEL 7 in order to install **golang**.


**What is the new behavior (if this is a feature change)?**
The pgBadger example with no longer have instructions for enabling the **server optional** repository on RHEL 7 in order to install **golang**.  These steps will have already been accomplished by following the instructions defined under **Installing Requirements** on the **Environment Setup** page.

