### PR TITLE
Fix typo in upgrade containers

### DIFF
--- a/centos7/11/Dockerfile.upgrade.centos7
+++ b/centos7/11/Dockerfile.upgrade.centos7
@@ -34,7 +34,7 @@ RUN yum -y update && yum install -y epel-release \
  && yum -y install \
  postgresql95 postgresql95-server postgresql95-contrib pgaudit_95 \
  postgresql96 postgresql96-server postgresql96-contrib pgaudit_96 \
- postgresql10 postgresql11-server postgresql10-contrib pgaudit12_10 \
+ postgresql10 postgresql10-server postgresql10-contrib pgaudit12_10 \
  postgresql11 postgresql11-server postgresql11-contrib pgaudit12_11 \
  && yum clean all -y
 

--- a/rhel7/11/Dockerfile.upgrade.rhel7
+++ b/rhel7/11/Dockerfile.upgrade.rhel7
@@ -45,7 +45,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y install \
  postgresql95 postgresql95-server postgresql95-contrib pgaudit95 \
  postgresql96 postgresql96-server postgresql96-contrib pgaudit96 \
- postgresql10 postgresql11-server postgresql10-contrib pgaudit10 \
+ postgresql10 postgresql10-server postgresql10-contrib pgaudit10 \
  postgresql11 postgresql11-server postgresql11-contrib pgaudit11 \
  && yum clean all -y
 


### PR DESCRIPTION
New upgrade containers for PG11 weren't installing PG10 server packages which caused upgrades to fail.