### PR TITLE
Instruct the User to Run Examples as a Regular User and Not a cluster-admin

### DIFF
--- a/hugo/content/installation/environment-setup.adoc
+++ b/hugo/content/installation/environment-setup.adoc
@@ -290,6 +290,11 @@ user such as:
 oc login -u someuser
 ....
 
+{{% notice tip %}}
+For the best results, it is recommended that you run the examples with a user that has **NOT** been
+assigned the **cluster-admin** cluster role.
+{{% /notice %}}
+
 For our development purposes only, we typically specify the OCP
 Authorization policy of `AllowAll` as documented here:
 
@@ -323,12 +328,33 @@ $ oc project demo
 Now using project "demo" on server "https://127.0.0.1:8443".
 ....
 
-Finally, you will want to ensure the proper privileges are added to the user in order to
-have the ability to create persistent volumes. A command similar to the following can be
-used to accomplish this, by adding the cluster-admin role to the *demo* user:
+When self-provisioning a new project using the `oc new-project` command, the current user (i.e.,
+the user you used when logging into OCP with the `oc login` command) will automatically be assigned
+to the **admin** role for that project.  This will allow the user to create the majority of the 
+objects needed to successfully run the examples.  However, in order to create the **Persistent 
+Volume** objects needed to properly configure storage for the examples, an additional role is 
+needed. Specifically, a new role is needed that can both create and delete **Persistent Volumes**.
+
+Using the following two commands, create a new Cluster Role that has the ability to create and delete
+persistent volumes, and then assign that role to your current user:
+
+{{% notice warning %}}
+Please be aware that the following two commands require privileges that your current user may not 
+have. In the event that you are unable to run these commands, and do not have access to a user 
+that is able to run them (e.g., the **system:admin** user that is created by default when 
+installing OCP), please contact your local OCP administrator to run the commands on your behalf, or
+grant you the access required to run them yourself.
+{{% /notice %}}
+
 ....
-oc adm policy add-cluster-role-to-user cluster-admin demo
+$ oc create clusterrole crunchytester --verb="create,delete" --resource=persistentvolumes
+clusterrole "crunchytester" created
+
+$ oc adm policy add-cluster-role-to-user crunchytester someuser
+cluster role "crunchytester" added: "someuser"
 ....
+
+Your user should now have the roles and privileges required to run the examples.
 
 == Next Steps
 


### PR DESCRIPTION
In the **OpenShift** section of the **Creating a Demo Namespace** portion of the **Environment Setup** page, the user is now told that in order to achieve the best results when running the examples, they should not run them as a user that has the **cluster-admin** cluster role.  Additionally, instructions are now provided to properly configure a regular user (i.e. a non-**cluster-admin** user) with the specific roles and privileges needed to successfully run the examples.

Instructing the user to properly configure and utilize a regular account and not a **cluster-admin** account when running the examples on **OCP** will ensure the proper Security Context Constraint, i.e. the **restricted** SCC, is applied when running the examples.  This will ensure the expected/intended user is utilized to run the pods defined in the examples, therefore allowing the various Crunchy containers to function as intended/designed within an OCP environment.

Closes CrunchyData/crunchy-containers#885

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Unexpected behavior is experienced when running the **crunchy-postgres** container on OCP through the direct creation of a pod (and not as a result of creating a deployment, etc.) with a user that has been assigned the **cluster-admin** role.  Specifically, the pod runs as a different user when the pod is created directly, e.g. not through a deployment, than if the pod is created as the result of a deployment.  This leads to unintended side-effects and errors when running the various examples and therefore deploying various Crunchy containers.


**What is the new behavior (if this is a feature change)?**
The user is now instructed to run the examples as a user that does not have the **cluster-admin** role, while also being provided with instructions for configuring a regular user account with the roles and privileges needed to run the examples.  This will ensure the proper **restricted** Security Context Constraint is applied to the pod when running the examples, which subsequently ensures the anticipated user is used to run the container(s) within a pod, allowing them to function as intended.


**Other information**:
N/A