### PR TITLE
Added Architecture Warning to the 'Getting Started\Kubernetes and Openshift' Page 

### DIFF
--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -15,6 +15,8 @@ defaultContentLanguage = "en"
 defaultContentLanguageInSubdir= false
 enableMissingTranslationPlaceholders = false
 
+# Set timeout for generating page contents
+timeout=20000
 
 # [Languages]
 # [Languages.en]

--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -9,6 +9,13 @@ Latest Release: 2.2.0 {docdate}
 
 == Getting Started
 
+{{% notice warning %}}
+The Kubernetes and OpenShift examples provided on this page have been designed using single-node Kubernetes/OCP clusters
+whose host machines provide any required supporting infrastructure or services (e.g. local hostPath storage or access
+to an NFS share). Therefore, for the best results when running these examples, it is recommended that you utilize a 
+single-node architecture as well.
+{{% /notice %}}
+
 {{% notice tip %}}
 The examples located in the *kube* directory work on both Kubernetes and OpenShift. Ensure the `CCP_CLI` environment variable
 is set to the correct binary for your environment.


### PR DESCRIPTION
Added a warning to the **Getting Started\Kubernetes and Openshift** page to indicate that the examples were designed to be run on (and therefore work best on) single-node Kube/OCP clusters whose host machines also provide any required supporting infrastructure or services (e.g. hostPath storage or access to NFS shares).  

Also, doubled the timeout value for generating page contents with hugo from the default value of 10,000 milliseconds to 20,000 milliseconds due to timeouts experienced when building the website locally.  I experienced this timeout when building the website locally before and after the changes above, specifically when building the **getting-started\\kubernetes-and-openshift\\_index.adoc** file.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
There is no guidance for the Kubernetes/OCP architecture to utilize when running the various examples on the **Getting Started\Kubernetes and Openshift** page, which can lead to issues such as the hostPath issue described here: CrunchyData/crunchy-containers-test#130

Also, the hugo build does not always complete when run locally, often timing out.

**What is the new behavior (if this is a feature change)?**
A warning is provided on the **Getting Started\Kubernetes and Openshift** page that indicates that the examples were designed using single-node clusters, and it is therefore recommended that users utilize single-node architectures as well.

The hugo build also consistently completes successfully when run locally.