### PR TITLE
Update statefulset SA rbac

### DIFF
--- a/examples/kube/statefulset/cleanup.sh
+++ b/examples/kube/statefulset/cleanup.sh
@@ -16,8 +16,7 @@ source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} statefulset statefulset
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} sa statefulset-sa
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} clusterrolebinding statefulset-sa
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} sa,role,rolebindings statefulset-sa
 ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc -l 'app=statefulset'
 
 if [[ -z "$CCP_STORAGE_CLASS" ]]

--- a/examples/kube/statefulset/run.sh
+++ b/examples/kube/statefulset/run.sh
@@ -25,17 +25,7 @@ then
     exit 1
 fi
 
-# As of Kube 1.6, it is necessary to allow the service account to perform
-# a label command. For this example, we open up wide permissions
-# for all serviceaccounts. This is NOT for production!
-
-${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} clusterrolebinding statefulset-sa \
-  --clusterrole=cluster-admin \
-  --user=admin \
-  --user=kubelet \
-  --group=system:serviceaccounts \
-  --namespace=$CCP_NAMESPACE
-
+expenv -f $DIR/statefulset-sa.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 expenv -f $DIR/statefulset-services.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 
 if [[ -v CCP_STORAGE_CLASS ]]

--- a/examples/kube/statefulset/statefulset-sa.json
+++ b/examples/kube/statefulset/statefulset-sa.json
@@ -1,0 +1,52 @@
+{
+    "apiVersion": "rbac.authorization.k8s.io/v1beta1",
+    "kind": "Role",
+    "metadata": {
+        "name": "statefulset-sa",
+        "namespace": "$CCP_NAMESPACE"
+    },
+    "rules": [
+        {
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "pods"
+            ],
+            "verbs": [
+                "get",
+                "list",
+                "update"
+            ]
+        }
+    ]
+}
+
+{
+    "apiVersion": "v1",
+    "kind": "ServiceAccount",
+    "metadata": {
+        "name": "statefulset-sa",
+        "namespace": "$CCP_NAMESPACE"
+    }
+}
+
+{
+    "apiVersion": "rbac.authorization.k8s.io/v1beta1",
+    "kind": "RoleBinding",
+    "metadata": {
+        "name": "statefulset-sa"
+    },
+    "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "statefulset-sa"
+    },
+    "subjects": [
+        {
+            "kind": "ServiceAccount",
+            "name": "statefulset-sa",
+            "namespace": "$CCP_NAMESPACE"
+        }
+    ]
+}

--- a/examples/kube/statefulset/statefulset-services.json
+++ b/examples/kube/statefulset/statefulset-services.json
@@ -1,12 +1,4 @@
 {
-  "apiVersion": "v1",
-  "kind": "ServiceAccount",
-  "metadata": {
-    "name": "statefulset-sa"
-  }
-}
-
-{
     "kind": "Service",
     "apiVersion": "v1",
     "metadata": {

--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -1886,7 +1886,7 @@ To shutdown the instance and remove the container for each example, run the foll
 
 ==== Kubernetes and OpenShift
 
-Start the example as follows:
+First, start the example with the following command:
 ....
 cd $CCPROOT/examples/kube/statefulset
 ./run.sh

--- a/tools/test-harness/statefulset_test.go
+++ b/tools/test-harness/statefulset_test.go
@@ -8,7 +8,7 @@ import (
 func TestStatefulSet(t *testing.T) {
 	t.Parallel()
 	t.Log("Testing the 'statefulset' example...")
-	// This example deploys replicas after primary is ready, 
+	// This example deploys replicas after primary is ready,
 	// so extra time in the timeout is allocated
 	harness := setup(t, time.Duration(time.Second*240), true)
 
@@ -33,9 +33,9 @@ func TestStatefulSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-    if len(pods) == 0 {
-        t.Fatal("No pods found in stateful set")
-    }
+	if len(pods) == 0 {
+		t.Fatal("No pods found in stateful set")
+	}
 
 	t.Log("Checking if pods are ready to use...")
 	if err := harness.Client.CheckPods(harness.Namespace, pods); err != nil {


### PR DESCRIPTION
The Statefulset RBAC was a `cluster-admin` account, when all it really needs is the ability to update pod labels.  I've limited the account to just what it needed and additionally split out the RBAC into a separate script so you can run it as cluster administrator.

Closes CrunchyData/crunchy-containers-test#165.
Closes CrunchyData/crunchy-containers-test#167.