### PR TITLE
Add missing security contexts

### DIFF
--- a/examples/kube/pitr/backup-pitr.json
+++ b/examples/kube/pitr/backup-pitr.json
@@ -21,6 +21,9 @@
                         }
                     }
                 ],
+                "securityContext": {
+                    $CCP_SECURITY_CONTEXT
+                },
                 "containers": [
                     {
                         "name": "backup-pitr",

--- a/examples/kube/primary-deployment/replica-statefulset-sc.json
+++ b/examples/kube/primary-deployment/replica-statefulset-sc.json
@@ -47,6 +47,9 @@
                 }
             },
             "spec": {
+                "securityContext": {
+                    $CCP_SECURITY_CONTEXT
+                },
                 "containers": [
                     {
                         "name": "postgres",

--- a/examples/kube/primary-deployment/replica-statefulset.json
+++ b/examples/kube/primary-deployment/replica-statefulset.json
@@ -47,6 +47,9 @@
                 }
             },
             "spec": {
+                "securityContext": {
+                    $CCP_SECURITY_CONTEXT
+                },
                 "containers": [
                     {
                         "name": "postgres",
@@ -149,7 +152,6 @@
                             }
                         ],
                         "resources": {},
-                        "securityContext": {},
                         "volumeMounts": [
                             {
                                 "mountPath": "/pgdata",


### PR DESCRIPTION
Security contexts were missing on some examples causing issues when fsGroups or supplementalGroups were required (GKE).