### PR TITLE
Add filesystem dashboard for volumes in Grafana

### DIFF
--- a/bin/grafana/start.sh
+++ b/bin/grafana/start.sh
@@ -24,6 +24,7 @@ ls -la /opt/cpm/bin
 
 DASHBOARDS=(
     CRUD_Details
+    FilesystemDetailsKube
     PostgreSQL
     PostgreSQLDetails
     TableSize_Detail

--- a/conf/grafana/FilesystemDetailsKube.json
+++ b/conf/grafana/FilesystemDetailsKube.json
@@ -1,0 +1,272 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 5,
+  "iteration": 1541625844844,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "height": "250px",
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "minSpan": null,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "100-(100*(node_filesystem_free_bytes{job=\"[[jobname]]\", mountpoint!~\"/|/conf|/etc.*|/run.*\", fstype!~\".*tmpfs.*|.*root.*|.*pipe.*\"} / node_filesystem_size_bytes{job=\"[[jobname]]\", mountpoint!~\"/|/conf|/etc.*|/run.*\", fstype!~\".*tmpfs.*|.*root.*|.*pipe.*\"}))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{mountpoint}}",
+          "refId": "A"
+        },
+        {
+          "expr": "100-(100*(node_filesystem_free{job=\"[[jobname]]\", mountpoint!~\"/|/conf|/etc.*|/run.*\", fstype!~\".*tmpfs.*|.*root.*|.*pipe.*\"} / node_filesystem_size{job=\"[[jobname]]\", mountpoint!~\"/|/conf|/etc.*|/run.*\", fstype!~\".*tmpfs.*|.*root.*|.*pipe.*\"}))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{mountpoint}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Filesystem Usage %",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "height": "250px",
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "node_filesystem_size_bytes{job=\"[[jobname]]\", mountpoint!~\"/|/conf|/etc.*|/run.*\", fstype!~\".*tmpfs.*|.*root.*|.*pipe.*\"} - node_filesystem_free_bytes{job=\"[[jobname]]\", mountpoint!~\"/|/conf|/etc.*|/run.*\", fstype!~\".*tmpfs.*|.*root.*|.*pipe.*\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{mountpoint}}",
+          "refId": "A"
+        },
+        {
+          "expr": "node_filesystem_size{job=\"[[jobname]]\", mountpoint!~\"/|/conf|/etc.*|/run.*\", fstype!~\".*tmpfs.*|.*root.*|.*pipe.*\"} - node_filesystem_free{job=\"[[jobname]]\", mountpoint=\"/pgdata|/backrestrepo|/pgwal\", fstype!~\".*tmpfs.*|.*root.*|.*pipe.*\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{mountpoint}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Filesystem Space Used",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "upgrade: primary-metrics",
+          "value": "upgrade: primary-metrics"
+        },
+        "datasource": "PROMETHEUS",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "jobname",
+        "options": [],
+        "query": "label_values(job)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "FilesystemDetails",
+  "uid": "g8iVvnHmz",
+  "version": 2
+}

--- a/examples/kube/metrics/cleanup.sh
+++ b/examples/kube/metrics/cleanup.sh
@@ -22,6 +22,7 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} sa prometheus-sa
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod metrics
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment primary-metrics replica-metrics
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service metrics primary-metrics replica-metrics
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap metrics-pgconf
 
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc metrics-prometheusdata metrics-grafanadata
 

--- a/examples/kube/metrics/configs/pgbackrest.conf
+++ b/examples/kube/metrics/configs/pgbackrest.conf
@@ -1,0 +1,6 @@
+[db]
+db-path=/pgdata/HOSTNAME
+
+[global]
+repo-path=/backrestrepo/HOSTNAME-backups
+log-path=/tmp

--- a/examples/kube/metrics/primary.json
+++ b/examples/kube/metrics/primary.json
@@ -95,6 +95,23 @@
                                 "name": "JOB_NAME",
                                 "value": "primary-metrics"
                             }
+                        ],
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/pgdata",
+                                "name": "pgdata",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/pgwal",
+                                "name": "pgwal",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/backrestrepo",
+                                "name": "backrestrepo",
+                                "readOnly": true
+                            }
                         ]
                     },
                     {
@@ -162,12 +179,35 @@
                             {
                                 "name": "PGDATA_PATH_OVERRIDE",
                                 "value": "primary-metrics"
+                            },
+                            {
+                                "name": "ARCHIVE_TIMEOUT",
+                                "value": "60"
+                            },
+                            {
+                                "name": "XLOGDIR",
+                                "value": "true"
                             }
                         ],
                         "volumeMounts": [
                             {
                                 "mountPath": "/pgdata",
                                 "name": "pgdata",
+                                "readOnly": false
+                            },
+                            {
+                                "mountPath": "/pgconf",
+                                "name": "pgconf",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/pgwal",
+                                "name": "pgwal",
+                                "readOnly": false
+                            },
+                            {
+                                "mountPath": "/backrestrepo",
+                                "name": "backrestrepo",
                                 "readOnly": false
                             }
                         ],
@@ -184,6 +224,20 @@
                 "volumes": [
                     {
                         "name": "pgdata",
+                        "emptyDir": {}
+                    },
+                    {
+                        "name": "pgwal",
+                        "emptyDir": {}
+                    },
+                    {
+                        "name": "pgconf",
+                        "configMap": {
+                            "name": "metrics-pgconf"
+                        }
+                    },
+                    {
+                        "name": "backrestrepo",
                         "emptyDir": {}
                     }
                 ],

--- a/examples/kube/metrics/replica.json
+++ b/examples/kube/metrics/replica.json
@@ -91,6 +91,23 @@
                                 "name": "DATA_SOURCE_NAME",
                                 "value": "postgresql://ccp_monitoring:password@127.0.0.1:5432/postgres?sslmode=disable"
                             }
+                        ],
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/pgdata",
+                                "name": "pgdata",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/pgwal",
+                                "name": "pgwal",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/backrestrepo",
+                                "name": "backrestrepo",
+                                "readOnly": true
+                            }
                         ]
                     },
                     {
@@ -162,12 +179,35 @@
                             {
                                 "name": "PGDATA_PATH_OVERRIDE",
                                 "value": "replica-metrics"
+                            },
+                            {
+                                "name": "ARCHIVE_TIMEOUT",
+                                "value": "60"
+                            },
+                            {
+                                "name": "XLOGDIR",
+                                "value": "true"
                             }
                         ],
                         "volumeMounts": [
                             {
                                 "mountPath": "/pgdata",
                                 "name": "pgdata",
+                                "readOnly": false
+                            },
+                            {
+                                "mountPath": "/pgconf",
+                                "name": "pgconf",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/pgwal",
+                                "name": "pgwal",
+                                "readOnly": false
+                            },
+                            {
+                                "mountPath": "/backrestrepo",
+                                "name": "backrestrepo",
                                 "readOnly": false
                             }
                         ],
@@ -184,6 +224,20 @@
                 "volumes": [
                     {
                         "name": "pgdata",
+                        "emptyDir": {}
+                    },
+                    {
+                        "name": "pgwal",
+                        "emptyDir": {}
+                    },
+                    {
+                        "name": "pgconf",
+                        "configMap": {
+                            "name": "metrics-pgconf"
+                        }
+                    },
+                    {
+                        "name": "backrestrepo",
                         "emptyDir": {}
                     }
                 ],

--- a/examples/kube/metrics/run.sh
+++ b/examples/kube/metrics/run.sh
@@ -26,6 +26,10 @@ then
     exit 1
 fi
 
+${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} \
+    configmap metrics-pgconf \
+    --from-file ${DIR?}/configs/pgbackrest.conf
+
 expenv -f $DIR/metrics.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 expenv -f $DIR/primary.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 expenv -f $DIR/replica.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -


### PR DESCRIPTION
Added a custom dashboard that will display [mount usage](https://i.imgur.com/mS8BbWo.png) (total % of volume used and actual size) for all the custom mount points (`/pgdata`, `/pgwal`, `/backrestrepo`, `/pgconf`... any thing that's mounted to collect).

Tuned the metrics example to included backrest and wal archiving so they show up in the new dashboard.

It's suggested that volumes are mounted to collect container as read only.

Closes CrunchyData/crunchy-containers#891.