### PR TITLE
Add namespace to PV cleanup in PITR example

### DIFF
--- a/examples/kube/pitr/run-restore-pitr.sh
+++ b/examples/kube/pitr/run-restore-pitr.sh
@@ -27,7 +27,7 @@ $CCPROOT/examples/waitforterm.sh restore-pitr ${CCP_CLI?}
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc recover-pvc restore-pitr-pgdata
 if [[ -z "$CCP_STORAGE_CLASS" ]]
 then
-    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv recover-pv restore-pitr-pgdata
+    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv ${CCP_NAMESPACE?}-recover-pv ${CCP_NAMESPACE?}-restore-pitr-pgdata
 fi
 
 dir_check_rm "restore-pitr"


### PR DESCRIPTION
Missing namespace from PV name in `run-restore-pitr.sh` script. 

Closes CrunchyData/crunchy-containers-test#143.