### PR TITLE
Echo the directory and file that will be used for the restore.

### DIFF
--- a/bin/pgrestore/start.sh
+++ b/bin/pgrestore/start.sh
@@ -54,6 +54,8 @@ then
     exit 1
 fi
 
+echo_info "Restore will be attempted using backup ${BACKUP_FILE?}"
+
 # Plain pg_dump backups are restored via psql - any kind of custom backup
 # (tar, directory, custom) are restored via pg_restore
 BACKUP_TYPE=$(file ${BACKUP_FILE?})


### PR DESCRIPTION
The full path and filename for the file that will be used to restore the database is now displayed in the logs when running a **pgrestore** container.  Being that the dump files produced by **pgdump** are created within a directory named according to the current timestamp when the backup was created, this allows admins viewing the logs to see exactly what backup file will be utilized for a restore, including the timestamp for that backup. 

Closes CrunchyData/crunchy-containers-test#133

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
When a **pgrestore** container is run, the specific backup file and directory that will be utilized for the restore (and therefore the specific timestamp for that backup) is not displayed.


**What is the new behavior (if this is a feature change)?**
When a **pgrestore** container is run, the full path and filename for the file that will be used to restore the database is now displayed.  This allows admins viewing the logs to see exactly what backup file will be utilized for a restore, including the timestamp for that backup. 

**Other information**:
N/A