### PR TITLE
Permissions Updates for RHEL containers

### DIFF
--- a/rhel7/9.6/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres-gis.rhel7
@@ -69,7 +69,7 @@ RUN chgrp -R 0 /opt/cpm /var/lib/pgsql \
     
 
 # Link pgbackrest.conf to default location for convenience
-RUN ln -sf /ln/pgbackrest.conf /etc/pgbackrest.conf
+RUN ln -sf /tmp/pgbackrest.conf /etc/pgbackrest.conf
 
 # add volumes to allow override of pg_hba.conf and postgresql.conf
 # add volumes to allow backup of postgres files


### PR DESCRIPTION
Permissions updates to bring all RHEL containers current. Fixes issues with permissions where two different containers access the same storage (i.e. upgrade, backrest restore, etc.)

First pull request of two. The second will be for CentOS changes.