### PR TITLE
Add custom backup job template to scheduler example

### DIFF
--- a/examples/kube/scheduler/cleanup.sh
+++ b/examples/kube/scheduler/cleanup.sh
@@ -16,6 +16,7 @@ source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap -l crunchy-scheduler=true
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap scheduler-backup-template
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job primary-backup-pgbasebackup
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod scheduler
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret primary-primaryuser-secret

--- a/examples/kube/scheduler/configs/backup-template.json
+++ b/examples/kube/scheduler/configs/backup-template.json
@@ -1,0 +1,69 @@
+{
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+        "name": "{{.Name}}",
+        "labels": {
+            "vendor": "crunchydata",
+            "pgbackup": "true",
+            "pg-cluster": "{{.Name}}"
+        }
+    },
+    "spec": {
+        "template": {
+            "metadata": {
+                "name": "{{.Name}}",
+                "labels": {
+                    "vendor": "crunchydata",
+                    "pgbackup": "true",
+                    "pg-cluster": "{{.Name}}"
+                }
+            },
+            "spec": {
+                "securityContext": {
+                     $CCP_SECURITY_CONTEXT
+                },
+                "volumes": [
+                    {
+                        "name": "pgdata",
+                        "persistentVolumeClaim": {
+                            "claimName": "{{.PvcName}}"
+                        }
+                    }
+				],
+                "containers": [
+                    {
+                        "name": "backup",
+                        "image": "{{.CCPImagePrefix}}/crunchy-backup:{{.CCPImageTag}}",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/pgdata",
+                                "name": "pgdata",
+                                "readOnly": false
+                            }
+                        ],
+                        "env": [
+                            {
+                                "name": "BACKUP_HOST",
+                                "value": "{{.BackupHost}}"
+                            },
+                            {
+                                "name": "BACKUP_USER",
+                                "value": "{{.BackupUser}}"
+                            },
+                            {
+                                "name": "BACKUP_PASS",
+                                "value": "{{.BackupPass}}"
+                            },
+                            {
+                                "name": "BACKUP_PORT",
+                                "value": "{{.BackupPort}}"
+                            }
+                        ]
+                    }
+                ],
+                "restartPolicy": "Never"
+            }
+        }
+    }
+}

--- a/examples/kube/scheduler/run.sh
+++ b/examples/kube/scheduler/run.sh
@@ -18,5 +18,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 ${DIR}/cleanup.sh
 
+expenv -f $DIR/configs/backup-template.json > /tmp/backup-template.json
+
+${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} configmap scheduler-backup-template \
+    --from-file /tmp/backup-template.json
+
 expenv -f $DIR/scheduler-sa.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 expenv -f $DIR/scheduler.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/scheduler/scheduler.json
+++ b/examples/kube/scheduler/scheduler.json
@@ -28,9 +28,22 @@
                         "value": "600"
                     }
                 ],
-                "volumeMounts": []
+                "volumeMounts": [
+                    {
+                        "mountPath": "/configs",
+                        "name": "configs",
+                        "readOnly": true
+                    }
+                ]
             }
         ],
-        "volumes": []
+        "volumes": [
+            {
+                "name": "configs",
+                "configMap": {
+                    "name": "scheduler-backup-template"
+                }
+            }
+        ]
     }
 }

--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -309,6 +309,14 @@ To configure Crunchy Scheduler to create pgBaseBackup scheduled backups, the fol
   for the structure required by the Scheduler.
 * The name of the PVC created for the backups.  This should be created by the user prior to scheduling the task.
 
+{{% notice tip %}}
+When using pgBaseBackup schedules, it may be required to apply specific `supplementalGroups` or an `fsGroup` 
+to the backup job created by the scheduler.  To apply a specific `securityContext` for your 
+storage provider, mount a `backup-template.json` to `/configs` on the scheduler pod.
+
+For an example of applying a custom template, link:https://github.com/CrunchyData/crunchy-containers/blob/scheduler/examples/kube/scheduler[see the schedule example].
+{{% /notice %}}
+
 ==== Kubernetes and OpenShift
 
 First, start the PostgreSQL example created for the Scheduler by running the following commands:


### PR DESCRIPTION
Adding a custom pgBaseBackup job template as a configmap to the scheduler example to support securityContext environments (GKE standard block storage).

Added a note about this feature which was undocumented.

Closes CrunchyData/crunchy-containers-test#158.