### PR TITLE
Fix kubeapi bug with deployment labels

### DIFF
--- a/tools/kubeapi/deployment.go
+++ b/tools/kubeapi/deployment.go
@@ -23,15 +23,13 @@ func (k *KubeAPI) GetDeploymentPods(namespace, deployment string) ([]string, err
 	}
 
 	var podList []string
-	for key, val := range d.Labels {
-		label := fmt.Sprintf("%s=%s", key, val)
-		pods, err := k.Client.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: label})
-		if err != nil {
-			return nil, err
-		}
-		for _, pod := range pods.Items {
-			podList = append(podList, pod.Name)
-		}
+	label := createLabel(d.Labels)
+	pods, err := k.Client.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: label})
+	if err != nil {
+		return nil, err
+	}
+	for _, pod := range pods.Items {
+		podList = append(podList, pod.Name)
 	}
 	return podList, nil
 }

--- a/tools/kubeapi/kubeapi.go
+++ b/tools/kubeapi/kubeapi.go
@@ -1,14 +1,16 @@
 package kubeapi
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-    _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 // KubeAPI is the main data structure containing
@@ -54,4 +56,17 @@ func homeDir() string {
 		return h
 	}
 	return os.Getenv("USERPROFILE") // windows
+}
+
+func createLabel(m map[string]string) string {
+	b := new(bytes.Buffer)
+	count := 0
+	for key, value := range m {
+		fmt.Fprintf(b, "%s=%s", key, value)
+		if count < (len(m) - 1) {
+			fmt.Fprintf(b, ",")
+		}
+		count++
+	}
+	return b.String()
 }


### PR DESCRIPTION
The kubeapi package was iterating over each label in a deployment individually which caused issues when generating a list of pods with any of those labels.