### PR TITLE
Remove securityContext from emptyDir examples, fix doc

### DIFF
--- a/examples/kube/metrics/primary.json
+++ b/examples/kube/metrics/primary.json
@@ -189,10 +189,7 @@
                 ],
                 "restartPolicy": "Always",
                 "terminationGracePeriodSeconds": 30,
-                "dnsPolicy": "ClusterFirst",
-                "securityContext": {
-                    $CCP_SECURITY_CONTEXT
-                }
+                "dnsPolicy": "ClusterFirst"
             }
         },
         "strategy": {

--- a/examples/kube/metrics/replica.json
+++ b/examples/kube/metrics/replica.json
@@ -189,10 +189,7 @@
                 ],
                 "restartPolicy": "Always",
                 "terminationGracePeriodSeconds": 30,
-                "dnsPolicy": "ClusterFirst",
-                "securityContext": {
-                    $CCP_SECURITY_CONTEXT
-                }
+                "dnsPolicy": "ClusterFirst"
             }
         },
         "strategy": {

--- a/examples/kube/primary-replica-dc/primary-replica-dc.json
+++ b/examples/kube/primary-replica-dc/primary-replica-dc.json
@@ -60,9 +60,6 @@
         }
     },
     "spec": {
-        "securityContext": {
-            $CCP_SECURITY_CONTEXT
-        },
         "containers": [
             {
                 "name": "postgres",
@@ -166,7 +163,7 @@
         }
     },
     "spec": {
-        "replicas": 2,
+        "replicas": 1,
         "selector": {
             "matchLabels": {
                 "name": "replica-dc"
@@ -179,9 +176,6 @@
                 }
             },
             "spec": {
-                "securityContext": {
-                    $CCP_SECURITY_CONTEXT
-                },
                 "containers": [
                     {
                         "name": "postgres",

--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -1728,12 +1728,9 @@ The container creates a default database called *userdb*, a default user called
 
 This example will create the following in your Kubernetes and OpenShift environments:
 
- * primary-deployment service which uses a PVC to persist PostgreSQL data
- * replica-deployment service, uses emptyDir persistence
- * primary-deployment deployment of replica count 1 for the primary
-   PostgreSQL database pod
- * replica-deployment deployment of replica count 1 for the replica
- * replica2-deployment deployment of replica count 1 for the 2nd replica
+ * primary and replica services
+ * primary-deployment deployment
+ * replica-deployment statefulset
  * ConfigMap to hold a custom `postgresql.conf`, `setup.sql`, and
    `pg_hba.conf` files
  * Secrets for the primary user, superuser, and normal user to
@@ -1757,6 +1754,18 @@ Start the example as follows:
 cd $CCPROOT/examples/kube/primary-deployment
 ./run.sh
 ....
+
+To scale the replica statefulset, run the following command:
+
+....
+${CCP_CLI?} scale --replicas=2 statefulset replica-deployment
+....
+
+{{% notice warning %}}
+This example only creates enough Persistent Volumes for a maximum of 2 replicas.
+If you are not using storage classes, the maximum amount of replicas this example can
+be scaled to is 2.
+{{% /notice %}}
 
 === Replication
 
@@ -1806,6 +1815,7 @@ psql -h localhost -p 12008 -U testuser -W userdb
 ==== Kubernetes and OpenShift
 
 Run the following command to deploy a primary and replica database cluster:
+
 ....
 cd $CCPROOT/examples/kube/primary-replica
 ./run.sh
@@ -1814,25 +1824,30 @@ cd $CCPROOT/examples/kube/primary-replica
 It takes about a minute for the replica to begin replicating with the
 primary.  To test out replication, see if replication is underway
 with this command:
+
 ....
-psql -h pr-primary -U postgres postgres -c 'table pg_stat_replication'
+${CCP_CLI?} exec -ti pr-primary -- psql -d postgres -c 'table pg_stat_replication'
 ....
 
 If you see a line returned from that query it means the primary is replicating
 to the replica.  Try creating some data on the primary:
+
 ....
-psql -h pr-primary -U postgres postgres -c 'create table foo (id int)'
-psql -h pr-primary -U postgres postgres -c 'insert into foo values (1)'
+
+${CCP_CLI?} exec -ti pr-primary -- psql -d postgres -c 'create table foo (id int)'
+${CCP_CLI?} exec -ti pr-primary -- psql -d postgres -c 'insert into foo values (1)'
 ....
 
 Then verify that the data is replicated to the replica:
+
 ....
-psql -h pr-replica -U postgres postgres -c 'table foo'
+${CCP_CLI?} exec -ti pr-replica -- psql -d postgres -c 'table foo'
 ....
 
 *primary-replica-dc*
 
 If you wanted to experiment with scaling up the number of replicas, you can run the following example:
+
 ....
 cd $CCPROOT/examples/kube/primary-replica-dc
 ./run.sh
@@ -1840,19 +1855,8 @@ cd $CCPROOT/examples/kube/primary-replica-dc
 
 You can verify that replication is working using the same commands as above.
 
-This example creates 2 replicas when it initially starts.  To scale
-up the number of replicas and view what the deployment looks like before and after, run these commands:
 ....
-${CCP_CLI} get deployment
-${CCP_CLI} scale --current-replicas=2 --replicas=3 deployment/replica-dc
-${CCP_CLI} get deployment
-${CCP_CLI} get pod
-....
-
-You can verify that you now have 3 replicas by running this query
-on the primary:
-....
-psql -h primary-dc -U postgres postgres -c 'table pg_stat_replication'
+${CCP_CLI?} exec -ti primary-dc -- psql -d postgres -c 'table pg_stat_replication'
 ....
 
 ==== Helm


### PR DESCRIPTION
The following examples use `emptyDir` volumes instead of creating standard storage.  This caused an issue on restricted OpenShift deployments where applying securityContexts to the memory volumes is not allowed.

Removed the securityContexts to avoid user error when they're running examples in the cloud (such as GKE OCP).

Also found a bug where deployment replica count was set to 2 causing problems with the deployment.

Closes CrunchyData/crunchy-containers-test#91.
Closes CrunchyData/crunchy-containers-test#77.
Closes CrunchyData/crunchy-containers-test#73.