### PR TITLE
[crunchy-postgres] Limit listener of temporary pg to unix domain socket

### DIFF
--- a/bin/postgres/start.sh
+++ b/bin/postgres/start.sh
@@ -304,13 +304,12 @@ function initialize_primary() {
         echo "Starting database.." >> /tmp/start-db.log
 
         echo_info "Temporarily starting database to run setup.sql.."
-        pg_ctl -D $PGDATA start
+        pg_ctl -D $PGDATA -o "-c listen_addresses=''" start
 
         echo_info "Waiting for PostgreSQL to start.."
         while true; do
             pg_isready \
-            --port=$PG_PRIMARY_PORT \
-            --host=$HOSTNAME \
+            --host=/tmp \
             --username=$PG_PRIMARY_USER \
             --timeout=2
             if [ $? -eq 0 ]; then


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

- The replica node uses `waitforpg` to detect when the master is ready for connections.
- Before the real master node comes up, a temporary master is used  in `initialize_primary`.
- There's a chance that `waitforpg`, if fast enough, will connect to the temporary master node instead of the real one. 

Same issue as described here https://github.com/CrunchyData/crunchy-containers/issues/653


**What is the new behavior (if this is a feature change)?**
- Temporary primary listens only on unix domain socket (same approach that the official pg docker images [use](https://github.com/docker-library/postgres/blob/040949af1595f49f2242f6d1f9c42fb042b3eaed/10/docker-entrypoint.sh#L114-L116)).
- `pg_isready` in `initialize_primary` probes the unix domain socket instead of the ip
- The rest of `psql` commands in `initialize_primary` already used the unix domain socket so no change was needed
- `waitforpg` can't connect any more to the temporary primary

**Other information**:

Tested by patching those changes into `crunchydata/crunchy-postgres:centos7-10.5-2.1.0`. We just use a cluster of 2 initially empty crunchy-postgres in our CI run. Works for us :)