### PR TITLE
Update postgres exporter version

### DIFF
--- a/bin/install-deps.sh
+++ b/bin/install-deps.sh
@@ -16,7 +16,7 @@
 # Dependency Versions
 PROMETHEUS_VERSION=2.3.1
 GRAFANA_VERSION=5.2.1
-POSTGRES_EXPORTER_VERSION=0.4.6
+POSTGRES_EXPORTER_VERSION=0.4.7
 NODE_EXPORTER_VERSION=0.16.0
 PGMONITOR_COMMIT='dffb2b5eb04ba13ee47ae81950410738d15e8c76'
 OPENSHIFT_CLIENT='https://github.com/openshift/origin/releases/download/v3.10.0/openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit.tar.gz'


### PR DESCRIPTION
The `postgresql exporter` inside of the collect container was crashing:

```
panic: Unknown unit for runtime variable: "B"

goroutine 17 [running]:
main.(*pgSetting).metric(0xc42027fb30, 0xc4201d5da0, 0x5)
	/home/travis/gopath/src/github.com/wrouesnel/postgres_exporter/cmd/postgres_exporter/pg_setting.go:69 +0x52b
main.querySettings(0xc4201c6000, 0xc420186fa0, 0x0, 0x0)
	/home/travis/gopath/src/github.com/wrouesnel/postgres_exporter/cmd/postgres_exporter/pg_setting.go:38 +0x215
main.(*Exporter).scrape(0xc4201ba100, 0xc4201c6000)
	/home/travis/gopath/src/github.com/wrouesnel/postgres_exporter/cmd/postgres_exporter/postgres_exporter.go:1048 +0x4a8
main.(*Exporter).Collect(0xc4201ba100, 0xc4201c6000)
	/home/travis/gopath/src/github.com/wrouesnel/postgres_exporter/cmd/postgres_exporter/postgres_exporter.go:767 +0x3c
main.(*Exporter).Describe(0xc4201ba100, 0xc4201684e0)
	/home/travis/gopath/src/github.com/wrouesnel/postgres_exporter/cmd/postgres_exporter/postgres_exporter.go:760 +0xb0
github.com/wrouesnel/postgres_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Register.func1(0x92a4e0, 0xc4201ba100, 0xc4201684e0)
	/home/travis/gopath/src/github.com/wrouesnel/postgres_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:242 +0x3b
created by github.com/wrouesnel/postgres_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Register
	/home/travis/gopath/src/github.com/wrouesnel/postgres_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:241 +0x14e
```

After reviewing the issues for that project, this was fixed in `0.4.7`.  Updating the exporter to this version fixed the crash.

Closes CrunchyData/crunchy-containers-test#164.