### PR TITLE
Change prometheus to use pod label for job name

### DIFF
--- a/conf/prometheus/prometheus-kube.yml
+++ b/conf/prometheus/prometheus-kube.yml
@@ -23,8 +23,7 @@ scrape_configs:
     regex: (^[^-]*).*
     target_label: instance
     replacement: '$1'
-  - source_labels: [__meta_kubernetes_namespace,__meta_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_namespace,__meta_kubernetes_pod_label_name]
     target_label: job
-    regex: '(^[^-]*).*'
     separator: ': '
     replacement: '$1$2'

--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -2263,10 +2263,20 @@ with the following credentials:
 * Password: *password*
 
 By default, Prometheus detects which environment its running on (Docker, Kubernetes, or OpenShift Container Platform)
-and applies a default configuration. If this container is running on Kubernetes or OpenShift Container Platform,
-it will use the Kubernetes API to discover pods with the label `"crunchy-collect": "true"`.
+and applies a default configuration. 
 
-The collect container *must* have this label to be discovered in these environments.
+When running in Kuberenetes and OpenShift, the following two labels are required by 
+the deployments:
+
+ * `"crunchy_collect": "true"`
+ * `"name": "some-pod-name-here"`
+
+The `crunchy_collect` label allows Prometheus to find all pods that are serving metrics 
+to be scraped for storage.
+
+The `name` label allows Prometheus to rewrite the name of the pod so if it changes there's not 
+duplicate entries.
+
 Additionally, the collect container uses a special PostgreSQL role `ccp_monitoring`.
 This user is created by setting the `PGMONITOR_PASSWORD` environment variable on the
 PostgreSQL container.


### PR DESCRIPTION
Before we parsed the pod name to create a job name which is used by the graphs to filter metrics for a specific pod.  This approach was prone to failure due to the limitations of what we can expect with regex.  To make this easier to configure by both the container and users, I changed this to use the pod label `name`.

Closes CrunchyData/crunchy-containers-test#142.