### PR TITLE
Add better error handling to vacuum

### DIFF
--- a/bin/vacuum/start-vacuum.sh
+++ b/bin/vacuum/start-vacuum.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 # Copyright 2016 - 2018 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+set -e
 
 source /opt/cpm/bin/common_lib.sh
 enable_debugging

--- a/vacuum/vacuum.go
+++ b/vacuum/vacuum.go
@@ -43,14 +43,14 @@ func main() {
 	if err != nil {
 		logger.Println("could not connect to " + parms.JOB_HOST)
 		logger.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 	defer conn.Close()
 	err = vacuumCommand(parms, conn)
 	if err != nil {
 		logger.Println(err.Error())
 		logger.Println("error performing query")
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 }


### PR DESCRIPTION
Vacuum job would not error if pod could not be found.  Adding harder exits and checks in the app and container script.

Closes CrunchyData/crunchy-containers-test#79.