### PR TITLE
Add timeout env to scheduler

### DIFF
--- a/examples/kube/scheduler/scheduler.json
+++ b/examples/kube/scheduler/scheduler.json
@@ -10,9 +10,6 @@
     },
     "spec": {
         "serviceAccountName": "scheduler-sa",
-        "securityContext": {
-            $CCP_SECURITY_CONTEXT
-        },
         "containers": [
             {
                 "name": "scheduler",
@@ -25,6 +22,10 @@
                                 "fieldPath": "metadata.namespace"
                             }
                         }
+                    },
+                    {
+                        "name": "TIMEOUT",
+                        "value": "600"
                     }
                 ],
                 "volumeMounts": []

--- a/hugo/content/container-specifications/crunchy-scheduler.md
+++ b/hugo/content/container-specifications/crunchy-scheduler.md
@@ -25,6 +25,7 @@ The Crunchy Scheduler Docker image contains the following packages:
 **Name**|**Default**|**Description**
 :-----|:-----|:-----
 **NAMESPACE**|None|The namespace the microservice should watch.  Crunchy Scheduler only works in a single namespace.
+**TIMEOUT**|300|The time (in seconds) the scheduler should wait before timing out on a backup job.
 
 ### Optional
 **Name**|**Default**|**Description**


### PR DESCRIPTION
Adding a configurable timeout (with a default of 300 seconds) to the scheduler.

Removed `securityContext` from the example which was causing issues in GKE (there's no volumes attached so there's no need for SC).

Closes CrunchyData/crunchy-containers-test#151.
Closes CrunchyData/crunchy-containers-test#146.