### PR TITLE
Added the 'list' Verb to the Command to Create the 'crunchytester' Cluster Role

### DIFF
--- a/hugo/content/installation/environment-setup.adoc
+++ b/hugo/content/installation/environment-setup.adoc
@@ -347,7 +347,7 @@ grant you the access required to run them yourself.
 {{% /notice %}}
 
 ....
-$ oc create clusterrole crunchytester --verb="create,delete" --resource=persistentvolumes
+$ oc create clusterrole crunchytester --verb="list,create,delete" --resource=persistentvolumes
 clusterrole "crunchytester" created
 
 $ oc adm policy add-cluster-role-to-user crunchytester someuser


### PR DESCRIPTION
The command to create the **crunchytester** Cluster Role in the **Creating A Demo Namespace/OpenShift** section of the **Environment Setup** page has been updated to include the **list** verb.  This will allow the user to list (i.e. view) Persistent Volumes created within the cluster when running the various examples.

Closes CrunchyData/crunchy-containers-test#159

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
While the the user is currently able to create and delete persistent volumes in order to run the various examples, they are unable to list the various persistent volumes being created when running the examples.


**What is the new behavior (if this is a feature change)?**
In addition to being able to create and delete persistent volumes in order to run the various examples, the user can now also view the various persistent volumes being created when running the examples.


**Other information**:
N/A