### PR TITLE
Update config_local for pgadmin4

### DIFF
--- a/conf/pgadmin4/config_local.py
+++ b/conf/pgadmin4/config_local.py
@@ -117,7 +117,7 @@ NODE_BLACKLIST = []
 #       from it, notably various paths such as LOG_FILE and anything
 #       using DATA_DIR.
 
-if builtins.SERVER_MODE is None:
+if (not hasattr(builtins, 'SERVER_MODE')) or builtins.SERVER_MODE is None:
     SERVER_MODE = True
 else:
     SERVER_MODE = builtins.SERVER_MODE


### PR DESCRIPTION
`config_local.py` syntax recently changed, fixing the SERVER_MODE logic to reflect this.

Closes CrunchyData/crunchy-containers-test#160.