### PR TITLE
Fixed the Links for the Crunchy Scheduler Config Maps

### DIFF
--- a/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
+++ b/hugo/content/getting-started/kubernetes-and-openshift/_index.adoc
@@ -286,9 +286,9 @@ delete the task.
 
 See the following examples for creating config maps that Crunchy Scheduler can parse:
 
-* link:https://github.com/CrunchyData/crunchy-containers/blob/scheduler/examples/kube/scheduler/configs/schedule-backrest-diff.json[pgBackRest Diff Backup]
-* link:https://github.com/CrunchyData/crunchy-containers/blob/scheduler/examples/kube/scheduler/configs/schedule-backrest-full.json[pgBackRest Full Backup]
-* link:https://github.com/CrunchyData/crunchy-containers/blob/scheduler/examples/kube/scheduler/configs/schedule-pgbasebackup.json[pgBaseBackup Backup]
+* link:https://github.com/CrunchyData/crunchy-containers/blob/master/examples/kube/scheduler/configs/schedule-backrest-diff.json[pgBackRest Diff Backup]
+* link:https://github.com/CrunchyData/crunchy-containers/blob/master/examples/kube/scheduler/configs/schedule-backrest-full.json[pgBackRest Full Backup]
+* link:https://github.com/CrunchyData/crunchy-containers/blob/master/examples/kube/scheduler/configs/schedule-pgbasebackup.json[pgBaseBackup Backup]
 
 The Crunchy Scheduler requires a Service Account to create jobs (pgBaseBackup) and to
 exec (pgBackRest).  See the link:https://github.com/CrunchyData/crunchy-containers/blob/scheduler/examples/kube/scheduler/scheduler-sa.json[scheduler example]


### PR DESCRIPTION
The links for the Crunchy Scheduler config maps now point to the **master** branch.  This will address the **404** errors that are currently thrown when attempting to follow the links for the config maps in the documentation.

However, please note that these links will only work once **develop** has been merged into **master**. This is because the files the links are pointing to do not currently exist on the **master** branch.

Closes CrunchyData/crunchy-containers-test#157

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
**404** errors are thrown when attempting to access the sample config maps for the Crunchy Scheduler.


**What is the new behavior (if this is a feature change)?**
The links now point to the **master** branch, and the user will now navigate to the proper files when clicking the links.


**Other information**:
