### PR TITLE
Added Missing CCP_NAMESPACE Env Var to the statefulset Helm Chart

### DIFF
--- a/examples/helm/statefulset/templates/set.yaml
+++ b/examples/helm/statefulset/templates/set.yaml
@@ -46,6 +46,10 @@ spec:
           value: userdb
         - name: PG_ROOT_PASSWORD
           value: "{{.Values.credentials.root}}"
+        - name: CCP_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         resources:
           requests:
             cpu: {{ .Values.resources.cpu }}


### PR DESCRIPTION
Added the missing CCP_NAMESPACE environment variable to the statefulset Helm Chart.  This addresses the the errors that are currently thrown when installing the **statefulset** Helm chart, as described in issue CrunchyData/crunchy-containers-test#176.

Closes CrunchyData/crunchy-containers-test#176

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Errors are thrown when installing the **statefulset** Helm chart, as described in issue CrunchyData/crunchy-containers-test#176.


**What is the new behavior (if this is a feature change)?**
The **statefulset** Helm chart installs and deploys successfully.


**Other information**:
N/A