### PR TITLE
Fix Directory Structure in Environment Setup & Add Default Grafana Credentials

### DIFF
--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -2344,7 +2344,11 @@ This example starts up 5 containers:
  * Prometheus (crunchy-prometheus)
 
 Every 5 seconds by default, Prometheus will scrape the Collect container
-for metrics.  These metrics will then be visualized by Grafana.
+for metrics.  These metrics will then be visualized by Grafana, which by default can be accessed
+with the following credentials:
+
+* Username : *admin*
+* Password: *password*
 
 By default, Prometheus detects which environment its running on (Docker, Kubernetes, or OpenShift Container Platform)
 and applies a default configuration. If this container is running on Kubernetes or OpenShift Container Platform,

--- a/hugo/content/installation/environment-setup.adoc
+++ b/hugo/content/installation/environment-setup.adoc
@@ -62,18 +62,15 @@ effect.
 
 Next, set up a project directory structure and pull down the project:
 ....
-mkdir -p $HOME/cdev/src $HOME/cdev/pkg $HOME/cdev/bin
+mkdir -p $HOME/cdev/src/github.com/crunchydata $HOME/cdev/pkg $HOME/cdev/bin
 ....
 
 == Installing Requirements
 
 === CentOS 7
 ....
-cd $GOPATH
 sudo yum -y install golang git docker
-cd src/github.com
-mkdir crunchydata
-cd crunchydata
+cd $GOPATH/src/github.com/crunchydata
 git clone https://github.com/crunchydata/crunchy-containers
 cd crunchy-containers
 git checkout 2.2.0
@@ -93,13 +90,10 @@ When setting up the environment on RHEL 7, there are slightly different steps th
 need to be taken.
 
 ....
-cd $GOPATH
 sudo subscription-manager repos --enable=rhel-7-server-optional-rpms
 sudo yum-config-manager --enable rhel-7-server-extras-rpms
 sudo yum -y install git golang
-cd src/github.com
-mkdir crunchydata
-cd crunchydata
+cd $GOPATH/src/github.com/crunchydata
 git clone https://github.com/crunchydata/crunchy-containers
 cd crunchy-containers
 git checkout 2.2.0


### PR DESCRIPTION
The `mkdir` command under the **Project Environment** section of the **Environment Setup** page now builds out the required directory structure needed to follow the subsequent setup instructions, specifically now creating the required **github.com** directory.  This addresses an issue under the current **Installing Requirements** section in which the user is told to `cd src/github.com`, but the **github** directory has not yet been created, resulting in an error.

Also now provide the default credentials for accessing **Grafana** under the **Metrics** example to facilitate accessing the **Grafana** web app when running the example.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
A `No such file or directory` error is thrown when the user is told to `cd src/github.com` under the **Project Environment** section of the **Environment Setup** page because directory **github.com** has not yet been created.

Also, the default credentials for accessing **Grafana** for the **Metrics** example are not currently specified.

**What is the new behavior (if this is a feature change)?**
The `mkdir` command under the **Project Environment** section of the **Environment Setup** page now builds out the required directory structure needed to follow the subsequent setup instructions in the **Installing Requirements** section, specifically now creating the required **github.com** directory.  Also, consolidated the creation of the required directories for the `git clone` command to a single command to simplify the setup of the project environment.

Also now provide the default credentials for accessing **Grafana** under the **Metrics** example to facilitate accessing the **Grafana** web app when running the example.

