### PR TITLE
Added Missing nss_wrapper Package to PG 9.5 & 9.6 backrest-restore Dockerfiles

### DIFF
--- a/rhel7/9.5/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.5/Dockerfile.backrest-restore.rhel7
@@ -34,6 +34,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y update && yum -y install  \
 	hostname \
 	gettext \
+        nss_wrapper \
  	procps-ng  \
  && yum -y clean all
 

--- a/rhel7/9.6/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.6/Dockerfile.backrest-restore.rhel7
@@ -34,6 +34,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y update && yum -y install  \
 	hostname \
 	gettext \
+        nss_wrapper \
  	procps-ng  \
  && yum -y clean all
 


### PR DESCRIPTION
Added the missing **nss_wrapper** package to the PG 9.5 and 9.6 backrest-restore Dockerfiles.  This will address the errors currently seen as a result of the missing **nss_wrapper** package when running backrest restore.

Closes CrunchyData/crunchy-containers-test#150

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Errors are thrown when running backrest restore for PG 9.5 and 9.6 due to a missing **nss_wrapper** package.


**What is the new behavior (if this is a feature change)?**
Missing **nss_wrapper** package errors are no longer thrown when running backrest restore for PG 9.5 and 9.6.


**Other information**:
N/A