### PR TITLE
Fix upgrade PVC definition

### DIFF
--- a/examples/kube/upgrade/upgrade-pvc.json
+++ b/examples/kube/upgrade/upgrade-pvc.json
@@ -2,7 +2,7 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "$CCP_NAMESPACE-upgrade-pgnewdata"
+      "name": "upgrade-pgnewdata"
     },
     "spec": {
       "selector": {


### PR DESCRIPTION
Wrong PVC name causes the example to sit in a pending state.

Closes CrunchyData/crunchy-containers-test#148.