### PR TITLE
Removed 'chgrp' Command from pgdump Dockerfile

### DIFF
--- a/bin/pgdump/start.sh
+++ b/bin/pgdump/start.sh
@@ -24,7 +24,6 @@ cat >> "${PGPASSFILE?}" <<-EOF
 EOF
 
 chmod 600 ${PGPASSFILE?}
-chgrp -R 0 ${PGPASSFILE?}
 
 pgisready ${PGDUMP_DB?} ${PGDUMP_HOST?} ${PGDUMP_PORT?} ${PGDUMP_USER?}
 


### PR DESCRIPTION
Removed the `chgrp -R 0 ${PGPASSFILE?}` command from the pgdump Dockerfile, since it is no longer needed to successfully run the **pgdump** container.  This will prevent the following error from being thrown when running in an environment other than OCP (e.g. a local Kubernetes cluster):

`chgrp: changing group of '/tmp/pgpass': Operation not permitted`

Closes CrunchyData/crunchy-containers-test#144

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The following error is thrown when running the **pgdump** container in an environment other than OCP (e.g. a local Kubernetes cluster):

`chgrp: changing group of '/tmp/pgpass': Operation not permitted`


**What is the new behavior (if this is a feature change)?**
The `chgrp` error is no longer thrown when running the **pgdump** container in an envrionment other than OCP.


**Other information**:
N/A