### PR TITLE
Clarified that 'cluster-admin' Needs to Be Assigned for Any Kubernetes Cluster

### DIFF
--- a/hugo/content/installation/environment-setup.adoc
+++ b/hugo/content/installation/environment-setup.adoc
@@ -202,23 +202,46 @@ with installation can occur unless you have a resolving hostname.
 
 You should see a single IP address returned from this command:
 ....
-hostname --ip-address
+$ hostname --ip-address
 ....
 
-When running the containers in GKE Role Based Account Control will need to be set up.
+In order to run the various examples, Role Based Account Control will need to be set up.
+Specifically, the **cluster-admin** role will need to be assigned to the Kubernetes user 
+that will be utilized to run the examples.  This is done by creating the proper
+**ClusterRoleBinding**:
+
 ....
-kubectl create clusterrolebinding cluster-admin-binding \
+$ kubectl create clusterrolebinding cluster-admin-binding \
+--clusterrole cluster-admin --user someuser
+....
+
+If you are running on GKE, the following command can be utilized to auto-populate the **user** 
+option with the account that is currently logged into Google Cloud:
+
+....
+$ kubectl create clusterrolebinding cluster-admin-binding \
 --clusterrole cluster-admin --user $(gcloud config get-value account)
 ....
 
-If more than one user will be running on the same kubernetes cluster in GKE, from the above command cluster-admin-binding will need to be unique and is the name that is added to the clusterrolebidings.  The example below will add another user to the clusterrolebinding with a unique value.
+If more than one user will be running the examples on the same Kubernetes cluster, a unique name 
+will need to be provided for each new **ClusterRoleBinding** created in order to assign the 
+**cluster-admin** role to every user.  The example below will create a **ClusterRoleBinding** with a
+unique value:
+
 ....
-$ ACCOUNT=$(gcloud info --format='value(config.account)')
 $ kubectl create clusterrolebinding <unique>-cluster-admin-binding \
     --clusterrole cluster-admin \
-    --user $ACCOUNT
+    --user someuser
+....
 
-ACCOUNT is just your google gcloud acount login, ie username@google.com
+If you are running on GKE, the following can be utilized to create a unique **ClusterRoleBinding**
+for each user, with the user's Google Cloud account prepended to the name of each new
+**ClusterRoleBinding**:
+
+....
+$ kubectl create clusterrolebinding "$(gcloud config get-value account)-cluster-admin-binding" \
+    --clusterrole cluster-admin \
+    --user $(gcloud config get-value account)
 ....
 
 === Helm
@@ -287,7 +310,7 @@ $ kubectl config view | grep namespace:
 This section assumes you are first logging into OpenShift as a normal
 user such as:
 ....
-oc login -u someuser
+$ oc login -u someuser
 ....
 
 {{% notice tip %}}


### PR DESCRIPTION
Updated the documentation to clarify that the **cluster-admin** role needs to be assigned to the user running the examples on any Kubernetes cluster, not just when using a cluster hosted on GKE.  More specifically, the instructions to assign the **cluster-admin** role to the user running the examples via a **ClusterRoleBinding** are no longer GKE specific, but rather now apply to Kubernetes in general.

Closes CrunchyData/crunchy-containers-test#174

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The documentation is unclear about what roles to assign to the Kubernetes user when running on a Kubernetes cluster that is not hosted on GKE (e.g. a local Kubernetes installation).


**What is the new behavior (if this is a feature change)?**
The documentation clarifies that the **cluster-admin** role should be assigned to the user when running the examples on any Kubernetes cluster, and not just when using GKE.


**Other information**:
N/A