### PR TITLE
Add probes to PITR example

### DIFF
--- a/examples/kube/pitr/pitr.json
+++ b/examples/kube/pitr/pitr.json
@@ -44,6 +44,24 @@
             {
                 "name": "postgres",
                 "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                "readinessProbe": {
+                    "exec": {
+                        "command": [
+                            "/opt/cpm/bin/readiness.sh"
+                        ]
+                    },
+                    "initialDelaySeconds": 40,
+                    "timeoutSeconds": 1
+                },
+                "livenessProbe": {
+                    "exec": {
+                        "command": [
+                            "/opt/cpm/bin/liveness.sh"
+                        ]
+                    },
+                    "initialDelaySeconds": 40,
+                    "timeoutSeconds": 1
+                },
                 "ports": [
                     {
                         "containerPort": 5432,

--- a/examples/kube/pitr/restore-pitr.json
+++ b/examples/kube/pitr/restore-pitr.json
@@ -68,6 +68,24 @@
             {
                 "name": "postgres",
                 "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                "readinessProbe": {
+                    "exec": {
+                        "command": [
+                            "/opt/cpm/bin/readiness.sh"
+                        ]
+                    },
+                    "initialDelaySeconds": 40,
+                    "timeoutSeconds": 1
+                },
+                "livenessProbe": {
+                    "exec": {
+                        "command": [
+                            "/opt/cpm/bin/liveness.sh"
+                        ]
+                    },
+                    "initialDelaySeconds": 40,
+                    "timeoutSeconds": 1
+                },
                 "ports": [
                     {
                         "containerPort": 5432,


### PR DESCRIPTION
Lack of probes was causing testers to get `psql` failures due to PostgreSQL not being ready yet.

Closes CrunchyData/crunchy-containers-test#99