### PR TITLE
Add script outputs to test harness

### DIFF
--- a/tools/kubeapi/job.go
+++ b/tools/kubeapi/job.go
@@ -1,6 +1,7 @@
 package kubeapi
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -39,7 +40,7 @@ func (k *KubeAPI) IsJobComplete(namespace string, job *v1batch.Job) error {
 				return err
 			}
 			if j.Status.Failed != 0 {
-				return fmt.Errorf("job failed to run: %s", job)
+				return errors.New("job failed to run")
 			}
 			if j.Status.Succeeded != 0 {
 				return nil

--- a/tools/test-harness/README.md
+++ b/tools/test-harness/README.md
@@ -20,6 +20,25 @@ This harness can be run both in and out of a Kubernetes cluster.
 * `GOMAXPROCS` env should be set to the amount of cores the test harness should use (parallization
   option)
 
+## Configuration
+
+The following environment variables can be used to configure the test harness:
+
+| Name                     | Default | Description                                                             |
+|--------------------------|---------|-------------------------------------------------------------------------|
+| `CCP_HARNESS_CLEANUP`    | true    | Configures the harness to run cleanup scripts after tests are complete. |
+| `CCP_HARNESS_DEBUG`      | true    | Configures the harness to log the output of the scripts being executed. |
+| `CCP_HARNESS_IN_CLUSTER` | false   | Configures the harness to run in/out of a Kubernetes cluster.           |
+
+
+To export these environment variables, run the following commands:
+
+```bash
+export CCP_HARNESS_CLEANUP=true
+export CCP_HARNESS_DEBUG=true
+export CCP_HARNESS_IN_CLUSTER=false
+```
+
 ## Running
 
 *Note*: It's recommended to disable the `go test` timeout (it defaults to 10 minutes which

--- a/tools/test-harness/setup_test.go
+++ b/tools/test-harness/setup_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	pg "github.com/crunchydata/crunchy-containers/tools/test-harness/data"
 	"github.com/crunchydata/crunchy-containers/tools/kubeapi"
+	pg "github.com/crunchydata/crunchy-containers/tools/test-harness/data"
 	"github.com/crunchydata/crunchy-containers/tools/test-harness/runner"
 )
 
@@ -16,19 +16,21 @@ type harness struct {
 	Cleanup   bool
 	Client    *kubeapi.KubeAPI
 	InCluster bool
+	Debug     bool
 }
 
 func setup(t *testing.T, timeout time.Duration, cleanup bool) *harness {
 	var test harness
-	test.Cleanup = true
-	test.InCluster = false
-	test.Namespace = "default"
+	test.Cleanup = envCheckBool("CCP_HARNES_CLEANUP", true)
+	test.Debug = envCheckBool("CCP_HARNESS_DEBUG", true)
+	test.InCluster = envCheckBool("CCP_HARNESS_IN_CLUSTER", false)
 
 	t.Log("Running Initialization Checks...")
 	envs := []string{
 		"CCPROOT", "CCP_BASEOS", "CCP_PGVERSION",
 		"CCP_IMAGE_PREFIX", "CCP_IMAGE_TAG",
 		"CCP_STORAGE_MODE", "CCP_STORAGE_CAPACITY", "CCP_CLI"}
+
 	if err := runner.GetEnv(envs); err != nil {
 		t.Fatal(err)
 	}

--- a/tools/test-harness/utils_test.go
+++ b/tools/test-harness/utils_test.go
@@ -18,6 +18,9 @@ func (h *harness) runExample(dir string, env []string, t *testing.T) (string, er
 	run := fmt.Sprintf("${CCPROOT}/%s", dir)
 	env = append(env, fmt.Sprintf("CCP_NAMESPACE=%s", h.Namespace))
 	out, err := runner.Run(os.ExpandEnv(run), env)
+	if h.Debug {
+		t.Logf("Output from script: %s\n%s", run, out)
+	}
 	return out, err
 }
 
@@ -129,4 +132,15 @@ func randomPort() int {
 	seed := rand.NewSource(time.Now().UnixNano())
 	r := rand.New(seed)
 	return r.Intn(max-min) + min
+}
+
+func envCheckBool(env string, defaultValue bool) bool {
+	value := os.Getenv(env)
+	if value == "" {
+		return defaultValue
+	}
+	if value == "true" {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Added script outputs to the test harness to additional debugging capabilities.  Added some additional flags for configuring the harness without changing code.

Closes CrunchyData/crunchy-containers#879.