### PR TITLE
Cleanup Directories Created for the Upgrade Example

### DIFF
--- a/examples/kube/upgrade/cleanup.sh
+++ b/examples/kube/upgrade/cleanup.sh
@@ -22,3 +22,5 @@ ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc upgrade-pgnewdata
 if [ -z "$CCP_STORAGE_CLASS" ]; then
   ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-upgrade-pgnewdata
 fi
+
+dir_check_rm "upgrade"


### PR DESCRIPTION
Added a call to function **dir_check_rm** (located in **common.sh**) in the cleanup script for the **Upgrade** example in order to properly cleanup all directories created when running the example.  This will ensure no directories are left over after running the example and then executing the cleanup script.

Closes CrunchyData/crunchy-containers-test#169

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The **demo-upgrade** directory is not removed when running the **cleanup.sh** script for the **Upgrade** example.


**What is the new behavior (if this is a feature change)?**
The **demo-upgrade** directory is removed/deleted when running the **cleanup.sh** script for the **Upgrade** example.


**Other information**:
N/A