### PR TITLE
Add namespace to PV name/directories

### DIFF
--- a/examples/common.sh
+++ b/examples/common.sh
@@ -38,9 +38,12 @@ function env_check_err() {
 }
 
 function dir_check_rm() {
-    if [[ -d ${CCP_STORAGE_PATH}/${1?} ]]
+    dir="${CCP_NAMESPACE?}-${1?}"
+    if [[ -d ${CCP_STORAGE_PATH}/${dir?} ]]
     then
-        sudo rm -rf ${CCP_STORAGE_PATH?}/${1?} && echo_info "Deleted ${1?} from the data directory." || echo_err "${1?} was not successfully deleted from the data directory."
+        sudo rm -rf ${CCP_STORAGE_PATH?}/${dir?} && \
+            echo_info "Deleted ${dir?} from the data directory." || \
+            echo_err "${dir?} was not successfully deleted from the data directory."
     fi
 }
 
@@ -48,6 +51,7 @@ function create_storage {
     env_check_err "CCP_STORAGE_CAPACITY"
     env_check_err "CCP_STORAGE_MODE"
     PVC="${1?}-pvc.json"
+    dir="${CCP_NAMESPACE?}-${1?}"
 
     if [[ ! -z ${CCP_STORAGE_CLASS} ]]
     then
@@ -56,13 +60,13 @@ function create_storage {
     elif [[ ! -z ${CCP_NFS_IP} ]]
     then
         echo_info "CCP_NFS_IP is set. Creating NFS based storage volumes."
-        sudo mkdir -p ${CCP_STORAGE_PATH?}/${1?}
-        sudo chmod -R 777 ${CCP_STORAGE_PATH?}/${1?}
+        sudo mkdir -p ${CCP_STORAGE_PATH?}/${dir?}
+        sudo chmod -R 777 ${CCP_STORAGE_PATH?}/${dir?}
         PV="${1?}-pv-nfs.json"
     else
         echo_info "CCP_NFS_IP and CCP_STORAGE_CLASS not set. Creating HostPath based storage volumes."
-        sudo mkdir -p ${CCP_STORAGE_PATH?}/${1?}
-        sudo chmod -R 777 ${CCP_STORAGE_PATH?}/${1?}
+        sudo mkdir -p ${CCP_STORAGE_PATH?}/${dir?}
+        sudo chmod -R 777 ${CCP_STORAGE_PATH?}/${dir?}
         PV="${1?}-pv.json"
     fi
 

--- a/examples/kube/backrest/async-archiving/backrest-async-archive-pv-nfs.json
+++ b/examples/kube/backrest/async-archiving/backrest-async-archive-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "br-aa-pgdata",
+        "name": "$CCP_NAMESPACE-br-aa-pgdata",
         "labels": {
-            "name": "br-aa-pgdata"
+            "name": "$CCP_NAMESPACE-br-aa-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/backrest-async-archive",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest-async-archive",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -24,9 +24,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "br-aa-backups",
+        "name": "$CCP_NAMESPACE-br-aa-backups",
         "labels": {
-            "name": "br-aa-backups"
+            "name": "$CCP_NAMESPACE-br-aa-backups"
         }
     },
     "spec": {
@@ -35,7 +35,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/backrest-async-archive",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest-async-archive",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/backrest/async-archiving/backrest-async-archive-pv.json
+++ b/examples/kube/backrest/async-archiving/backrest-async-archive-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "br-aa-pgdata",
+        "name": "$CCP_NAMESPACE-br-aa-pgdata",
         "labels": {
-            "name": "br-aa-pgdata"
+            "name": "$CCP_NAMESPACE-br-aa-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/backrest-async-archive"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest-async-archive"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -23,9 +23,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "br-aa-backups",
+        "name": "$CCP_NAMESPACE-br-aa-backups",
         "labels": {
-            "name": "br-aa-backups"
+            "name": "$CCP_NAMESPACE-br-aa-backups"
         }
     },
     "spec": {
@@ -34,7 +34,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/backrest-async-archive"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest-async-archive"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/backrest/async-archiving/backrest-async-archive-pvc.json
+++ b/examples/kube/backrest/async-archiving/backrest-async-archive-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "br-aa-pgdata"
+            "name": "$CCP_NAMESPACE-br-aa-pgdata"
           }
         },
         "accessModes": [
@@ -30,7 +30,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "br-aa-backups"
+            "name": "$CCP_NAMESPACE-br-aa-backups"
           }
         },
         "accessModes": [

--- a/examples/kube/backrest/async-archiving/cleanup.sh
+++ b/examples/kube/backrest/async-archiving/cleanup.sh
@@ -20,7 +20,7 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod backrest-async-archive
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap br-aa-pgconf
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc br-aa-pgdata br-aa-backups
 if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv br-aa-pgdata br-aa-backups
+  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-br-aa-pgdata $CCP_NAMESPACE-br-aa-backups
 fi
 
 $CCPROOT/examples/waitforterm.sh backrest-async-archive ${CCP_CLI?}

--- a/examples/kube/backrest/backup/backrest-pv-nfs.json
+++ b/examples/kube/backrest/backup/backrest-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "br-pgdata",
+        "name": "$CCP_NAMESPACE-br-pgdata",
         "labels": {
-            "name": "br-pgdata"
+            "name": "$CCP_NAMESPACE-br-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/backrest",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -24,9 +24,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "br-backups",
+        "name": "$CCP_NAMESPACE-br-backups",
         "labels": {
-            "name": "br-backups"
+            "name": "$CCP_NAMESPACE-br-backups"
         }
     },
     "spec": {
@@ -35,7 +35,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/backrest",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/backrest/backup/backrest-pv.json
+++ b/examples/kube/backrest/backup/backrest-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "br-pgdata",
+        "name": "$CCP_NAMESPACE-br-pgdata",
         "labels": {
-            "name": "br-pgdata"
+            "name": "$CCP_NAMESPACE-br-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/backrest"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -23,9 +23,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "br-backups",
+        "name": "$CCP_NAMESPACE-br-backups",
         "labels": {
-            "name": "br-backups"
+            "name": "$CCP_NAMESPACE-br-backups"
         }
     },
     "spec": {
@@ -34,7 +34,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/backrest"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/backrest/backup/backrest-pvc.json
+++ b/examples/kube/backrest/backup/backrest-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "br-pgdata"
+            "name": "$CCP_NAMESPACE-br-pgdata"
           }
         },
         "accessModes": [
@@ -30,7 +30,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "br-backups"
+            "name": "$CCP_NAMESPACE-br-backups"
           }
         },
         "accessModes": [

--- a/examples/kube/backrest/backup/cleanup.sh
+++ b/examples/kube/backrest/backup/cleanup.sh
@@ -20,7 +20,7 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod backrest
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap br-pgconf
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc br-pgdata br-backups
 if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv br-pgdata br-backups
+  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-br-pgdata $CCP_NAMESPACE-br-backups
 fi
 
 $CCPROOT/examples/waitforterm.sh backrest ${CCP_CLI?}

--- a/examples/kube/backrest/full/backrest-full-restored-pv-nfs.json
+++ b/examples/kube/backrest/full/backrest-full-restored-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "br-new-pgdata",
+        "name": "$CCP_NAMESPACE-br-new-pgdata",
         "labels": {
-            "name": "br-new-pgdata"
+            "name": "$CCP_NAMESPACE-br-new-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/backrest-full-restored",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest-full-restored",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/backrest/full/backrest-full-restored-pv.json
+++ b/examples/kube/backrest/full/backrest-full-restored-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "br-new-pgdata",
+        "name": "$CCP_NAMESPACE-br-new-pgdata",
         "labels": {
-            "name": "br-new-pgdata"
+            "name": "$CCP_NAMESPACE-br-new-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/backrest-full-restored"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest-full-restored"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/backrest/full/backrest-full-restored-pvc.json
+++ b/examples/kube/backrest/full/backrest-full-restored-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "br-new-pgdata"
+            "name": "$CCP_NAMESPACE-br-new-pgdata"
           }
         },
         "accessModes": [

--- a/examples/kube/backrest/full/cleanup.sh
+++ b/examples/kube/backrest/full/cleanup.sh
@@ -18,7 +18,7 @@ echo_info "Cleaning up.."
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service backrest backrest-full-restored
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod backrest backrest-full-restored
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc br-new-pgdata
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv br-new-pgdata
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-br-new-pgdata
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job backrest-full-restore-job
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap br-full-restore-pgconf
 

--- a/examples/kube/backup/backup-pv-nfs.json
+++ b/examples/kube/backup/backup-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "backup-pgdata",
+        "name": "$CCP_NAMESPACE-backup-pgdata",
         "labels": {
-            "name": "backup-pgdata"
+            "name": "$CCP_NAMESPACE-backup-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/backup",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backup",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/backup/backup-pv.json
+++ b/examples/kube/backup/backup-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "backup-pgdata",
+        "name": "$CCP_NAMESPACE-backup-pgdata",
         "labels": {
-            "name": "backup-pgdata"
+            "name": "$CCP_NAMESPACE-backup-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/backup"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backup"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/backup/backup-pvc.json
+++ b/examples/kube/backup/backup-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "backup-pgdata"
+            "name": "$CCP_NAMESPACE-backup-pgdata"
           }
         },
         "accessModes": [

--- a/examples/kube/backup/cleanup.sh
+++ b/examples/kube/backup/cleanup.sh
@@ -20,7 +20,7 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc backup-pgdata
 
 if [[ -z "$CCP_STORAGE_CLASS" ]]
 then
-    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv backup-pgdata
+    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-backup-pgdata
 fi
 
 dir_check_rm "backup"

--- a/examples/kube/centralized-logging/postgres-cluster/postgres-cluster-pv-nfs.json
+++ b/examples/kube/centralized-logging/postgres-cluster/postgres-cluster-pv-nfs.json
@@ -2,10 +2,10 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "primary-deployment-pgdata",
+        "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
         "labels":{
            "k8s-app": "postgres-cluster",
-           "name": "primary-deployment-pgdata"
+           "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
         }
     },
     "spec": {
@@ -14,7 +14,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/primary-deployment",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -25,10 +25,10 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "replica-deployment-pgdata",
+        "name": "$CCP_NAMESPACE-replica-deployment-pgdata",
         "labels":{
            "k8s-app": "postgres-cluster",
-           "name": "replica-deployment-pgdata"
+           "name": "$CCP_NAMESPACE-replica-deployment-pgdata"
         }
     },
     "spec": {
@@ -37,7 +37,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/replica-deployment",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-replica-deployment",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/centralized-logging/postgres-cluster/postgres-cluster-pv.json
+++ b/examples/kube/centralized-logging/postgres-cluster/postgres-cluster-pv.json
@@ -2,10 +2,10 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "primary-deployment-pgdata",
+        "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
         "labels":{
            "k8s-app": "postgres-cluster",
-            "name": "primary-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
         }
     },
     "spec": {
@@ -14,7 +14,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/primary-deployment"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -24,10 +24,10 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "replica-deployment-pgdata",
+        "name": "$CCP_NAMESPACE-replica-deployment-pgdata",
         "labels":{
            "k8s-app": "postgres-cluster",
-            "name": "replica-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-replica-deployment-pgdata"
         }
     },
     "spec": {
@@ -36,7 +36,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/replica-deployment"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-replica-deployment"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/centralized-logging/postgres-cluster/postgres-cluster-pvc.json
+++ b/examples/kube/centralized-logging/postgres-cluster/postgres-cluster-pvc.json
@@ -10,7 +10,7 @@
     "spec": {
       "selector": {
         "matchLabels": {
-          "name": "primary-deployment-pgdata"
+          "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
         }
       },
       "accessModes": [
@@ -36,7 +36,7 @@
     "spec": {
       "selector": {
         "matchLabels": {
-          "name": "replica-deployment-pgdata"
+          "name": "$CCP_NAMESPACE-replica-deployment-pgdata"
         }
       },
       "accessModes": [

--- a/examples/kube/custom-config-ssl/cleanup.sh
+++ b/examples/kube/custom-config-ssl/cleanup.sh
@@ -16,7 +16,6 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-CONFDIR=$CCP_STORAGE_PATH/custom-config-ssl-pgconf
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service custom-config-ssl
@@ -26,7 +25,7 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc custom-config-ssl-pgdata cu
 
 if [[ -z "$CCP_STORAGE_CLASS" ]]
 then
-    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv custom-config-ssl-pgdata custom-config-pgwal custom-config-ssl-backrestrepo
+    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-custom-config-ssl-pgdata $CCP_NAMESPACE-custom-config-pgwal $CCP_NAMESPACE-custom-config-ssl-backrestrepo
 fi
 
 $CCPROOT/examples/waitforterm.sh custom-config-ssl ${CCP_CLI?}

--- a/examples/kube/custom-config-ssl/custom-config-ssl-pv-nfs.json
+++ b/examples/kube/custom-config-ssl/custom-config-ssl-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "custom-config-ssl-pgdata",
+        "name": "$CCP_NAMESPACE-custom-config-ssl-pgdata",
         "labels": {
-            "name": "custom-config-ssl-pgdata"
+            "name": "$CCP_NAMESPACE-custom-config-ssl-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/custom-config-ssl",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config-ssl",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -24,9 +24,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "custom-config-ssl-backrestrepo",
+        "name": "$CCP_NAMESPACE-custom-config-ssl-backrestrepo",
         "labels": {
-            "name": "custom-config-ssl-backrestrepo"
+            "name": "$CCP_NAMESPACE-custom-config-ssl-backrestrepo"
         }
     },
     "spec": {
@@ -35,7 +35,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/custom-config-ssl",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config-ssl",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/custom-config-ssl/custom-config-ssl-pv.json
+++ b/examples/kube/custom-config-ssl/custom-config-ssl-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "custom-config-ssl-pgdata",
+        "name": "$CCP_NAMESPACE-custom-config-ssl-pgdata",
         "labels": {
-            "name": "custom-config-ssl-pgdata"
+            "name": "$CCP_NAMESPACE-custom-config-ssl-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/custom-config-ssl"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config-ssl"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -23,9 +23,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "custom-config-ssl-backrestrepo",
+        "name": "$CCP_NAMESPACE-custom-config-ssl-backrestrepo",
         "labels": {
-            "name": "custom-config-ssl-backrestrepo"
+            "name": "$CCP_NAMESPACE-custom-config-ssl-backrestrepo"
         }
     },
     "spec": {
@@ -34,7 +34,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/custom-config-ssl"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config-ssl"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/custom-config-ssl/custom-config-ssl-pvc.json
+++ b/examples/kube/custom-config-ssl/custom-config-ssl-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
       "selector": {
         "matchLabels": {
-          "name": "custom-config-ssl-pgdata"
+          "name": "$CCP_NAMESPACE-custom-config-ssl-pgdata"
         }
       },
       "accessModes": [
@@ -30,7 +30,7 @@
     "spec": {
       "selector": {
         "matchLabels": {
-          "name": "custom-config-ssl-backrestrepo"
+          "name": "$CCP_NAMESPACE-custom-config-ssl-backrestrepo"
         }
       },
       "accessModes": [

--- a/examples/kube/custom-config/cleanup.sh
+++ b/examples/kube/custom-config/cleanup.sh
@@ -23,7 +23,7 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap custom-config-pgconf
 
 if [[ -z "$CCP_STORAGE_CLASS" ]]
 then
-    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv custom-config-pgdata custom-config-pgwal custom-config-br
+    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-custom-config-pgdata $CCP_NAMESPACE-custom-config-pgwal $CCP_NAMESPACE-custom-config-br
 fi
 
 $CCPROOT/examples/waitforterm.sh custom-config ${CCP_CLI?}

--- a/examples/kube/custom-config/custom-config-pv-nfs.json
+++ b/examples/kube/custom-config/custom-config-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "custom-config-pgdata",
+        "name": "$CCP_NAMESPACE-custom-config-pgdata",
         "labels": {
-            "name": "custom-config-pgdata"
+            "name": "$CCP_NAMESPACE-custom-config-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/custom-config",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -24,9 +24,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "custom-config-br",
+        "name": "$CCP_NAMESPACE-custom-config-br",
         "labels": {
-            "name": "custom-config-br"
+            "name": "$CCP_NAMESPACE-custom-config-br"
         }
     },
     "spec": {
@@ -35,7 +35,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/custom-config",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -46,9 +46,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "custom-config-pgwal",
+        "name": "$CCP_NAMESPACE-custom-config-pgwal",
         "labels": {
-            "name": "custom-config-pgwal"
+            "name": "$CCP_NAMESPACE-custom-config-pgwal"
         }
     },
     "spec": {
@@ -57,7 +57,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/custom-config",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/custom-config/custom-config-pv.json
+++ b/examples/kube/custom-config/custom-config-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "custom-config-pgdata",
+        "name": "$CCP_NAMESPACE-custom-config-pgdata",
         "labels": {
-            "name": "custom-config-pgdata"
+            "name": "$CCP_NAMESPACE-custom-config-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/custom-config"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -23,9 +23,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "custom-config-br",
+        "name": "$CCP_NAMESPACE-custom-config-br",
         "labels": {
-            "name": "custom-config-br"
+            "name": "$CCP_NAMESPACE-custom-config-br"
         }
     },
     "spec": {
@@ -34,7 +34,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/custom-config"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -44,9 +44,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "custom-config-pgwal",
+        "name": "$CCP_NAMESPACE-custom-config-pgwal",
         "labels": {
-            "name": "custom-config-pgwal"
+            "name": "$CCP_NAMESPACE-custom-config-pgwal"
         }
     },
     "spec": {
@@ -55,7 +55,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/custom-config"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/custom-config/custom-config-pvc.json
+++ b/examples/kube/custom-config/custom-config-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "custom-config-pgdata"
+            "name": "$CCP_NAMESPACE-custom-config-pgdata"
           }
         },
         "accessModes": [
@@ -30,7 +30,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "custom-config-br"
+            "name": "$CCP_NAMESPACE-custom-config-br"
           }
         },
         "accessModes": [
@@ -53,7 +53,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "custom-config-pgwal"
+            "name": "$CCP_NAMESPACE-custom-config-pgwal"
           }
         },
         "accessModes": [

--- a/examples/kube/metrics/cleanup.sh
+++ b/examples/kube/metrics/cleanup.sh
@@ -26,7 +26,7 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service metrics primary-metrics
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc metrics-prometheusdata metrics-grafanadata
 
 if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv metrics-prometheusdata metrics-grafanadata
+  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-metrics-prometheusdata $CCP_NAMESPACE-metrics-grafanadata
 fi
 
 $CCPROOT/examples/waitforterm.sh metrics ${CCP_CLI?}

--- a/examples/kube/metrics/metrics-pv-nfs.json
+++ b/examples/kube/metrics/metrics-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "metrics-grafanadata",
+        "name": "$CCP_NAMESPACE-metrics-grafanadata",
         "labels": {
-            "name": "metrics-grafanadata"
+            "name": "$CCP_NAMESPACE-metrics-grafanadata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/metrics",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-metrics",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -24,9 +24,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "metrics-prometheusdata",
+        "name": "$CCP_NAMESPACE-metrics-prometheusdata",
         "labels": {
-            "name": "metrics-prometheusdata"
+            "name": "$CCP_NAMESPACE-metrics-prometheusdata"
         }
     },
     "spec": {
@@ -35,7 +35,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/metrics",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-metrics",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/metrics/metrics-pv.json
+++ b/examples/kube/metrics/metrics-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "metrics-grafanadata",
+        "name": "$CCP_NAMESPACE-metrics-grafanadata",
         "labels": {
-            "name": "metrics-grafanadata"
+            "name": "$CCP_NAMESPACE-metrics-grafanadata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/metrics"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-metrics"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -23,9 +23,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "metrics-prometheusdata",
+        "name": "$CCP_NAMESPACE-metrics-prometheusdata",
         "labels": {
-            "name": "metrics-prometheusdata"
+            "name": "$CCP_NAMESPACE-metrics-prometheusdata"
         }
     },
     "spec": {
@@ -34,7 +34,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/metrics"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-metrics"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/metrics/metrics-pvc.json
+++ b/examples/kube/metrics/metrics-pvc.json
@@ -7,7 +7,7 @@
       "spec": {
         "selector": {
           "matchLabels": {
-            "name": "metrics-prometheusdata"
+            "name": "$CCP_NAMESPACE-metrics-prometheusdata"
           }
         },
         "accessModes": [
@@ -30,7 +30,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "metrics-grafanadata"
+            "name": "$CCP_NAMESPACE-metrics-grafanadata"
           }
         },
         "accessModes": [

--- a/examples/kube/pgadmin4-http/cleanup.sh
+++ b/examples/kube/pgadmin4-http/cleanup.sh
@@ -21,7 +21,7 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pgadmin4-http-secrets
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc pgadmin4-http-data
 
 if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv pgadmin4-http-data
+  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-pgadmin4-http-data
 fi
 
 $CCPROOT/examples/waitforterm.sh pgadmin4-http ${CCP_CLI?}

--- a/examples/kube/pgadmin4-http/pgadmin4-http-pv-nfs.json
+++ b/examples/kube/pgadmin4-http/pgadmin4-http-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "pgadmin4-http-data",
+        "name": "$CCP_NAMESPACE-pgadmin4-http-data",
         "labels": {
-            "name": "pgadmin4-http-data"
+            "name": "$CCP_NAMESPACE-pgadmin4-http-data"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/pgadmin4-http",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pgadmin4-http",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/pgadmin4-http/pgadmin4-http-pv.json
+++ b/examples/kube/pgadmin4-http/pgadmin4-http-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "pgadmin4-http-data",
+        "name": "$CCP_NAMESPACE-pgadmin4-http-data",
         "labels": {
-            "name": "pgadmin4-http-data"
+            "name": "$CCP_NAMESPACE-pgadmin4-http-data"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/pgadmin4-http"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pgadmin4-http"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/pgadmin4-http/pgadmin4-http-pvc.json
+++ b/examples/kube/pgadmin4-http/pgadmin4-http-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "pgadmin4-http-data"
+            "name": "$CCP_NAMESPACE-pgadmin4-http-data"
           }
         },
         "accessModes": [

--- a/examples/kube/pgadmin4-https/cleanup.sh
+++ b/examples/kube/pgadmin4-https/cleanup.sh
@@ -25,7 +25,7 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pgadmin4-https-tls
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc pgadmin4-https-data
 
 if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv pgadmin4-https-data
+  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-pgadmin4-https-data
 fi
 
 rm -f ${DIR?}/server.crt ${DIR?}/server.key ${DIR?}/privkey.pem

--- a/examples/kube/pgadmin4-https/pgadmin4-https-pv-nfs.json
+++ b/examples/kube/pgadmin4-https/pgadmin4-https-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "pgadmin4-https-data",
+        "name": "$CCP_NAMESPACE-pgadmin4-https-data",
         "labels": {
-            "name": "pgadmin4-https-data"
+            "name": "$CCP_NAMESPACE-pgadmin4-https-data"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/pgadmin4-https",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pgadmin4-https",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/pgadmin4-https/pgadmin4-https-pv.json
+++ b/examples/kube/pgadmin4-https/pgadmin4-https-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "pgadmin4-https-data",
+        "name": "$CCP_NAMESPACE-pgadmin4-https-data",
         "labels": {
-            "name": "pgadmin4-https-data"
+            "name": "$CCP_NAMESPACE-pgadmin4-https-data"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/pgadmin4-https"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pgadmin4-https"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/pgadmin4-https/pgadmin4-https-pvc.json
+++ b/examples/kube/pgadmin4-https/pgadmin4-https-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "pgadmin4-https-data"
+            "name": "$CCP_NAMESPACE-pgadmin4-https-data"
           }
         },
         "accessModes": [

--- a/examples/kube/pgdump/cleanup.sh
+++ b/examples/kube/pgdump/cleanup.sh
@@ -17,7 +17,7 @@ echo_info "Cleaning up.."
 
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job pgdump
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc pgdump-pgdata
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv pgdump-pgdata
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-pgdump-pgdata
 
 $CCPROOT/examples/waitforterm.sh pgdump ${CCP_CLI?}
 

--- a/examples/kube/pgdump/pgdump-pv-nfs.json
+++ b/examples/kube/pgdump/pgdump-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "pgdump-pgdata",
+        "name": "$CCP_NAMESPACE-pgdump-pgdata",
         "labels": {
-            "name": "pgdump-pgdata"
+            "name": "$CCP_NAMESPACE-pgdump-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/pgdump",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pgdump",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/pgdump/pgdump-pv.json
+++ b/examples/kube/pgdump/pgdump-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "pgdump-pgdata",
+        "name": "$CCP_NAMESPACE-pgdump-pgdata",
         "labels": {
-            "name": "pgdump-pgdata"
+            "name": "$CCP_NAMESPACE-pgdump-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/pgdump"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pgdump"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/pgdump/pgdump-pvc.json
+++ b/examples/kube/pgdump/pgdump-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "pgdump-pgdata"
+            "name": "$CCP_NAMESPACE-pgdump-pgdata"
           }
         },
         "accessModes": [

--- a/examples/kube/pitr/backup-pitr-pv-nfs.json
+++ b/examples/kube/pitr/backup-pitr-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "backup-pitr-pgdata",
+        "name": "$CCP_NAMESPACE-backup-pitr-pgdata",
         "labels": {
-            "name": "backup-pitr-pgdata"
+            "name": "$CCP_NAMESPACE-backup-pitr-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/backup-pitr",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backup-pitr",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/pitr/backup-pitr-pv.json
+++ b/examples/kube/pitr/backup-pitr-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "backup-pitr-pgdata",
+        "name": "$CCP_NAMESPACE-backup-pitr-pgdata",
         "labels": {
-            "name": "backup-pitr-pgdata"
+            "name": "$CCP_NAMESPACE-backup-pitr-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/backup-pitr"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backup-pitr"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/pitr/backup-pitr-pvc.json
+++ b/examples/kube/pitr/backup-pitr-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
       "selector": {
         "matchLabels": {
-          "name": "backup-pitr-pgdata"
+          "name": "$CCP_NAMESPACE-backup-pitr-pgdata"
         }
       },
       "accessModes": [

--- a/examples/kube/pitr/cleanup.sh
+++ b/examples/kube/pitr/cleanup.sh
@@ -16,17 +16,15 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod restore-pitr
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service restore-pitr
-sudo CCP_STORAGE_PATH=$CCP_STORAGE_PATH rm -rf $CCP_STORAGE_PATH/restore-pitr
-
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service pitr
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod pitr
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod restore-pitr pitr
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service restore-pitr pitr
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job backup-pitr
 
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc pitr-pgdata pitr-pgwal backup-pitr-pgdata restore-pitr-pgdata recover-pvc
 if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv pitr-pgdata pitr-pgwal backup-pitr-pgdata restore-pitr-pgdata recover-pv
+  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-pitr-pgdata \
+    $CCP_NAMESPACE-pitr-pgwal $CCP_NAMESPACE-backup-pitr-pgdata \
+    $CCP_NAMESPACE-restore-pitr-pgdata $CCP_NAMESPACE-recover-pv
 fi
 
 dir_check_rm "pitr"

--- a/examples/kube/pitr/pitr-pv-nfs.json
+++ b/examples/kube/pitr/pitr-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "pitr-pgdata",
+        "name": "$CCP_NAMESPACE-pitr-pgdata",
         "labels": {
-            "name": "pitr-pgdata"
+            "name": "$CCP_NAMESPACE-pitr-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/pitr",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pitr",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -24,9 +24,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "pitr-pgwal",
+        "name": "$CCP_NAMESPACE-pitr-pgwal",
         "labels": {
-            "name": "pitr-pgwal"
+            "name": "$CCP_NAMESPACE-pitr-pgwal"
         }
     },
     "spec": {
@@ -35,7 +35,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/pitr",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pitr",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/pitr/pitr-pv.json
+++ b/examples/kube/pitr/pitr-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "pitr-pgdata",
+        "name": "$CCP_NAMESPACE-pitr-pgdata",
         "labels": {
-            "name": "pitr-pgdata"
+            "name": "$CCP_NAMESPACE-pitr-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/pitr"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pitr"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -23,9 +23,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "pitr-pgwal",
+        "name": "$CCP_NAMESPACE-pitr-pgwal",
         "labels": {
-            "name": "pitr-pgwal"
+            "name": "$CCP_NAMESPACE-pitr-pgwal"
         }
     },
     "spec": {
@@ -34,7 +34,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/pitr"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pitr"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/pitr/pitr-pvc.json
+++ b/examples/kube/pitr/pitr-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
       "selector": {
         "matchLabels": {
-          "name": "pitr-pgwal"
+          "name": "$CCP_NAMESPACE-pitr-pgwal"
         }
       },
       "accessModes": [
@@ -30,7 +30,7 @@
     "spec": {
       "selector": {
         "matchLabels": {
-          "name": "pitr-pgdata"
+          "name": "$CCP_NAMESPACE-pitr-pgdata"
         }
       },
       "accessModes": [

--- a/examples/kube/pitr/restore-pitr-pv-nfs.json
+++ b/examples/kube/pitr/restore-pitr-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "recover-pv",
+        "name": "$CCP_NAMESPACE-recover-pv",
         "labels": {
-            "name": "recover-pv"
+            "name": "$CCP_NAMESPACE-recover-pv"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/restore-pitr",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-restore-pitr",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -24,9 +24,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "restore-pitr-pgdata",
+        "name": "$CCP_NAMESPACE-restore-pitr-pgdata",
         "labels": {
-            "name": "restore-pitr-pgdata"
+            "name": "$CCP_NAMESPACE-restore-pitr-pgdata"
         }
     },
     "spec": {
@@ -35,7 +35,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/restore-pitr",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-restore-pitr",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/pitr/restore-pitr-pv.json
+++ b/examples/kube/pitr/restore-pitr-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "recover-pv",
+        "name": "$CCP_NAMESPACE-recover-pv",
         "labels": {
-            "name": "recover-pv"
+            "name": "$CCP_NAMESPACE-recover-pv"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/restore-pitr"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-restore-pitr"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -23,9 +23,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "restore-pitr-pgdata",
+        "name": "$CCP_NAMESPACE-restore-pitr-pgdata",
         "labels": {
-            "name": "restore-pitr-pgdata"
+            "name": "$CCP_NAMESPACE-restore-pitr-pgdata"
         }
     },
     "spec": {
@@ -34,7 +34,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/restore-pitr"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-restore-pitr"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/pitr/restore-pitr-pvc.json
+++ b/examples/kube/pitr/restore-pitr-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
       "selector": {
         "matchLabels": {
-          "name": "restore-pitr-pgdata"
+          "name": "$CCP_NAMESPACE-restore-pitr-pgdata"
         }
       },
       "accessModes": [
@@ -29,10 +29,10 @@
     },
     "spec": {
         "selector": {
-        "matchLabels": {
-            "name": "recover-pv"
-        }
-  },
+          "matchLabels": {
+            "name": "$CCP_NAMESPACE-recover-pv"
+          }
+        },
         "accessModes": [
             "$CCP_STORAGE_MODE"
         ],

--- a/examples/kube/primary-deployment/cleanup.sh
+++ b/examples/kube/primary-deployment/cleanup.sh
@@ -25,7 +25,8 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc -l name=replica-deployment
 
 if [ -z "$CCP_STORAGE_CLASS" ]
 then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv primary-deployment-pgdata replica-deployment-pgdata replica2-deployment-pgdata
+  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-primary-deployment-pgdata \
+    $CCP_NAMESPACE-replica-deployment-pgdata $CCP_NAMESPACE-replica2-deployment-pgdata
 fi
 
 dir_check_rm "primary-deployment"

--- a/examples/kube/primary-deployment/primary-deployment-pv-nfs.json
+++ b/examples/kube/primary-deployment/primary-deployment-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "primary-deployment-pgdata",
+        "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
         "labels": {
-            "name": "primary-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/primary-deployment",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -24,9 +24,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "replica-deployment-pgdata",
+        "name": "$CCP_NAMESPACE-replica-deployment-pgdata",
         "labels": {
-            "name": "replica-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-replica-deployment-pgdata"
         }
     },
     "spec": {
@@ -35,7 +35,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/primary-deployment",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -46,9 +46,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "replica2-deployment-pgdata",
+        "name": "$CCP_NAMESPACE-replica2-deployment-pgdata",
         "labels": {
-            "name": "replica2-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-replica2-deployment-pgdata"
         }
     },
     "spec": {
@@ -57,7 +57,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/primary-deployment",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/primary-deployment/primary-deployment-pv.json
+++ b/examples/kube/primary-deployment/primary-deployment-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "primary-deployment-pgdata",
+        "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
         "labels": {
-            "name": "primary-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/primary-deployment"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -23,9 +23,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "replica-deployment-pgdata",
+        "name": "$CCP_NAMESPACE-replica-deployment-pgdata",
         "labels": {
-            "name": "replica-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-replica-deployment-pgdata"
         }
     },
     "spec": {
@@ -34,7 +34,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/primary-deployment"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -44,9 +44,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "replica2-deployment-pgdata",
+        "name": "$CCP_NAMESPACE-replica2-deployment-pgdata",
         "labels": {
-            "name": "replica2-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-replica2-deployment-pgdata"
         }
     },
     "spec": {
@@ -55,7 +55,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/primary-deployment"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/primary-deployment/primary-deployment-pvc.json
+++ b/examples/kube/primary-deployment/primary-deployment-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
       "selector": {
         "matchLabels": {
-          "name": "primary-deployment-pgdata"
+          "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
         }
       },
       "accessModes": [

--- a/examples/kube/primary/cleanup.sh
+++ b/examples/kube/primary/cleanup.sh
@@ -20,7 +20,7 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod primary
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc primary-pgdata
 
 if [ -z "$CCP_STORAGE_CLASS" ]; then
-    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv primary-pgdata
+    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-primary-pgdata
 fi
 
 $CCPROOT/examples/waitforterm.sh primary ${CCP_CLI?}

--- a/examples/kube/primary/primary-pv-nfs.json
+++ b/examples/kube/primary/primary-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "primary-pgdata",
+        "name": "$CCP_NAMESPACE-primary-pgdata",
         "labels": {
-            "name": "primary-pgdata"
+            "name": "$CCP_NAMESPACE-primary-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/primary",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/primary/primary-pv.json
+++ b/examples/kube/primary/primary-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "primary-pgdata",
+        "name": "$CCP_NAMESPACE-primary-pgdata",
         "labels": {
-            "name": "primary-pgdata"
+            "name": "$CCP_NAMESPACE-primary-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/primary"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/primary/primary-pvc.json
+++ b/examples/kube/primary/primary-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
       "selector": {
         "matchLabels": {
-          "name": "primary-pgdata"
+          "name": "$CCP_NAMESPACE-primary-pgdata"
         }
       },
       "accessModes": [

--- a/examples/kube/restore/cleanup.sh
+++ b/examples/kube/restore/cleanup.sh
@@ -20,7 +20,7 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service restore
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc restore-pgdata
 
 if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv restore-pgdata
+  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-restore-pgdata
 fi
 
 $CCPROOT/examples/waitforterm.sh restore ${CCP_CLI?}

--- a/examples/kube/restore/restore-pv-nfs.json
+++ b/examples/kube/restore/restore-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "restore-pgdata",
+        "name": "$CCP_NAMESPACE-restore-pgdata",
         "labels": {
-            "name": "restore-pgdata"
+            "name": "$CCP_NAMESPACE-restore-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/restore",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-restore",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/restore/restore-pv.json
+++ b/examples/kube/restore/restore-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "restore-pgdata",
+        "name": "$CCP_NAMESPACE-restore-pgdata",
         "labels": {
-            "name": "restore-pgdata"
+            "name": "$CCP_NAMESPACE-restore-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/restore"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-restore"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/restore/restore-pvc.json
+++ b/examples/kube/restore/restore-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
         "selector": {
           "matchLabels": {
-            "name": "restore-pgdata"
+            "name": "$CCP_NAMESPACE-restore-pgdata"
           }
         },
         "accessModes": [

--- a/examples/kube/scheduler/primary/cleanup.sh
+++ b/examples/kube/scheduler/primary/cleanup.sh
@@ -25,7 +25,7 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc primary-deployment-pgdata p
 
 if [ -z "$CCP_STORAGE_CLASS" ]
 then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv primary-deployment-pgdata primary-deployment-br primary-deployment-backup
+  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-primary-deployment-pgdata $CCP_NAMESPACE-primary-deployment-br $CCP_NAMESPACE-primary-deployment-backup
 fi
 
 dir_check_rm "primary-deployment"

--- a/examples/kube/scheduler/primary/primary-deployment-pv-nfs.json
+++ b/examples/kube/scheduler/primary/primary-deployment-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "primary-deployment-pgdata",
+        "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
         "labels": {
-            "name": "primary-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/primary-deployment",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -24,9 +24,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "primary-deployment-br",
+        "name": "$CCP_NAMESPACE-primary-deployment-br",
         "labels": {
-            "name": "primary-deployment-br"
+            "name": "$CCP_NAMESPACE-primary-deployment-br"
         }
     },
     "spec": {
@@ -35,7 +35,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/primary-deployment",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -46,9 +46,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "primary-deployment-backup",
+        "name": "$CCP_NAMESPACE-primary-deployment-backup",
         "labels": {
-            "name": "primary-deployment-backup"
+            "name": "$CCP_NAMESPACE-primary-deployment-backup"
         }
     },
     "spec": {
@@ -57,7 +57,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/primary-deployment",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/scheduler/primary/primary-deployment-pv.json
+++ b/examples/kube/scheduler/primary/primary-deployment-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "primary-deployment-pgdata",
+        "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
         "labels": {
-            "name": "primary-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/primary-deployment"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -23,9 +23,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "primary-deployment-br",
+        "name": "$CCP_NAMESPACE-primary-deployment-br",
         "labels": {
-            "name": "primary-deployment-br"
+            "name": "$CCP_NAMESPACE-primary-deployment-br"
         }
     },
     "spec": {
@@ -34,7 +34,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/primary-deployment"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -44,9 +44,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "primary-deployment-backup",
+        "name": "$CCP_NAMESPACE-primary-deployment-backup",
         "labels": {
-            "name": "primary-deployment-backup"
+            "name": "$CCP_NAMESPACE-primary-deployment-backup"
         }
     },
     "spec": {
@@ -55,7 +55,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/primary-deployment"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/scheduler/primary/primary-deployment-pvc.json
+++ b/examples/kube/scheduler/primary/primary-deployment-pvc.json
@@ -7,7 +7,7 @@
     "spec": {
       "selector": {
         "matchLabels": {
-          "name": "primary-deployment-pgdata"
+          "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
         }
       },
       "accessModes": [
@@ -30,7 +30,7 @@
     "spec": {
       "selector": {
         "matchLabels": {
-          "name": "primary-deployment-br"
+          "name": "$CCP_NAMESPACE-primary-deployment-br"
         }
       },
       "accessModes": [
@@ -53,7 +53,7 @@
     "spec": {
       "selector": {
         "matchLabels": {
-          "name": "primary-deployment-backup"
+          "name": "$CCP_NAMESPACE-primary-deployment-backup"
         }
       },
       "accessModes": [

--- a/examples/kube/statefulset/cleanup.sh
+++ b/examples/kube/statefulset/cleanup.sh
@@ -18,10 +18,10 @@ echo_info "Cleaning up.."
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} statefulset statefulset
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} sa statefulset-sa
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} clusterrolebinding statefulset-sa
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc -l 'name=statefulset-pgdata'
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc -l "name=$CCP_NAMESPACE-statefulset-pgdata"
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc -l 'app=statefulset'
 if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv -l 'name=statefulset-pgdata'
+  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv -l "name=$CCP_NAMESPACE-statefulset-pgdata"
 fi
 
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service statefulset statefulset-primary statefulset-replica

--- a/examples/kube/statefulset/statefulset-pv-nfs.json
+++ b/examples/kube/statefulset/statefulset-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "statefulset-pgdata-0",
+        "name": "$CCP_NAMESPACE-statefulset-pgdata-0",
         "labels": {
-            "name": "statefulset-pgdata"
+            "name": "$CCP_NAMESPACE-statefulset-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/statefulset",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-statefulset",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -24,9 +24,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "statefulset-pgdata-1",
+        "name": "$CCP_NAMESPACE-statefulset-pgdata-1",
         "labels": {
-            "name": "statefulset-pgdata"
+            "name": "$CCP_NAMESPACE-statefulset-pgdata"
         }
     },
     "spec": {
@@ -35,7 +35,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/statefulset",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-statefulset",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"
@@ -46,9 +46,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "statefulset-pgdata-2",
+        "name": "$CCP_NAMESPACE-statefulset-pgdata-2",
         "labels": {
-            "name": "statefulset-pgdata"
+            "name": "$CCP_NAMESPACE-statefulset-pgdata"
         }
     },
     "spec": {
@@ -57,7 +57,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/statefulset",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-statefulset",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/statefulset/statefulset-pv.json
+++ b/examples/kube/statefulset/statefulset-pv.json
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "statefulset-pgdata-0",
         "labels": {
-            "name": "statefulset-pgdata"
+            "name": "$CCP_NAMESPACE-statefulset-pgdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/statefulset"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-statefulset"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -25,7 +25,7 @@
     "metadata": {
         "name": "statefulset-pgdata-1",
         "labels": {
-            "name": "statefulset-pgdata"
+            "name": "$CCP_NAMESPACE-statefulset-pgdata"
         }
     },
     "spec": {
@@ -34,7 +34,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/statefulset"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-statefulset"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }
@@ -46,7 +46,7 @@
     "metadata": {
         "name": "statefulset-pgdata-2",
         "labels": {
-            "name": "statefulset-pgdata"
+            "name": "$CCP_NAMESPACE-statefulset-pgdata"
         }
     },
     "spec": {
@@ -55,7 +55,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/statefulset"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-statefulset"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/upgrade/cleanup.sh
+++ b/examples/kube/upgrade/cleanup.sh
@@ -20,5 +20,5 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod primary primary-upgrade
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job upgrade
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc upgrade-pgnewdata
 if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv upgrade-pgnewdata
+  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-upgrade-pgnewdata
 fi

--- a/examples/kube/upgrade/upgrade-pv-nfs.json
+++ b/examples/kube/upgrade/upgrade-pv-nfs.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "upgrade-pgnewdata",
+        "name": "$CCP_NAMESPACE-upgrade-pgnewdata",
         "labels": {
-            "name": "upgrade-pgnewdata"
+            "name": "$CCP_NAMESPACE-upgrade-pgnewdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "nfs": {
-            "path": "$CCP_STORAGE_PATH/upgrade",
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-upgrade",
             "server": "$CCP_NFS_IP"
         },
         "persistentVolumeReclaimPolicy": "Retain"

--- a/examples/kube/upgrade/upgrade-pv.json
+++ b/examples/kube/upgrade/upgrade-pv.json
@@ -2,9 +2,9 @@
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
-        "name": "upgrade-pgnewdata",
+        "name": "$CCP_NAMESPACE-upgrade-pgnewdata",
         "labels": {
-            "name": "upgrade-pgnewdata"
+            "name": "$CCP_NAMESPACE-upgrade-pgnewdata"
         }
     },
     "spec": {
@@ -13,7 +13,7 @@
         },
         "accessModes": ["$CCP_STORAGE_MODE"],
         "hostPath": {
-            "path": "$CCP_STORAGE_PATH/upgrade"
+            "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-upgrade"
         },
         "persistentVolumeReclaimPolicy": "Retain"
     }

--- a/examples/kube/upgrade/upgrade-pvc.json
+++ b/examples/kube/upgrade/upgrade-pvc.json
@@ -2,12 +2,12 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "upgrade-pgnewdata"
+      "name": "$CCP_NAMESPACE-upgrade-pgnewdata"
     },
     "spec": {
       "selector": {
         "matchLabels": {
-          "name": "upgrade-pgnewdata"
+          "name": "$CCP_NAMESPACE-upgrade-pgnewdata"
         }
       },
       "accessModes": [

--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -12,7 +12,7 @@ Latest Release: 2.2.0 {docdate}
 {{% notice warning %}}
 The Kubernetes and OpenShift examples provided on this page have been designed using single-node Kubernetes/OCP clusters
 whose host machines provide any required supporting infrastructure or services (e.g. local hostPath storage or access
-to an NFS share). Therefore, for the best results when running these examples, it is recommended that you utilize a 
+to an NFS share). Therefore, for the best results when running these examples, it is recommended that you utilize a
 single-node architecture as well.
 {{% /notice %}}
 
@@ -1039,7 +1039,7 @@ in the link:/installation/storage-configuration/[Storage Configuration documenta
 include its use of persistent volumes and volume claims to store the backup data files.
 
 A successful backup will perform `pg_basebackup` on the *primary* container and store
-the backup in the `$CCP_STORAGE_PATH` volume under a directory named `primary-backups`. Each
+the backup in the `$CCP_STORAGE_PATH` volume under a directory named `$CCP_NAMESPACE-primary-backups`. Each
 backup will be stored in a subdirectory with a timestamp as the name, allowing any number of backups to be kept.
 
 The backup script will do the following:
@@ -1427,7 +1427,7 @@ mode.
 Lastly, you can test a full recovery using *all* of the WAL files, if
 you remove the `RECOVERY_TARGET_NAME` environment variable completely.
 
-The storage portions of this example can all be found under `$CCP_STORAGE_PATH`.
+The storage portions of this example can all be found under `$CCP_STORAGE_PATH/$CCP_NAMESPACE-restore-pitr`.
 
 == Connection Pooling
 

--- a/hugo/content/installation/storage-configuration.adoc
+++ b/hugo/content/installation/storage-configuration.adoc
@@ -20,14 +20,14 @@ Other storage backends work as well including GCE, EBS, ScaleIO, and
 others, but may require you to modify various examples or configuration.
 
 Crunchy Containers are tested, developed, and examples provided
-that use the various storage types listed above.  This insures 
-that customers have a high degree of choices when it comes to 
-choosing a volume type.  HostPath and NFS allow precise host path 
-choices for where database volumes are persisted.  HostPath and NFS 
-also allow governance models where volume creation is performed 
+that use the various storage types listed above.  This insures
+that customers have a high degree of choices when it comes to
+choosing a volume type.  HostPath and NFS allow precise host path
+choices for where database volumes are persisted.  HostPath and NFS
+also allow governance models where volume creation is performed
 by an administrator instead of the application/developer team.
 
-Where customers desire a dynamic form of volume creation (e.g. self service), 
+Where customers desire a dynamic form of volume creation (e.g. self service),
 storage classes are also supported within the example set.
 
 Environment variables are set to determine how and what storage
@@ -49,6 +49,13 @@ export CCP_STORAGE_CAPACITY=400M
 NOTE: It may be necessary to grant your user in OpenShift or Kubernetes the
 rights to modify the hostaccess SCC. This can be done with the command: `oadm policy add-scc-to-user hostaccess $(oc whoami)`
 
+{{% notice tip %}}
+When running examples against HostPath storage, the run scripts provided in the
+examples will create directories using the following pattern:
+
+`$CCP_STORAGE_PATH/$CCP_NAMESPACE-<EXAMPLE_NAME>`
+{{% /notice %}}
+
 == NFS
 
 NFS can also be used as a storage mechanism.  Instructions
@@ -65,14 +72,21 @@ export CCP_STORAGE_CAPACITY=400M
 ....
 
 In the example above the group ownership of the NFS mount is assumed to be
-*nfsnobody* or *65534*.  Additionally, it is recommended that root not be squashed on 
-the NFS share (`no_root_squash`) in order to ensure the proper directories can be 
+*nfsnobody* or *65534*.  Additionally, it is recommended that root not be squashed on
+the NFS share (`no_root_squash`) in order to ensure the proper directories can be
 created, modified and removed as needed for the various container examples.
 
 {{% notice warning %}}
 The examples in the Crunchy Container suite need access to the NFS export to create
 the directories used by the examples.  The NFS export should be mounted locally so
 the example `run.sh` scripts can do proper setup.
+{{% /notice %}}
+
+{{% notice tip %}}
+NWhen running examples against NFS storage, the run scripts provided in the
+examples will create directories using the following pattern:
+
+`$CCP_STORAGE_PATH/$CCP_NAMESPACE-<EXAMPLE_NAME>`
 {{% /notice %}}
 
 {{%expand "Configuration Notes for NFS" %}}


### PR DESCRIPTION
Changing how we create PVs for hostpath/NFS to avoid collisions when testing in parallel by appending the namespace to the directories, PV name and PV labels.

I decided against doing the `<PATH>/<NAMESPACE>/<EXAMPLE>` structure because it does not allow us to cleanup examples easily (multiple examples in the same namespace with recursive deletes would blow away the whole directory or leave the namespaced directories after testing is complete).  By making this `<PATH>/<NAMESPACE>-<EXAMPLE>` we can clean up properly and support parallelization.

I had to change the name of the PVs to also contain the namespace because PVs are global objects and do not carry namespace metadata.  This caused bugs where PVCs were claiming PVs for different namespaces.  I've updated the selector labels to reflect this change so the examples use the correct PV.

Closes CrunchyData/crunchy-containers#862.