### PR TITLE
Add GIS backrest test cases

### DIFF
--- a/examples/kube/backrest/async-archiving/backrest.json
+++ b/examples/kube/backrest/async-archiving/backrest.json
@@ -43,14 +43,14 @@
                 "securityContext": {
                     "privileged": false
                 },
-                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
                 "readinessProbe": {
                     "exec": {
                         "command": [
                             "/opt/cpm/bin/readiness.sh"
                         ]
                     },
-                    "initialDelaySeconds": 40,
+                    "initialDelaySeconds": 70,
                     "timeoutSeconds": 1
                 },
                 "livenessProbe": {
@@ -59,7 +59,7 @@
                             "/opt/cpm/bin/liveness.sh"
                         ]
                     },
-                    "initialDelaySeconds": 40,
+                    "initialDelaySeconds": 70,
                     "timeoutSeconds": 1
                 },
                 "ports": [

--- a/examples/kube/backrest/async-archiving/run.sh
+++ b/examples/kube/backrest/async-archiving/run.sh
@@ -16,6 +16,10 @@ source ${CCPROOT}/examples/common.sh
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# This var lets us change the image to gis by setting
+# CCP_PG_IMAGE='-gis'.
+export CCP_PG_IMAGE=${CCP_PG_IMAGE:-}
+
 ${DIR}/cleanup.sh
 
 create_storage "backrest-async-archive"

--- a/examples/kube/backrest/backup/backrest.json
+++ b/examples/kube/backrest/backup/backrest.json
@@ -43,14 +43,14 @@
                 "securityContext": {
                     "privileged": false
                 },
-                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
                 "readinessProbe": {
                     "exec": {
                         "command": [
                             "/opt/cpm/bin/readiness.sh"
                         ]
                     },
-                    "initialDelaySeconds": 40,
+                    "initialDelaySeconds": 70,
                     "timeoutSeconds": 1
                 },
                 "livenessProbe": {
@@ -59,7 +59,7 @@
                             "/opt/cpm/bin/liveness.sh"
                         ]
                     },
-                    "initialDelaySeconds": 40,
+                    "initialDelaySeconds": 70,
                     "timeoutSeconds": 1
                 },
                 "ports": [

--- a/examples/kube/backrest/backup/run.sh
+++ b/examples/kube/backrest/backup/run.sh
@@ -18,6 +18,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 ${DIR}/cleanup.sh
 
+# This var lets us change the image to gis by setting
+# CCP_PG_IMAGE='-gis'.
+export CCP_PG_IMAGE=${CCP_PG_IMAGE:-}
+
 create_storage "backrest"
 if [[ $? -ne 0 ]]
 then

--- a/examples/kube/backrest/delta/backrest-restored.json
+++ b/examples/kube/backrest/delta/backrest-restored.json
@@ -40,7 +40,7 @@
         "containers": [
             {
                 "name": "backrest",
-                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
                 "readinessProbe": {
                     "exec": {
                         "command": [

--- a/examples/kube/backrest/delta/post-restore.sh
+++ b/examples/kube/backrest/delta/post-restore.sh
@@ -16,4 +16,8 @@ source ${CCPROOT}/examples/common.sh
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# This var lets us change the image to gis by setting
+# CCP_PG_IMAGE='-gis'.
+export CCP_PG_IMAGE=${CCP_PG_IMAGE:-}
+
 expenv -f $DIR/backrest-restored.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/backrest/full/backrest-restored.json
+++ b/examples/kube/backrest/full/backrest-restored.json
@@ -40,7 +40,7 @@
         "containers": [
             {
                 "name": "backrest",
-                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
                 "readinessProbe": {
                     "exec": {
                         "command": [

--- a/examples/kube/backrest/full/post-restore.sh
+++ b/examples/kube/backrest/full/post-restore.sh
@@ -16,4 +16,8 @@ source ${CCPROOT}/examples/common.sh
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# This var lets us change the image to gis by setting
+# CCP_PG_IMAGE='-gis'.
+export CCP_PG_IMAGE=${CCP_PG_IMAGE:-}
+
 expenv -f $DIR/backrest-restored.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/backrest/pitr/backrest-restored.json
+++ b/examples/kube/backrest/pitr/backrest-restored.json
@@ -40,7 +40,7 @@
         "containers": [
             {
                 "name": "backrest",
-                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
                 "readinessProbe": {
                     "exec": {
                         "command": [

--- a/examples/kube/backrest/pitr/post-restore.sh
+++ b/examples/kube/backrest/pitr/post-restore.sh
@@ -16,4 +16,8 @@ source ${CCPROOT}/examples/common.sh
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# This var lets us change the image to gis by setting
+# CCP_PG_IMAGE='-gis'.
+export CCP_PG_IMAGE=${CCP_PG_IMAGE:-}
+
 expenv -f $DIR/backrest-restored.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -720,6 +720,11 @@ the additional `-backups` the backups will populate in the `pgdata` directory.
 
 ==== Kubernetes and OpenShift
 
+{{% notice tip %}}
+The BackRest examples on Kubernetes/OpenShift can be configured to use the PostGIS images
+by setting the following environment variable: `export CCP_PG_IMAGE='-gis'`
+{{% /notice %}}
+
 ===== Backup
 
 Start the example as follows:

--- a/tools/test-harness/backrest_gis_test.go
+++ b/tools/test-harness/backrest_gis_test.go
@@ -1,0 +1,266 @@
+package tests
+
+import (
+    "time"
+	"testing"
+)
+
+func TestBackrestAsyncArchiveGIS(t *testing.T) {
+	t.Parallel()
+	t.Log("Testing the 'backrest/async-archiving' example...")
+
+    // Extra time because GIS causes backup to take longer.
+    gisTimeout := time.Second * 240
+    harness := setup(t, gisTimeout, true)
+
+	env := []string{"CCP_PG_IMAGE=-gis"}
+	_, err := harness.runExample("examples/kube/backrest/async-archiving/run.sh", env, t)
+	if err != nil {
+		t.Fatalf("Could not run example: %s", err)
+	}
+	if harness.Cleanup {
+		defer harness.Client.DeleteNamespace(harness.Namespace)
+		defer harness.runExample("examples/kube/backrest/async-archiving/cleanup.sh", env, t)
+	}
+
+	pods := []string{"backrest-async-archive"}
+	t.Log("Checking if pods are ready to use...")
+	if err := harness.Client.CheckPods(harness.Namespace, pods); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Running full backup...")
+	// Required for OCP - backrest gets confused when random UIDs aren't found in PAM.
+	// Exec doesn't load bashrc or bash_profile, so we need to set this explicitly.
+	fullBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
+	_, stderr, err := harness.Client.Exec(harness.Namespace, "backrest-async-archive", "backrest", fullBackup)
+	if err != nil {
+		t.Logf("\n%s", stderr)
+		t.Fatalf("Error execing into container: %s", err)
+	}
+
+	t.Log("Running diff backup...")
+	diffBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
+	_, stderr, err = harness.Client.Exec(harness.Namespace, "backrest-async-archive", "backrest", diffBackup)
+	if err != nil {
+		t.Logf("\n%s", stderr)
+		t.Fatalf("Error execing into container: %s", err)
+	}
+
+	report, err := harness.createReport()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(report)
+}
+
+func TestBackrestDeltaRestoreGIS(t *testing.T) {
+	t.Parallel()
+	t.Log("Testing the 'backrest/delta' example...")
+
+    // Extra time because GIS causes backup to take longer.
+    gisTimeout := time.Second * 240
+    harness := setup(t, gisTimeout, true)
+
+	env := []string{"CCP_PG_IMAGE=-gis"}
+	_, err := harness.runExample("examples/kube/backrest/backup/run.sh", env, t)
+	if err != nil {
+		t.Fatalf("Could not run example: %s", err)
+	}
+	if harness.Cleanup {
+		defer harness.Client.DeleteNamespace(harness.Namespace)
+		defer harness.runExample("examples/kube/backrest/backup/cleanup.sh", env, t)
+	}
+
+	t.Log("Checking if pods are ready to use...")
+	pods := []string{"backrest"}
+	if err := harness.Client.CheckPods(harness.Namespace, pods); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Running full backup...")
+	// Required for OCP - backrest gets confused when random UIDs aren't found in PAM.
+	// Exec doesn't load bashrc or bash_profile, so we need to set this explicitly.
+	fullBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
+	_, stderr, err := harness.Client.Exec(harness.Namespace, "backrest", "backrest", fullBackup)
+	if err != nil {
+		t.Logf("\n%s", stderr)
+		t.Fatalf("Error execing into container: %s", err)
+	}
+
+	// Delta Restore
+	_, err = harness.runExample("examples/kube/backrest/delta/run.sh", env, t)
+	if err != nil {
+		t.Fatalf("Could not run example: %s", err)
+	}
+	if harness.Cleanup {
+		defer harness.runExample("examples/kube/backrest/delta/cleanup.sh", env, t)
+	}
+
+	t.Log("Checking if job has completed...")
+	job, err := harness.Client.GetJob(harness.Namespace, "backrest-delta-restore-job")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := harness.Client.IsJobComplete(harness.Namespace, job); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = harness.runExample("examples/kube/backrest/delta/post-restore.sh", env, t)
+	if err != nil {
+		t.Fatalf("Could not run 'post-restore.sh': %s", err)
+	}
+
+	t.Log("Checking if pods are ready to use...")
+	if err := harness.Client.CheckPods(harness.Namespace, pods); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := harness.createReport()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(report)
+}
+
+func TestBackrestFullRestoreGIS(t *testing.T) {
+	t.Parallel()
+	t.Log("Testing the 'backrest/full' example...")
+
+    // Extra time because GIS causes backup to take longer.
+    gisTimeout := time.Second * 240
+    harness := setup(t, gisTimeout, true)
+
+	env := []string{"CCP_PG_IMAGE=-gis"}
+	_, err := harness.runExample("examples/kube/backrest/backup/run.sh", env, t)
+	if err != nil {
+		t.Fatalf("Could not run example: %s", err)
+	}
+	if harness.Cleanup {
+		defer harness.Client.DeleteNamespace(harness.Namespace)
+		defer harness.runExample("examples/kube/backrest/backup/cleanup.sh", env, t)
+	}
+
+	t.Log("Checking if pods are ready to use...")
+	pods := []string{"backrest"}
+	if err := harness.Client.CheckPods(harness.Namespace, pods); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Running full backup...")
+	// Required for OCP - backrest gets confused when random UIDs aren't found in PAM.
+	// Exec doesn't load bashrc or bash_profile, so we need to set this explicitly.
+	fullBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
+	_, stderr, err := harness.Client.Exec(harness.Namespace, "backrest", "backrest", fullBackup)
+	if err != nil {
+		t.Logf("\n%s", stderr)
+		t.Fatalf("Error execing into container: %s", err)
+	}
+
+	// Full Restore
+	_, err = harness.runExample("examples/kube/backrest/full/run.sh", env, t)
+	if err != nil {
+		t.Fatalf("Could not run example: %s", err)
+	}
+	if harness.Cleanup {
+		defer harness.runExample("examples/kube/backrest/full/cleanup.sh", env, t)
+	}
+
+	t.Log("Checking if job has completed...")
+	job, err := harness.Client.GetJob(harness.Namespace, "backrest-full-restore-job")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := harness.Client.IsJobComplete(harness.Namespace, job); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = harness.runExample("examples/kube/backrest/full/post-restore.sh", env, t)
+	if err != nil {
+		t.Fatalf("Could not run 'post-restore.sh': %s", err)
+	}
+
+	t.Log("Checking if pods are ready to use...")
+	restoredPod := []string{"backrest-full-restored"}
+	if err := harness.Client.CheckPods(harness.Namespace, restoredPod); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := harness.createReport()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(report)
+}
+
+func TestBackrestPITRRestoreGIS(t *testing.T) {
+	t.Parallel()
+	t.Log("Testing the 'backrest/pitr' example...")
+
+    // Extra time because GIS causes backup to take longer.
+    gisTimeout := time.Second * 240
+    harness := setup(t, gisTimeout, true)
+
+	env := []string{"CCP_PG_IMAGE=-gis"}
+	_, err := harness.runExample("examples/kube/backrest/backup/run.sh", env, t)
+	if err != nil {
+		t.Fatalf("Could not run example: %s", err)
+	}
+	if harness.Cleanup {
+		defer harness.Client.DeleteNamespace(harness.Namespace)
+		defer harness.runExample("examples/kube/backrest/backup/cleanup.sh", env, t)
+	}
+
+	t.Log("Checking if pods are ready to use...")
+	pods := []string{"backrest"}
+	if err := harness.Client.CheckPods(harness.Namespace, pods); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Running full backup...")
+	// Required for OCP - backrest gets confused when random UIDs aren't found in PAM.
+	// Exec doesn't load bashrc or bash_profile, so we need to set this explicitly.
+	fullBackup := []string{"/usr/bin/pgbackrest", "--stanza=db", "backup", "--type=full"}
+	_, stderr, err := harness.Client.Exec(harness.Namespace, "backrest", "backrest", fullBackup)
+	if err != nil {
+		t.Logf("\n%s", stderr)
+		t.Fatalf("Error execing into container: %s", err)
+	}
+
+	// PITR Restore
+	out, err := harness.runExample("examples/kube/backrest/pitr/run.sh", env, t)
+	if err != nil {
+		t.Fatalf("Could not run example: %s %s", out, err)
+	}
+	if harness.Cleanup {
+		defer harness.runExample("examples/kube/backrest/pitr/cleanup.sh", env, t)
+	}
+
+	t.Log("Checking if job has completed...")
+	job, err := harness.Client.GetJob(harness.Namespace, "backrest-pitr-restore-job")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := harness.Client.IsJobComplete(harness.Namespace, job); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = harness.runExample("examples/kube/backrest/pitr/post-restore.sh", env, t)
+	if err != nil {
+		t.Fatalf("Could not run 'post-restore.sh': %s", err)
+	}
+
+	t.Log("Checking if pods are ready to use...")
+	if err := harness.Client.CheckPods(harness.Namespace, pods); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := harness.createReport()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(report)
+}


### PR DESCRIPTION
There were no examples/test coverage on GIS images using backrest.  I've reused the backrest examples by adding a new var `$CCP_PG_IMAGE` which can be set to `CCP_PG_IMAGE='-gis'` to switch over to GIS.  Run scripts set a proper default so this is non-required variable.

Increased initial delays on these examples because installing PostGIS takes more time during setup and backups take longer (slow storage causes automated tests to fail if value is too low).