### PR TITLE
Enable optional rpms for badger install

### DIFF
--- a/rhel7/10/Dockerfile.pgbadger.rhel7
+++ b/rhel7/10/Dockerfile.pgbadger.rhel7
@@ -34,7 +34,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 
 RUN yum -y update \
  && yum -y install epel-release \
- && yum -y install \
+ && yum -y install --enablerepo="rhel-7-server-optional-rpms" \
       gettext \
       hostname \
       pgbadger \
@@ -58,7 +58,7 @@ VOLUME ["/pgdata", "/report"]
 
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
-	
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 

--- a/rhel7/11/Dockerfile.pgbadger.rhel7
+++ b/rhel7/11/Dockerfile.pgbadger.rhel7
@@ -34,7 +34,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 
 RUN yum -y update \
  && yum -y install epel-release \
- && yum -y install \
+ && yum -y install --enablerepo="rhel-7-server-optional-rpms" \
       gettext \
       hostname \
       pgbadger \
@@ -58,7 +58,7 @@ VOLUME ["/pgdata", "/report"]
 
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
-	
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 

--- a/rhel7/9.5/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbadger.rhel7
@@ -37,7 +37,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 
 RUN yum -y update \
  && yum -y install epel-release \
- && yum -y install \
+ && yum -y install --enablerepo="rhel-7-server-optional-rpms" \
       gettext \
       hostname \
       pgbadger \
@@ -61,7 +61,7 @@ VOLUME ["/pgdata", "/report"]
 
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
-	
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 

--- a/rhel7/9.6/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbadger.rhel7
@@ -34,7 +34,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 
 RUN yum -y update \
  && yum -y install epel-release \
- && yum -y install \
+ && yum -y install --enablerepo="rhel-7-server-optional-rpms" \
       gettext \
       hostname \
       pgbadger \
@@ -58,7 +58,7 @@ VOLUME ["/pgdata", "/report"]
 
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
-	
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 


### PR DESCRIPTION
RHEL7 Badger images failing builds, required extra RPMs to be enabled.  

Closes CrunchyData/crunchy-containers-test#155.