### PR TITLE
Fix load balancing in pgpool example

### DIFF
--- a/examples/kube/pgpool/configs/pgpool.conf
+++ b/examples/kube/pgpool/configs/pgpool.conf
@@ -54,12 +54,12 @@ pcp_socket_dir = '/tmp'
 
 backend_hostname0 = 'pr-primary'
 backend_port0 = 5432
-backend_weight0= 1
+backend_weight0= .5
 backend_flag0= 'DISALLOW_TO_FAILOVER'
 
 backend_hostname1 = 'pr-replica'
 backend_port1 = 5432
-backend_weight1= 1
+backend_weight1= .5
 backend_flag1= 'DISALLOW_TO_FAILOVER'
 
 #backend_hostname0 = 'master'
@@ -259,7 +259,7 @@ failover_if_affected_tuples_mismatch = off
 # LOAD BALANCING MODE
 #------------------------------------------------------------------------------
 
-load_balance_mode = off
+load_balance_mode = on
                                    # Activate load balancing mode
                                    # (change requires restart)
 ignore_leading_white_space = on
@@ -476,7 +476,7 @@ wd_authkey = ''
 
 delegate_IP = ''
                                     # delegate IP address
-                                    # If this is empty, virtual IP never bring up. 
+                                    # If this is empty, virtual IP never bring up.
                                     # (change requires restart)
 ifconfig_path = '/sbin'
                                     # ifconfig command path
@@ -508,7 +508,7 @@ wd_escalation_command = ''
                                     # Executes this command at escalation on new active pgpool.
                                     # (change requires restart)
 
-# - Lifecheck Setting - 
+# - Lifecheck Setting -
 
 # -- common --
 
@@ -534,7 +534,7 @@ heartbeat_destination0 = 'host0_ip1'
                                     # Host name or IP address of destination 0
                                     # for sending heartbeat signal.
                                     # (change requires restart)
-heartbeat_destination_port0 = 9694 
+heartbeat_destination_port0 = 9694
                                     # Port number of destination 0 for sending
                                     # heartbeat signal. Usually this is the
                                     # same as wd_heartbeat_port.


### PR DESCRIPTION
Load balancing was not enabled so selects were only going to primary.

Works now:

```bash
[~]$ psql -d postgres -U testuser -h pgpool -c "show pool_nodes" -x
-[ RECORD 1 ]-----+-----------
node_id           | 0
hostname          | pr-primary
port              | 5432
status            | up
lb_weight         | 0.500000
role              | primary
select_cnt        | 14525
load_balance_node | true
replication_delay | 0
-[ RECORD 2 ]-----+-----------
node_id           | 1
hostname          | pr-replica
port              | 5432
status            | up
lb_weight         | 0.500000
role              | standby
select_cnt        | 10804
load_balance_node | false
replication_delay | 0
```

Closes CrunchyData/crunchy-containers-test#121