### PR TITLE
Fix GID bug in postgres containers

### DIFF
--- a/bin/common/uid_postgres.sh
+++ b/bin/common/uid_postgres.sh
@@ -1,16 +1,22 @@
-#!/bin/sh
-if ! whoami &> /dev/null; then
-  if [ -w /etc/passwd ]; then
-  	sed  "/postgres:x:26/d" /etc/passwd >> /tmp/uid.tmp
-  	cp /tmp/uid.tmp /etc/passwd
-  	rm -f /tmp/uid.tmp
-    echo "${USER_NAME:-postgres}:x:$(id -u):0:${USER_NAME:-postgres} user:${HOME}:/bin/bash" >> /etc/passwd
-  fi
-  
-  if [ -w /etc/group ]; then
-    echo "nfsnobody:x:65534:" >> /etc/group
-    echo "postgres:x:$(id -u):postgres" >> /etc/group
-  fi
+#!/bin/bash
+
+if ! whoami &> /dev/null
+then
+    if [[ -w /etc/passwd ]]
+    then
+        sed  "/postgres:x:26:/d" /etc/passwd >> /tmp/uid.tmp
+        cp /tmp/uid.tmp /etc/passwd
+        rm -f /tmp/uid.tmp
+        echo "${USER_NAME:-postgres}:x:$(id -u):0:${USER_NAME:-postgres} user:${HOME}:/bin/bash" >> /etc/passwd
+    fi
+
+    if [[ -w /etc/group ]]
+    then
+        sed  "/postgres:x:26/d" /etc/group >> /tmp/gid.tmp
+        cp /tmp/gid.tmp /etc/group
+        rm -f /tmp/gid.tmp
+        echo "nfsnobody:x:65534:" >> /etc/group
+        echo "postgres:x:$(id -g):postgres" >> /etc/group
+    fi
 fi
 exec "$@"
- 


### PR DESCRIPTION
The `uid_postgres.sh` script is not removing the default entry for postgres user (GID 26) which causes `operation not permitted` errors when attempting to alter group ownership to `postgres`.

```bash
bash-4.2$ grep postgres /etc/group
postgres:x:26:
postgres:x:0:postgres
```

The double entry causes this to happen:

```bash
bash-4.2$ chown postgres:postgres /tmp/test
chown: changing ownership of '/tmp/test': Operation not permitted
```