### PR TITLE
Add example cleanup via labels

### DIFF
--- a/examples/common.sh
+++ b/examples/common.sh
@@ -80,3 +80,15 @@ function create_storage {
        expenv -f ${DIR?}/${PVC?} | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
     fi
 }
+
+function cleanup() {
+    label="cleanup=${1?}"
+
+    CONFIG="configmap,secret"
+    DEPLOY="deployment,daemonset,job,pod,replicaset,service,statefulset"
+    RBAC="clusterrolebinding,clusterrole,role,rolebinding,serviceaccount"
+    VOLUME="pvc,pv"
+    OBJECTS="${CONFIG?},${DEPLOY?},${RBAC?},${VOLUME?}"
+
+    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} ${OBJECTS?} --selector=${label?}
+}

--- a/examples/kube/backrest/async-archiving/backrest-async-archive-pv-nfs.json
+++ b/examples/kube/backrest/async-archiving/backrest-async-archive-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-br-aa-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-br-aa-pgdata"
+            "name": "$CCP_NAMESPACE-br-aa-pgdata",
+            "cleanup": "$CCP_NAMESPACE-backrest-async-archive"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest-async-archive",
             "server": "$CCP_NFS_IP"
@@ -26,14 +29,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-br-aa-backups",
         "labels": {
-            "name": "$CCP_NAMESPACE-br-aa-backups"
+            "name": "$CCP_NAMESPACE-br-aa-backups",
+            "cleanup": "$CCP_NAMESPACE-backrest-async-archive"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest-async-archive",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/backrest/async-archiving/backrest-async-archive-pv.json
+++ b/examples/kube/backrest/async-archiving/backrest-async-archive-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-br-aa-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-br-aa-pgdata"
+            "name": "$CCP_NAMESPACE-br-aa-pgdata",
+            "cleanup": "$CCP_NAMESPACE-backrest-async-archive"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest-async-archive"
         },
@@ -25,14 +28,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-br-aa-backups",
         "labels": {
-            "name": "$CCP_NAMESPACE-br-aa-backups"
+            "name": "$CCP_NAMESPACE-br-aa-backups",
+            "cleanup": "$CCP_NAMESPACE-backrest-async-archive"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest-async-archive"
         },

--- a/examples/kube/backrest/async-archiving/backrest-async-archive-pvc-sc.json
+++ b/examples/kube/backrest/async-archiving/backrest-async-archive-pvc-sc.json
@@ -2,36 +2,42 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "br-aa-pgdata"
+        "name": "br-aa-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backrest-async-archive"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }
 
 {
-    "kind": "PersistentVolumeClaim",
-    "apiVersion": "v1",
-    "metadata": {
-        "name": "br-aa-backups"
-    },
-    "spec": {
+  "kind": "PersistentVolumeClaim",
+  "apiVersion": "v1",
+  "metadata": {
+      "name": "br-aa-backups",
+      "labels": {
+          "cleanup": "$CCP_NAMESPACE-backrest-async-archive"
+      }
+  },
+  "spec": {
       "accessModes": [
-        "$CCP_STORAGE_MODE"
+          "$CCP_STORAGE_MODE"
       ],
       "storageClassName": "$CCP_STORAGE_CLASS",
       "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
+          "requests": {
+              "storage": "$CCP_STORAGE_CAPACITY"
+          }
       }
-    }
+  }
 }

--- a/examples/kube/backrest/async-archiving/backrest-async-archive-pvc.json
+++ b/examples/kube/backrest/async-archiving/backrest-async-archive-pvc.json
@@ -2,13 +2,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "br-aa-pgdata"
+        "name": "br-aa-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backrest-async-archive"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-br-aa-pgdata"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-br-aa-pgdata"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"
@@ -25,13 +28,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "br-aa-backups"
+        "name": "br-aa-backups",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backrest-async-archive"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-br-aa-backups"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-br-aa-backups"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"

--- a/examples/kube/backrest/async-archiving/backrest.json
+++ b/examples/kube/backrest/async-archiving/backrest.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "backrest-async-archive",
         "labels": {
-            "name": "backrest-async-archive"
+            "name": "backrest-async-archive",
+            "cleanup": "$CCP_NAMESPACE-backrest-async-archive"
         }
     },
     "spec": {
@@ -30,7 +31,8 @@
     "metadata": {
         "name": "backrest-async-archive",
         "labels": {
-            "name": "backrest-async-archive"
+            "name": "backrest-async-archive",
+            "cleanup": "$CCP_NAMESPACE-backrest-async-archive"
         }
     },
     "spec": {

--- a/examples/kube/backrest/async-archiving/cleanup.sh
+++ b/examples/kube/backrest/async-archiving/cleanup.sh
@@ -15,13 +15,7 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service backrest-async-archive
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod backrest-async-archive
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap br-aa-pgconf
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc br-aa-pgdata br-aa-backups
-if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-br-aa-pgdata $CCP_NAMESPACE-br-aa-backups
-fi
+cleanup "${CCP_NAMESPACE?}-backrest-async-archive"
 
 $CCPROOT/examples/waitforterm.sh backrest-async-archive ${CCP_CLI?}
 

--- a/examples/kube/backrest/async-archiving/run.sh
+++ b/examples/kube/backrest/async-archiving/run.sh
@@ -33,4 +33,7 @@ ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} \
     configmap br-aa-pgconf \
     --from-file ${DIR?}/configs/pgbackrest.conf
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap \
+    br-aa-pgconf cleanup=${CCP_NAMESPACE?}-backrest-async-archive
+
 expenv -f $DIR/backrest.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/backrest/backup-env/backrest-pv-nfs.json
+++ b/examples/kube/backrest/backup-env/backrest-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-br-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-br-pgdata"
+            "name": "$CCP_NAMESPACE-br-pgdata",
+            "cleanup": "$CCP_NAMESPACE-backrest-env"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest",
             "server": "$CCP_NFS_IP"
@@ -26,14 +29,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-br-backups",
         "labels": {
-            "name": "$CCP_NAMESPACE-br-backups"
+            "name": "$CCP_NAMESPACE-br-backups",
+            "cleanup": "$CCP_NAMESPACE-backrest-env"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/backrest/backup-env/backrest-pv.json
+++ b/examples/kube/backrest/backup-env/backrest-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-br-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-br-pgdata"
+            "name": "$CCP_NAMESPACE-br-pgdata",
+            "cleanup": "$CCP_NAMESPACE-backrest-env"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest"
         },
@@ -25,14 +28,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-br-backups",
         "labels": {
-            "name": "$CCP_NAMESPACE-br-backups"
+            "name": "$CCP_NAMESPACE-br-backups",
+            "cleanup": "$CCP_NAMESPACE-backrest-env"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest"
         },

--- a/examples/kube/backrest/backup-env/backrest-pvc-sc.json
+++ b/examples/kube/backrest/backup-env/backrest-pvc-sc.json
@@ -2,36 +2,42 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "br-pgdata"
+        "name": "br-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backrest-env"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }
 
 {
-    "kind": "PersistentVolumeClaim",
-    "apiVersion": "v1",
-    "metadata": {
-        "name": "br-backups"
-    },
-    "spec": {
+  "kind": "PersistentVolumeClaim",
+  "apiVersion": "v1",
+  "metadata": {
+      "name": "br-backups",
+      "labels": {
+          "cleanup": "$CCP_NAMESPACE-backrest-env"
+      }
+  },
+  "spec": {
       "accessModes": [
-        "$CCP_STORAGE_MODE"
+          "$CCP_STORAGE_MODE"
       ],
       "storageClassName": "$CCP_STORAGE_CLASS",
       "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
+          "requests": {
+              "storage": "$CCP_STORAGE_CAPACITY"
+          }
       }
-    }
+  }
 }

--- a/examples/kube/backrest/backup-env/backrest-pvc.json
+++ b/examples/kube/backrest/backup-env/backrest-pvc.json
@@ -2,13 +2,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "br-pgdata"
+        "name": "br-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backrest-env"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-br-pgdata"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-br-pgdata"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"
@@ -25,13 +28,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "br-backups"
+        "name": "br-backups",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backrest-env"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-br-backups"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-br-backups"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"

--- a/examples/kube/backrest/backup-env/backrest.json
+++ b/examples/kube/backrest/backup-env/backrest.json
@@ -2,9 +2,10 @@
     "kind": "Service",
     "apiVersion": "v1",
     "metadata": {
-        "name": "backrest",
+        "name": "backrest-env",
         "labels": {
-            "name": "backrest"
+            "name": "backrest-env",
+            "cleanup": "$CCP_NAMESPACE-backrest-env"
         }
     },
     "spec": {
@@ -17,7 +18,7 @@
             }
         ],
         "selector": {
-            "name": "backrest"
+            "name": "backrest-env"
         },
         "type": "ClusterIP",
         "sessionAffinity": "None"
@@ -28,9 +29,10 @@
     "kind": "Pod",
     "apiVersion": "v1",
     "metadata": {
-        "name": "backrest",
+        "name": "backrest-env",
         "labels": {
-            "name": "backrest"
+            "name": "backrest-env",
+            "cleanup": "$CCP_NAMESPACE-backrest-env"
         }
     },
     "spec": {

--- a/examples/kube/backrest/backup-env/cleanup.sh
+++ b/examples/kube/backrest/backup-env/cleanup.sh
@@ -15,13 +15,8 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service backrest
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod backrest
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc br-pgdata br-backups
-if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-br-pgdata $CCP_NAMESPACE-br-backups
-fi
+cleanup "$CCP_NAMESPACE-backrest-env"
 
 $CCPROOT/examples/waitforterm.sh backrest ${CCP_CLI?}
 
-dir_check_rm "backrest"
+dir_check_rm "backrest-env"

--- a/examples/kube/backrest/backup/backrest-pv-nfs.json
+++ b/examples/kube/backrest/backup/backrest-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-br-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-br-pgdata"
+            "name": "$CCP_NAMESPACE-br-pgdata",
+            "cleanup": "$CCP_NAMESPACE-backrest"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest",
             "server": "$CCP_NFS_IP"
@@ -26,14 +29,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-br-backups",
         "labels": {
-            "name": "$CCP_NAMESPACE-br-backups"
+            "name": "$CCP_NAMESPACE-br-backups",
+            "cleanup": "$CCP_NAMESPACE-backrest"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/backrest/backup/backrest-pv.json
+++ b/examples/kube/backrest/backup/backrest-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-br-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-br-pgdata"
+            "name": "$CCP_NAMESPACE-br-pgdata",
+            "cleanup": "$CCP_NAMESPACE-backrest"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest"
         },
@@ -25,14 +28,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-br-backups",
         "labels": {
-            "name": "$CCP_NAMESPACE-br-backups"
+            "name": "$CCP_NAMESPACE-br-backups",
+            "cleanup": "$CCP_NAMESPACE-backrest"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest"
         },

--- a/examples/kube/backrest/backup/backrest-pvc-sc.json
+++ b/examples/kube/backrest/backup/backrest-pvc-sc.json
@@ -2,36 +2,42 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "br-pgdata"
+        "name": "br-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backrest"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }
 
 {
-    "kind": "PersistentVolumeClaim",
-    "apiVersion": "v1",
-    "metadata": {
-        "name": "br-backups"
-    },
-    "spec": {
+  "kind": "PersistentVolumeClaim",
+  "apiVersion": "v1",
+  "metadata": {
+      "name": "br-backups",
+      "labels": {
+          "cleanup": "$CCP_NAMESPACE-backrest"
+      }
+  },
+  "spec": {
       "accessModes": [
-        "$CCP_STORAGE_MODE"
+          "$CCP_STORAGE_MODE"
       ],
       "storageClassName": "$CCP_STORAGE_CLASS",
       "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
+          "requests": {
+              "storage": "$CCP_STORAGE_CAPACITY"
+          }
       }
-    }
+  }
 }

--- a/examples/kube/backrest/backup/backrest-pvc.json
+++ b/examples/kube/backrest/backup/backrest-pvc.json
@@ -2,13 +2,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "br-pgdata"
+        "name": "br-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backrest"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-br-pgdata"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-br-pgdata"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"
@@ -25,13 +28,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "br-backups"
+        "name": "br-backups",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backrest"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-br-backups"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-br-backups"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"

--- a/examples/kube/backrest/backup/backrest.json
+++ b/examples/kube/backrest/backup/backrest.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "backrest",
         "labels": {
-            "name": "backrest"
+            "name": "backrest",
+            "cleanup": "$CCP_NAMESPACE-backrest"
         }
     },
     "spec": {
@@ -30,7 +31,8 @@
     "metadata": {
         "name": "backrest",
         "labels": {
-            "name": "backrest"
+            "name": "backrest",
+            "cleanup": "$CCP_NAMESPACE-backrest"
         }
     },
     "spec": {

--- a/examples/kube/backrest/backup/cleanup.sh
+++ b/examples/kube/backrest/backup/cleanup.sh
@@ -15,13 +15,7 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service backrest
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod backrest
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap br-pgconf
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc br-pgdata br-backups
-if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-br-pgdata $CCP_NAMESPACE-br-backups
-fi
+cleanup "${CCP_NAMESPACE?}-backrest"
 
 $CCPROOT/examples/waitforterm.sh backrest ${CCP_CLI?}
 

--- a/examples/kube/backrest/backup/run.sh
+++ b/examples/kube/backrest/backup/run.sh
@@ -33,4 +33,7 @@ ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} \
     configmap br-pgconf \
     --from-file ${DIR?}/configs/pgbackrest.conf
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap \
+    br-pgconf cleanup=${CCP_NAMESPACE?}-backrest
+
 expenv -f $DIR/backrest.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/backrest/delta/backrest-restored.json
+++ b/examples/kube/backrest/delta/backrest-restored.json
@@ -2,9 +2,10 @@
     "kind": "Service",
     "apiVersion": "v1",
     "metadata": {
-        "name": "backrest",
+        "name": "backrest-env",
         "labels": {
-            "name": "backrest"
+            "name": "backrest-env",
+            "cleanup": "$CCP_NAMESPACE-backrest-env"
         }
     },
     "spec": {
@@ -17,7 +18,7 @@
             }
         ],
         "selector": {
-            "name": "backrest"
+            "name": "backrest-env"
         },
         "type": "ClusterIP",
         "sessionAffinity": "None"
@@ -30,7 +31,8 @@
     "metadata": {
         "name": "backrest",
         "labels": {
-            "name": "backrest"
+            "name": "backrest",
+            "cleanup": "$CCP_NAMESPACE-backrest-delta-restore"
         }
     },
     "spec": {

--- a/examples/kube/backrest/delta/cleanup.sh
+++ b/examples/kube/backrest/delta/cleanup.sh
@@ -15,9 +15,9 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service backrest
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod backrest
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job backrest-delta-restore-job
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap br-delta-restore-pgconf
+cleanup "$CCP_NAMESPACE-backrest-delta-restore"
+
+# Cleanup backrest pods if they're running from backup examples
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod,service backrest
 
 $CCPROOT/examples/waitforterm.sh backrest ${CCP_CLI?}

--- a/examples/kube/backrest/delta/delta-restore.json
+++ b/examples/kube/backrest/delta/delta-restore.json
@@ -9,7 +9,8 @@
             "metadata": {
                 "name": "backrest-delta-restore-job",
                 "labels": {
-                    "app": "backrest-delta-restore-job"
+                    "app": "backrest-delta-restore-job",
+                    "cleanup": "$CCP_NAMESPACE-backrest-delta-restore"
                 }
             },
             "spec": {
@@ -30,7 +31,7 @@
                             },
                             {
                                 "name": "PG_HOSTNAME",
-				"value": "backrest"
+                                "value": "backrest"
                             }
                         ],
                         "volumeMounts": [

--- a/examples/kube/backrest/delta/run.sh
+++ b/examples/kube/backrest/delta/run.sh
@@ -18,8 +18,14 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 ${DIR}/cleanup.sh
 
+# Cleanup backrest pods if they're running from backup examples
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod,service backrest
+
 ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} \
     configmap br-delta-restore-pgconf \
     --from-file ${DIR?}/configs/pgbackrest.conf
+
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap \
+    br-delta-restore-pgconf cleanup=${CCP_NAMESPACE?}-backrest-delta-restore
 
 expenv -f $DIR/delta-restore.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/backrest/full/backrest-full-restored-pv-nfs.json
+++ b/examples/kube/backrest/full/backrest-full-restored-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-br-new-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-br-new-pgdata"
+            "name": "$CCP_NAMESPACE-br-new-pgdata",
+            "cleanup": "$CCP_NAMESPACE-backrest-full-restore"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest-full-restored",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/backrest/full/backrest-full-restored-pv.json
+++ b/examples/kube/backrest/full/backrest-full-restored-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-br-new-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-br-new-pgdata"
+            "name": "$CCP_NAMESPACE-br-new-pgdata",
+            "cleanup": "$CCP_NAMESPACE-backrest-full-restore"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backrest-full-restored"
         },

--- a/examples/kube/backrest/full/backrest-full-restored-pvc-sc.json
+++ b/examples/kube/backrest/full/backrest-full-restored-pvc-sc.json
@@ -2,17 +2,20 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "br-new-pgdata"
+        "name": "br-new-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backrest-full-restore"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/backrest/full/backrest-full-restored-pvc.json
+++ b/examples/kube/backrest/full/backrest-full-restored-pvc.json
@@ -2,13 +2,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "br-new-pgdata"
+        "name": "br-new-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backrest-full-restore"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-br-new-pgdata"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-br-new-pgdata"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"
@@ -20,4 +23,3 @@
         }
     }
 }
-

--- a/examples/kube/backrest/full/backrest-restored.json
+++ b/examples/kube/backrest/full/backrest-restored.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "backrest-full-restored",
         "labels": {
-            "name": "backrest-full-restored"
+            "name": "backrest-full-restored",
+            "cleanup": "$CCP_NAMESPACE-backrest-full-restore"
         }
     },
     "spec": {
@@ -30,7 +31,8 @@
     "metadata": {
         "name": "backrest-full-restored",
         "labels": {
-            "name": "backrest-full-restored"
+            "name": "backrest-full-restored",
+            "cleanup": "$CCP_NAMESPACE-backrest-full-restore"
         }
     },
     "spec": {

--- a/examples/kube/backrest/full/cleanup.sh
+++ b/examples/kube/backrest/full/cleanup.sh
@@ -15,12 +15,9 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service backrest backrest-full-restored
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod backrest backrest-full-restored
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc br-new-pgdata
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-br-new-pgdata
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job backrest-full-restore-job
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap br-full-restore-pgconf
+cleanup "$CCP_NAMESPACE-backrest-full-restore"
+
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod,service backrest backrest 
 
 $CCPROOT/examples/waitforterm.sh backrest ${CCP_CLI?}
 

--- a/examples/kube/backrest/full/full-restore.json
+++ b/examples/kube/backrest/full/full-restore.json
@@ -9,7 +9,8 @@
             "metadata": {
                 "name": "backrest-full-restore-job",
                 "labels": {
-                    "app": "backrest-full-restore-job"
+                    "app": "backrest-full-restore-job",
+                    "cleanup": "$CCP_NAMESPACE-backrest-full-restore"
                 }
             },
             "spec": {
@@ -27,7 +28,7 @@
                             },
                             {
                                 "name": "PG_HOSTNAME",
-				"value": "backrest-full-restored"
+                                "value": "backrest-full-restored"
                             }
                         ],
                         "volumeMounts": [

--- a/examples/kube/backrest/full/run.sh
+++ b/examples/kube/backrest/full/run.sh
@@ -29,4 +29,7 @@ ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} \
     configmap br-full-restore-pgconf \
     --from-file ${DIR?}/configs/pgbackrest.conf
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap \
+    br-full-restore-pgconf cleanup=${CCP_NAMESPACE?}-backrest-full-restore
+
 expenv -f $DIR/full-restore.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/backrest/pitr/backrest-restored.json
+++ b/examples/kube/backrest/pitr/backrest-restored.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "backrest",
         "labels": {
-            "name": "backrest"
+            "name": "backrest",
+            "cleanup": "$CCP_NAMESPACE-backrest-pitr-restore"
         }
     },
     "spec": {
@@ -30,7 +31,8 @@
     "metadata": {
         "name": "backrest",
         "labels": {
-            "name": "backrest"
+            "name": "backrest",
+            "cleanup": "$CCP_NAMESPACE-backrest-pitr-restore"
         }
     },
     "spec": {

--- a/examples/kube/backrest/pitr/cleanup.sh
+++ b/examples/kube/backrest/pitr/cleanup.sh
@@ -15,9 +15,8 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service backrest
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod backrest
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job backrest-pitr-restore-job
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap br-pitr-restore-pgconf
+cleanup "$CCP_NAMESPACE-backrest-pitr-restore"
+
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod,service backrest
 
 $CCPROOT/examples/waitforterm.sh backrest ${CCP_CLI?}

--- a/examples/kube/backrest/pitr/pitr-restore.json
+++ b/examples/kube/backrest/pitr/pitr-restore.json
@@ -9,7 +9,8 @@
             "metadata": {
                 "name": "backrest-pitr-restore-job",
                 "labels": {
-                    "app": "backrest-pitr-restore-job"
+                    "app": "backrest-pitr-restore-job",
+                    "cleanup": "$CCP_NAMESPACE-backrest-pitr-restore"
                 }
             },
             "spec": {

--- a/examples/kube/backrest/pitr/run.sh
+++ b/examples/kube/backrest/pitr/run.sh
@@ -35,4 +35,7 @@ ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} \
     configmap br-pitr-restore-pgconf \
     --from-file ${DIR?}/configs/pgbackrest.conf
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap \
+    br-pitr-restore-pgconf cleanup=${CCP_NAMESPACE?}-backrest-pitr-restore
+
 expenv -f $DIR/pitr-restore.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/backup/backup-pv-nfs.json
+++ b/examples/kube/backup/backup-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-backup-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-backup-pgdata"
+            "name": "$CCP_NAMESPACE-backup-pgdata",
+            "cleanup": "$CCP_NAMESPACE-backup"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backup",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/backup/backup-pv.json
+++ b/examples/kube/backup/backup-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-backup-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-backup-pgdata"
+            "name": "$CCP_NAMESPACE-backup-pgdata",
+            "cleanup": "$CCP_NAMESPACE-backup"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backup"
         },

--- a/examples/kube/backup/backup-pvc-sc.json
+++ b/examples/kube/backup/backup-pvc-sc.json
@@ -2,17 +2,20 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "backup-pgdata"
+        "name": "backup-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backup"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/backup/backup-pvc.json
+++ b/examples/kube/backup/backup-pvc.json
@@ -2,13 +2,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "backup-pgdata"
+        "name": "backup-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backup"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-backup-pgdata"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-backup-pgdata"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"

--- a/examples/kube/backup/backup.json
+++ b/examples/kube/backup/backup.json
@@ -9,7 +9,8 @@
             "metadata": {
                 "name": "backup",
                 "labels": {
-                    "app": "backup"
+                    "app": "backup",
+                    "cleanup": "$CCP_NAMESPACE-backup"
                 }
             },
             "spec": {
@@ -22,7 +23,7 @@
                     }
                 ],
                 "securityContext": {
-                     $CCP_SECURITY_CONTEXT
+                    $CCP_SECURITY_CONTEXT
                 },
                 "containers": [
                     {

--- a/examples/kube/backup/cleanup.sh
+++ b/examples/kube/backup/cleanup.sh
@@ -15,12 +15,6 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job backup
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc backup-pgdata
-
-if [[ -z "$CCP_STORAGE_CLASS" ]]
-then
-    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-backup-pgdata
-fi
+cleanup "${CCP_NAMESPACE?}-backup"
 
 dir_check_rm "backup"

--- a/examples/kube/centralized-logging/postgres-cluster/cleanup.sh
+++ b/examples/kube/centralized-logging/postgres-cluster/cleanup.sh
@@ -15,6 +15,6 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment,statefulset,pod,configmap,secret,service,pvc,pv --selector=k8s-app=postgres-cluster
+cleanup "${CCP_NAMESPACE?}-postgres-cluster"
 
 dir_check_rm "postgres-cluster"

--- a/examples/kube/centralized-logging/postgres-cluster/postgres-cluster-pv-nfs.json
+++ b/examples/kube/centralized-logging/postgres-cluster/postgres-cluster-pv-nfs.json
@@ -3,16 +3,18 @@
     "kind": "PersistentVolume",
     "metadata": {
         "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
-        "labels":{
-           "k8s-app": "postgres-cluster",
-           "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-postgres-cluster",
+            "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-postgres-cluster",
             "server": "$CCP_NFS_IP"
@@ -26,16 +28,18 @@
     "kind": "PersistentVolume",
     "metadata": {
         "name": "$CCP_NAMESPACE-replica-deployment-pgdata",
-        "labels":{
-           "k8s-app": "postgres-cluster",
-           "name": "$CCP_NAMESPACE-replica-deployment-pgdata"
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-postgres-cluster",
+            "name": "$CCP_NAMESPACE-replica-deployment-pgdata"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-postgres-cluster",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/centralized-logging/postgres-cluster/postgres-cluster-pv.json
+++ b/examples/kube/centralized-logging/postgres-cluster/postgres-cluster-pv.json
@@ -3,8 +3,8 @@
     "kind": "PersistentVolume",
     "metadata": {
         "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
-        "labels":{
-           "k8s-app": "postgres-cluster",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-postgres-cluster",
             "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
         }
     },
@@ -12,7 +12,9 @@
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-postgres-cluster"
         },
@@ -20,13 +22,14 @@
     }
 }
 
+
 {
     "apiVersion": "v1",
     "kind": "PersistentVolume",
     "metadata": {
         "name": "$CCP_NAMESPACE-replica-deployment-pgdata",
         "labels":{
-           "k8s-app": "postgres-cluster",
+           "cleanup": "$CCP_NAMESPACE-postgres-cluster",
             "name": "$CCP_NAMESPACE-replica-deployment-pgdata"
         }
     },

--- a/examples/kube/centralized-logging/postgres-cluster/postgres-cluster-pvc-sc.json
+++ b/examples/kube/centralized-logging/postgres-cluster/postgres-cluster-pvc-sc.json
@@ -2,21 +2,21 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "primary-deployment-pgdata",
-      "labels":{
-         "k8s-app": "postgres-cluster"
-      }
+        "name": "primary-deployment-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-postgres-cluster"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }
 
@@ -24,20 +24,20 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "replica-deployment-pgdata",
-      "labels":{
-         "k8s-app": "postgres-cluster"
-      }
+        "name": "replica-deployment-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-postgres-cluster"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/centralized-logging/postgres-cluster/postgres-cluster-pvc.json
+++ b/examples/kube/centralized-logging/postgres-cluster/postgres-cluster-pvc.json
@@ -2,50 +2,50 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "primary-deployment-pgdata",
-      "labels":{
-         "k8s-app": "postgres-cluster"
-      }
+        "name": "primary-deployment-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-postgres-cluster"
+        }
     },
     "spec": {
-      "selector": {
-        "matchLabels": {
-          "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
+        "selector": {
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
+            }
+        },
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      },
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
-      }
     }
 }
 
 {
-    "kind": "PersistentVolumeClaim",
-    "apiVersion": "v1",
-    "metadata": {
+  "kind": "PersistentVolumeClaim",
+  "apiVersion": "v1",
+  "metadata": {
       "name": "replica-deployment-pgdata",
-      "labels":{
-         "k8s-app": "postgres-cluster"
+      "labels": {
+          "cleanup": "$CCP_NAMESPACE-postgres-cluster"
       }
-    },
-    "spec": {
+  },
+  "spec": {
       "selector": {
-        "matchLabels": {
-          "name": "$CCP_NAMESPACE-replica-deployment-pgdata"
-        }
+          "matchLabels": {
+              "name": "$CCP_NAMESPACE-replica-deployment-pgdata"
+          }
       },
       "accessModes": [
-        "$CCP_STORAGE_MODE"
+          "$CCP_STORAGE_MODE"
       ],
       "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
+          "requests": {
+              "storage": "$CCP_STORAGE_CAPACITY"
+          }
       }
-    }
+  }
 }

--- a/examples/kube/centralized-logging/postgres-cluster/postgres-cluster.json
+++ b/examples/kube/centralized-logging/postgres-cluster/postgres-cluster.json
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "primary-deployment",
         "labels": {
-            "k8s-app": "postgres-cluster",
+            "cleanup": "$CCP_NAMESPACE-postgres-cluster",
             "name": "primary-deployment"
         }
     },
@@ -31,7 +31,7 @@
     "metadata": {
         "name": "replica-deployment",
         "labels": {
-            "k8s-app": "postgres-cluster",
+            "cleanup": "$CCP_NAMESPACE-postgres-cluster",
             "name": "replica-deployment"
         }
     },
@@ -58,7 +58,7 @@
     "metadata": {
         "name": "primary-deployment",
         "labels": {
-            "k8s-app": "postgres-cluster",
+            "cleanup": "$CCP_NAMESPACE-postgres-cluster",
             "name": "primary-deployment"
         }
     },
@@ -67,7 +67,7 @@
         "template": {
             "metadata": {
                 "labels": {
-                    "k8s-app": "postgres-cluster",
+                    "cleanup": "$CCP_NAMESPACE-postgres-cluster",
                     "name": "primary-deployment"
                 }
             },
@@ -195,7 +195,7 @@
     "metadata": {
         "name": "replica-deployment",
         "labels": {
-            "k8s-app": "postgres-cluster",
+            "cleanup": "$CCP_NAMESPACE-postgres-cluster",
             "name": "replica-deployment"
         }
     },
@@ -204,7 +204,7 @@
         "template": {
             "metadata": {
                 "labels": {
-                    "k8s-app": "postgres-cluster",
+                    "cleanup": "$CCP_NAMESPACE-postgres-cluster",
                     "name": "replica-deployment"
                 }
             },

--- a/examples/kube/centralized-logging/postgres-cluster/run.sh
+++ b/examples/kube/centralized-logging/postgres-cluster/run.sh
@@ -27,7 +27,8 @@ fi
 
 ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} configmap postgres-cluster-pgconf \
   --from-file ${DIR?}/configs/postgresql.conf
+
 ${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap postgres-cluster-pgconf \
-    k8s-app=postgres-cluster
+    cleanup=$CCP_NAMESPACE-postgres-cluster
 
 expenv -f $DIR/postgres-cluster.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/custom-config-ssl/custom-config-ssl-pv-nfs.json
+++ b/examples/kube/custom-config-ssl/custom-config-ssl-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-custom-config-ssl-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-custom-config-ssl-pgdata"
+            "name": "$CCP_NAMESPACE-custom-config-ssl-pgdata",
+            "cleanup": "$CCP_NAMESPACE-custom-config-ssl"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config-ssl",
             "server": "$CCP_NFS_IP"
@@ -26,14 +29,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-custom-config-ssl-backrestrepo",
         "labels": {
-            "name": "$CCP_NAMESPACE-custom-config-ssl-backrestrepo"
+            "name": "$CCP_NAMESPACE-custom-config-ssl-backrestrepo",
+            "cleanup": "$CCP_NAMESPACE-custom-config-ssl"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config-ssl",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/custom-config-ssl/custom-config-ssl-pv.json
+++ b/examples/kube/custom-config-ssl/custom-config-ssl-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-custom-config-ssl-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-custom-config-ssl-pgdata"
+            "name": "$CCP_NAMESPACE-custom-config-ssl-pgdata",
+            "cleanup": "$CCP_NAMESPACE-custom-config-ssl"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config-ssl"
         },
@@ -25,14 +28,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-custom-config-ssl-backrestrepo",
         "labels": {
-            "name": "$CCP_NAMESPACE-custom-config-ssl-backrestrepo"
+            "name": "$CCP_NAMESPACE-custom-config-ssl-backrestrepo",
+            "cleanup": "$CCP_NAMESPACE-custom-config-ssl"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config-ssl"
         },

--- a/examples/kube/custom-config-ssl/custom-config-ssl-pvc-sc.json
+++ b/examples/kube/custom-config-ssl/custom-config-ssl-pvc-sc.json
@@ -2,18 +2,21 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "custom-config-ssl-pgdata"
+        "name": "custom-config-ssl-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-custom-config-ssl"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }
 
@@ -21,17 +24,20 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "custom-config-ssl-backrestrepo"
+        "name": "custom-config-ssl-backrestrepo",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-custom-config-ssl"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/custom-config-ssl/custom-config-ssl-pvc.json
+++ b/examples/kube/custom-config-ssl/custom-config-ssl-pvc.json
@@ -2,22 +2,25 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "custom-config-ssl-pgdata"
+        "name": "custom-config-ssl-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-custom-config-ssl"
+        }
     },
     "spec": {
-      "selector": {
-        "matchLabels": {
-          "name": "$CCP_NAMESPACE-custom-config-ssl-pgdata"
+        "selector": {
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-custom-config-ssl-pgdata"
+            }
+        },
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      },
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
-      }
     }
 }
 
@@ -25,21 +28,24 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "custom-config-ssl-backrestrepo"
+        "name": "custom-config-ssl-backrestrepo",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-custom-config-ssl"
+        }
     },
     "spec": {
-      "selector": {
-        "matchLabels": {
-          "name": "$CCP_NAMESPACE-custom-config-ssl-backrestrepo"
+        "selector": {
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-custom-config-ssl-backrestrepo"
+            }
+        },
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      },
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
-      }
     }
 }

--- a/examples/kube/custom-config-ssl/custom-config-ssl.json
+++ b/examples/kube/custom-config-ssl/custom-config-ssl.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "custom-config-ssl",
         "labels": {
-            "name": "custom-config-ssl"
+            "name": "custom-config-ssl",
+            "cleanup": "$CCP_NAMESPACE-custom-config-ssl"
         }
     },
     "spec": {
@@ -29,7 +30,8 @@
     "metadata": {
         "name": "custom-config-ssl",
         "labels": {
-            "name": "custom-config-ssl"
+            "name": "custom-config-ssl",
+            "cleanup": "$CCP_NAMESPACE-custom-config-ssl"
         }
     },
     "spec": {

--- a/examples/kube/custom-config-ssl/run.sh
+++ b/examples/kube/custom-config-ssl/run.sh
@@ -47,6 +47,9 @@ ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} secret generic ${CONTAINER_NAME
     --from-file=pg-ident-conf=${DIR?}/configs/pg_ident.conf \
     --from-file=postgresql-conf=${DIR?}/configs/postgresql.conf
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} secret \
+    ${CONTAINER_NAME?}-secrets cleanup=${CCP_NAMESPACE?}-${CONTAINER_NAME?}
+
 expenv -f $DIR/custom-config-ssl.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 
 echo ""

--- a/examples/kube/custom-config/cleanup.sh
+++ b/examples/kube/custom-config/cleanup.sh
@@ -16,15 +16,7 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service custom-config
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod custom-config
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc custom-config-pgdata custom-config-pgwal custom-config-br
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap custom-config-pgconf
-
-if [[ -z "$CCP_STORAGE_CLASS" ]]
-then
-    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-custom-config-pgdata $CCP_NAMESPACE-custom-config-pgwal $CCP_NAMESPACE-custom-config-br
-fi
+cleanup "${CCP_NAMESPACE?}-custom-config"
 
 $CCPROOT/examples/waitforterm.sh custom-config ${CCP_CLI?}
 

--- a/examples/kube/custom-config/custom-config-pv-nfs.json
+++ b/examples/kube/custom-config/custom-config-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-custom-config-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-custom-config-pgdata"
+            "name": "$CCP_NAMESPACE-custom-config-pgdata",
+            "cleanup": "$CCP_NAMESPACE-custom-config"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config",
             "server": "$CCP_NFS_IP"
@@ -26,14 +29,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-custom-config-br",
         "labels": {
-            "name": "$CCP_NAMESPACE-custom-config-br"
+            "name": "$CCP_NAMESPACE-custom-config-br",
+            "cleanup": "$CCP_NAMESPACE-custom-config"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config",
             "server": "$CCP_NFS_IP"
@@ -48,14 +54,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-custom-config-pgwal",
         "labels": {
-            "name": "$CCP_NAMESPACE-custom-config-pgwal"
+            "name": "$CCP_NAMESPACE-custom-config-pgwal",
+            "cleanup": "$CCP_NAMESPACE-custom-config"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/custom-config/custom-config-pv.json
+++ b/examples/kube/custom-config/custom-config-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-custom-config-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-custom-config-pgdata"
+            "name": "$CCP_NAMESPACE-custom-config-pgdata",
+            "cleanup": "$CCP_NAMESPACE-custom-config"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config"
         },
@@ -25,14 +28,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-custom-config-br",
         "labels": {
-            "name": "$CCP_NAMESPACE-custom-config-br"
+            "name": "$CCP_NAMESPACE-custom-config-br",
+            "cleanup": "$CCP_NAMESPACE-custom-config"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config"
         },
@@ -46,14 +52,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-custom-config-pgwal",
         "labels": {
-            "name": "$CCP_NAMESPACE-custom-config-pgwal"
+            "name": "$CCP_NAMESPACE-custom-config-pgwal",
+            "cleanup": "$CCP_NAMESPACE-custom-config"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-custom-config"
         },

--- a/examples/kube/custom-config/custom-config-pvc-sc.json
+++ b/examples/kube/custom-config/custom-config-pvc-sc.json
@@ -2,55 +2,64 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "custom-config-pgdata"
+        "name": "custom-config-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-custom-config"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }
 
 {
-    "kind": "PersistentVolumeClaim",
-    "apiVersion": "v1",
-    "metadata": {
-        "name": "custom-config-br"
-    },
-    "spec": {
+  "kind": "PersistentVolumeClaim",
+  "apiVersion": "v1",
+  "metadata": {
+      "name": "custom-config-br",
+      "labels": {
+          "cleanup": "$CCP_NAMESPACE-custom-config"
+      }
+  },
+  "spec": {
       "accessModes": [
-        "$CCP_STORAGE_MODE"
+          "$CCP_STORAGE_MODE"
       ],
       "storageClassName": "$CCP_STORAGE_CLASS",
       "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
+          "requests": {
+              "storage": "$CCP_STORAGE_CAPACITY"
+          }
       }
-    }
+  }
 }
 
 {
-    "kind": "PersistentVolumeClaim",
-    "apiVersion": "v1",
-    "metadata": {
-        "name": "custom-config-pgwal"
-    },
-    "spec": {
+  "kind": "PersistentVolumeClaim",
+  "apiVersion": "v1",
+  "metadata": {
+      "name": "custom-config-pgwal",
+      "labels": {
+          "cleanup": "$CCP_NAMESPACE-custom-config"
+      }
+  },
+  "spec": {
       "accessModes": [
-        "$CCP_STORAGE_MODE"
+          "$CCP_STORAGE_MODE"
       ],
       "storageClassName": "$CCP_STORAGE_CLASS",
       "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
+          "requests": {
+              "storage": "$CCP_STORAGE_CAPACITY"
+          }
       }
-    }
+  }
 }

--- a/examples/kube/custom-config/custom-config-pvc.json
+++ b/examples/kube/custom-config/custom-config-pvc.json
@@ -2,13 +2,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "custom-config-pgdata"
+        "name": "custom-config-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-custom-config"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-custom-config-pgdata"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-custom-config-pgdata"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"
@@ -25,13 +28,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "custom-config-br"
+        "name": "custom-config-br",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-custom-config"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-custom-config-br"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-custom-config-br"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"
@@ -48,13 +54,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "custom-config-pgwal"
+        "name": "custom-config-pgwal",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-custom-config"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-custom-config-pgwal"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-custom-config-pgwal"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"

--- a/examples/kube/custom-config/custom-config.json
+++ b/examples/kube/custom-config/custom-config.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "custom-config",
         "labels": {
-            "name": "custom-config"
+            "name": "custom-config",
+            "cleanup": "$CCP_NAMESPACE-custom-config"
         }
     },
     "spec": {
@@ -30,14 +31,15 @@
     "metadata": {
         "name": "custom-config",
         "labels": {
-            "name": "custom-config"
+            "name": "custom-config",
+            "cleanup": "$CCP_NAMESPACE-custom-config"
         }
     },
     "spec": {
         "securityContext": {
-           $CCP_SECURITY_CONTEXT
-        	},
-    "containers": [
+            $CCP_SECURITY_CONTEXT
+        },
+        "containers": [
             {
                 "name": "postgres",
                 "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",

--- a/examples/kube/custom-config/run.sh
+++ b/examples/kube/custom-config/run.sh
@@ -34,4 +34,7 @@ ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} configmap custom-config-pgconf 
     --from-file ${DIR?}/configs/pre-start-hook.sh \
     --from-file ${DIR?}/configs/post-start-hook.sh
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap \
+    custom-config-pgconf cleanup=${CCP_NAMESPACE?}-custom-config
+
 expenv -f $DIR/custom-config.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/metrics/cleanup.sh
+++ b/examples/kube/metrics/cleanup.sh
@@ -16,19 +16,7 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} clusterrolebinding prometheus-sa
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} clusterrole prometheus-sa
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} sa prometheus-sa
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod metrics
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment primary-metrics replica-metrics
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service metrics primary-metrics replica-metrics
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap metrics-pgconf
-
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc metrics-prometheusdata metrics-grafanadata
-
-if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-metrics-prometheusdata $CCP_NAMESPACE-metrics-grafanadata
-fi
+cleanup "${CCP_NAMESPACE?}-metrics"
 
 $CCPROOT/examples/waitforterm.sh metrics ${CCP_CLI?}
 $CCPROOT/examples/waitforterm.sh primary-metrics ${CCP_CLI?}

--- a/examples/kube/metrics/metrics-pv-nfs.json
+++ b/examples/kube/metrics/metrics-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-metrics-grafanadata",
         "labels": {
-            "name": "$CCP_NAMESPACE-metrics-grafanadata"
+            "name": "$CCP_NAMESPACE-metrics-grafanadata",
+            "cleanup": "$CCP_NAMESPACE-metrics"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-metrics",
             "server": "$CCP_NFS_IP"
@@ -26,14 +29,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-metrics-prometheusdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-metrics-prometheusdata"
+            "name": "$CCP_NAMESPACE-metrics-prometheusdata",
+            "cleanup": "$CCP_NAMESPACE-metrics"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-metrics",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/metrics/metrics-pv.json
+++ b/examples/kube/metrics/metrics-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-metrics-grafanadata",
         "labels": {
-            "name": "$CCP_NAMESPACE-metrics-grafanadata"
+            "name": "$CCP_NAMESPACE-metrics-grafanadata",
+            "cleanup": "$CCP_NAMESPACE-metrics"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-metrics"
         },
@@ -25,14 +28,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-metrics-prometheusdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-metrics-prometheusdata"
+            "name": "$CCP_NAMESPACE-metrics-prometheusdata",
+            "cleanup": "$CCP_NAMESPACE-metrics"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-metrics"
         },

--- a/examples/kube/metrics/metrics-pvc-sc.json
+++ b/examples/kube/metrics/metrics-pvc-sc.json
@@ -2,18 +2,21 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "metrics-prometheusdata"
+        "name": "metrics-prometheusdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-metrics"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }
 
@@ -21,17 +24,20 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "metrics-grafanadata"
+        "name": "metrics-grafanadata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-metrics"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/metrics/metrics-pvc.json
+++ b/examples/kube/metrics/metrics-pvc.json
@@ -2,13 +2,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "metrics-prometheusdata"
+        "name": "metrics-prometheusdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-metrics"
+        }
     },
-      "spec": {
+    "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-metrics-prometheusdata"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-metrics-prometheusdata"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"
@@ -25,13 +28,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "metrics-grafanadata"
+        "name": "metrics-grafanadata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-metrics"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-metrics-grafanadata"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-metrics-grafanadata"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"

--- a/examples/kube/metrics/metrics.json
+++ b/examples/kube/metrics/metrics.json
@@ -2,7 +2,10 @@
     "apiVersion": "rbac.authorization.k8s.io/v1beta1",
     "kind": "ClusterRole",
     "metadata": {
-        "name": "prometheus-sa"
+        "name": "prometheus-sa",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-metrics"
+        }
     },
     "rules": [
         {
@@ -17,32 +20,30 @@
                 "list",
                 "watch"
             ]
-        },
-        {
-            "nonResourceURLs": [
-                "/metrics"
-            ],
-            "verbs": [
-                "get",
-                "list",
-                "watch"
-            ]
         }
     ]
 }
+
 {
     "apiVersion": "v1",
     "kind": "ServiceAccount",
     "metadata": {
         "name": "prometheus-sa",
-        "namespace": "$CCP_NAMESPACE"
+        "namespace": "$CCP_NAMESPACE",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-metrics"
+        }
     }
 }
+
 {
     "apiVersion": "rbac.authorization.k8s.io/v1beta1",
     "kind": "ClusterRoleBinding",
     "metadata": {
-        "name": "prometheus-sa"
+        "name": "prometheus-sa",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-metrics"
+        }
     },
     "roleRef": {
         "apiGroup": "rbac.authorization.k8s.io",
@@ -57,13 +58,15 @@
         }
     ]
 }
+
 {
     "kind": "Service",
     "apiVersion": "v1",
     "metadata": {
         "name": "metrics",
         "labels": {
-            "name": "metrics"
+            "name": "metrics",
+            "cleanup": "$CCP_NAMESPACE-metrics"
         }
     },
     "spec": {
@@ -88,13 +91,15 @@
         "sessionAffinity": "None"
     }
 }
+
 {
     "kind": "Pod",
     "apiVersion": "v1",
     "metadata": {
         "name": "metrics",
         "labels": {
-            "name": "metrics"
+            "name": "metrics",
+            "cleanup": "$CCP_NAMESPACE-metrics"
         }
     },
     "spec": {

--- a/examples/kube/metrics/primary.json
+++ b/examples/kube/metrics/primary.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "primary-metrics",
         "labels": {
-            "name": "primary-metrics"
+            "name": "primary-metrics",
+            "cleanup": "$CCP_NAMESPACE-metrics"
         }
     },
     "spec": {
@@ -45,7 +46,8 @@
     "metadata": {
         "name": "primary-metrics",
         "labels": {
-            "name": "primary-metrics"
+            "name": "primary-metrics",
+            "cleanup": "$CCP_NAMESPACE-metrics"
         }
     },
     "spec": {
@@ -54,7 +56,8 @@
             "metadata": {
                 "labels": {
                     "name": "primary-metrics",
-                    "crunchy_collect": "true"
+                    "crunchy_collect": "true",
+                    "cleanup": "$CCP_NAMESPACE-metrics"
                 }
             },
             "spec": {

--- a/examples/kube/metrics/replica.json
+++ b/examples/kube/metrics/replica.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "replica-metrics",
         "labels": {
-            "name": "replica-metrics"
+            "name": "replica-metrics",
+            "cleanup": "$CCP_NAMESPACE-metrics"
         }
     },
     "spec": {
@@ -45,7 +46,8 @@
     "metadata": {
         "name": "replica-metrics",
         "labels": {
-            "name": "replica-metrics"
+            "name": "replica-metrics",
+            "cleanup": "$CCP_NAMESPACE-metrics"
         }
     },
     "spec": {
@@ -54,7 +56,8 @@
             "metadata": {
                 "labels": {
                     "name": "replica-metrics",
-                    "crunchy_collect": "true"
+                    "crunchy_collect": "true",
+                    "cleanup": "$CCP_NAMESPACE-metrics"
                 }
             },
             "spec": {

--- a/examples/kube/metrics/run.sh
+++ b/examples/kube/metrics/run.sh
@@ -30,6 +30,9 @@ ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} \
     configmap metrics-pgconf \
     --from-file ${DIR?}/configs/pgbackrest.conf
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap \
+    metrics-pgconf cleanup=${CCP_NAMESPACE?}-metrics
+
 expenv -f $DIR/metrics.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 expenv -f $DIR/primary.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 expenv -f $DIR/replica.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/pgadmin4-http/cleanup.sh
+++ b/examples/kube/pgadmin4-http/cleanup.sh
@@ -15,14 +15,7 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service pgadmin4-http
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod pgadmin4-http
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pgadmin4-http-secrets
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc pgadmin4-http-data
-
-if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-pgadmin4-http-data
-fi
+cleanup "${CCP_NAMESPACE?}-pgadmin4-http"
 
 $CCPROOT/examples/waitforterm.sh pgadmin4-http ${CCP_CLI?}
 

--- a/examples/kube/pgadmin4-http/pgadmin4-http-pv-nfs.json
+++ b/examples/kube/pgadmin4-http/pgadmin4-http-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-pgadmin4-http-data",
         "labels": {
-            "name": "$CCP_NAMESPACE-pgadmin4-http-data"
+            "name": "$CCP_NAMESPACE-pgadmin4-http-data",
+            "cleanup": "$CCP_NAMESPACE-pgadmin4-http"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pgadmin4-http",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/pgadmin4-http/pgadmin4-http-pv.json
+++ b/examples/kube/pgadmin4-http/pgadmin4-http-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-pgadmin4-http-data",
         "labels": {
-            "name": "$CCP_NAMESPACE-pgadmin4-http-data"
+            "name": "$CCP_NAMESPACE-pgadmin4-http-data",
+            "cleanup": "$CCP_NAMESPACE-pgadmin4-http"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pgadmin4-http"
         },

--- a/examples/kube/pgadmin4-http/pgadmin4-http-pvc-sc.json
+++ b/examples/kube/pgadmin4-http/pgadmin4-http-pvc-sc.json
@@ -2,17 +2,20 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "pgadmin4-http-data"
+        "name": "pgadmin4-http-data",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-pgadmin4-http"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/pgadmin4-http/pgadmin4-http-pvc.json
+++ b/examples/kube/pgadmin4-http/pgadmin4-http-pvc.json
@@ -2,13 +2,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "pgadmin4-http-data"
+        "name": "pgadmin4-http-data",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-pgadmin4-http"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-pgadmin4-http-data"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-pgadmin4-http-data"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"

--- a/examples/kube/pgadmin4-http/pgadmin4-http.json
+++ b/examples/kube/pgadmin4-http/pgadmin4-http.json
@@ -4,16 +4,19 @@
     "metadata": {
         "name": "pgadmin4-http",
         "labels": {
-            "name": "pgadmin4-http"
+            "name": "pgadmin4-http",
+            "cleanup": "$CCP_NAMESPACE-pgadmin4-http"
         }
     },
     "spec": {
-        "ports": [{
-            "name": "pgadmin4-http",
-            "protocol": "TCP",
-            "port": 5050,
-            "targetPort": 5050
-        }],
+        "ports": [
+            {
+                "name": "pgadmin4-http",
+                "protocol": "TCP",
+                "port": 5050,
+                "targetPort": 5050
+            }
+        ],
         "selector": {
             "name": "pgadmin4-http"
         },
@@ -28,7 +31,8 @@
     "metadata": {
         "name": "pgadmin4-http",
         "labels": {
-            "name": "pgadmin4-http"
+            "name": "pgadmin4-http",
+            "cleanup": "$CCP_NAMESPACE-pgadmin4-http"
         }
     },
     "spec": {

--- a/examples/kube/pgadmin4-http/run.sh
+++ b/examples/kube/pgadmin4-http/run.sh
@@ -29,4 +29,7 @@ ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} secret generic pgadmin4-http-se
     --from-literal=pgadmin-email='admin@admin.com' \
     --from-literal=pgadmin-password='password'
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} secret \
+    pgadmin4-http-secrets cleanup=${CCP_NAMESPACE?}-pgadmin4-http
+
 expenv -f $DIR/pgadmin4-http.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/pgadmin4-https/cleanup.sh
+++ b/examples/kube/pgadmin4-https/cleanup.sh
@@ -17,19 +17,9 @@ source ${CCPROOT}/examples/common.sh
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service pgadmin4-https
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod pgadmin4-https
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pgadmin4-https-secrets
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pgadmin4-https-tls
-
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc pgadmin4-https-data
-
-if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-pgadmin4-https-data
-fi
-
 rm -f ${DIR?}/server.crt ${DIR?}/server.key ${DIR?}/privkey.pem
 
+cleanup "$CCP_NAMESPACE-pgadmin4-https"
 $CCPROOT/examples/waitforterm.sh pgadmin4-https ${CCP_CLI?}
 
 dir_check_rm "pgadmin4-https"

--- a/examples/kube/pgadmin4-https/pgadmin4-https-pv-nfs.json
+++ b/examples/kube/pgadmin4-https/pgadmin4-https-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-pgadmin4-https-data",
         "labels": {
-            "name": "$CCP_NAMESPACE-pgadmin4-https-data"
+            "name": "$CCP_NAMESPACE-pgadmin4-https-data",
+            "cleanup": "$CCP_NAMESPACE-pgadmin4-https"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pgadmin4-https",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/pgadmin4-https/pgadmin4-https-pv.json
+++ b/examples/kube/pgadmin4-https/pgadmin4-https-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-pgadmin4-https-data",
         "labels": {
-            "name": "$CCP_NAMESPACE-pgadmin4-https-data"
+            "name": "$CCP_NAMESPACE-pgadmin4-https-data",
+            "cleanup": "$CCP_NAMESPACE-pgadmin4-https"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pgadmin4-https"
         },

--- a/examples/kube/pgadmin4-https/pgadmin4-https-pvc-sc.json
+++ b/examples/kube/pgadmin4-https/pgadmin4-https-pvc-sc.json
@@ -2,17 +2,20 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "pgadmin4-https-data"
+        "name": "pgadmin4-https-data",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-pgadmin4-https"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/pgadmin4-https/pgadmin4-https-pvc.json
+++ b/examples/kube/pgadmin4-https/pgadmin4-https-pvc.json
@@ -2,13 +2,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "pgadmin4-https-data"
+        "name": "pgadmin4-https-data",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-pgadmin4-https"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-pgadmin4-https-data"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-pgadmin4-https-data"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"

--- a/examples/kube/pgadmin4-https/pgadmin4-https.json
+++ b/examples/kube/pgadmin4-https/pgadmin4-https.json
@@ -4,16 +4,19 @@
     "metadata": {
         "name": "pgadmin4-https",
         "labels": {
-            "name": "pgadmin4-https"
+            "name": "pgadmin4-https",
+            "cleanup": "$CCP_NAMESPACE-pgadmin4-https"
         }
     },
     "spec": {
-        "ports": [{
-            "name": "pgadmin4-https",
-            "protocol": "TCP",
-            "port": 5050,
-            "targetPort": 5050
-        }],
+        "ports": [
+            {
+                "name": "pgadmin4-https",
+                "protocol": "TCP",
+                "port": 5050,
+                "targetPort": 5050
+            }
+        ],
         "selector": {
             "name": "pgadmin4-https"
         },
@@ -28,7 +31,8 @@
     "metadata": {
         "name": "pgadmin4-https",
         "labels": {
-            "name": "pgadmin4-https"
+            "name": "pgadmin4-https",
+            "cleanup": "$CCP_NAMESPACE-pgadmin4-https"
         }
     },
     "spec": {

--- a/examples/kube/pgadmin4-https/run.sh
+++ b/examples/kube/pgadmin4-https/run.sh
@@ -31,8 +31,14 @@ ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} secret generic pgadmin4-https-s
     --from-literal=pgadmin-email='admin@admin.com' \
     --from-literal=pgadmin-password='password'
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} secret \
+    pgadmin4-https-secrets cleanup=${CCP_NAMESPACE?}-pgadmin4-https
+
 ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} secret generic pgadmin4-https-tls \
     --from-file=pgadmin-cert=${DIR?}/server.crt \
     --from-file=pgadmin-key=${DIR?}/server.key
+
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} secret \
+    pgadmin4-https-tls cleanup=${CCP_NAMESPACE?}-pgadmin4-https
 
 expenv -f $DIR/pgadmin4-https.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/pgaudit/cleanup.sh
+++ b/examples/kube/pgaudit/cleanup.sh
@@ -15,8 +15,6 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service pgaudit
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod pgaudit
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap pgaudit-pgconf
+cleanup "${CCP_NAMESPACE?}-pgaudit"
 
 $CCPROOT/examples/waitforterm.sh pgaudit ${CCP_CLI?} ${CCP_NAMESPACE}

--- a/examples/kube/pgaudit/pgaudit.json
+++ b/examples/kube/pgaudit/pgaudit.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "pgaudit",
         "labels": {
-            "name": "pgaudit"
+            "name": "pgaudit",
+            "cleanup": "$CCP_NAMESPACE-pgaudit"
         }
     },
     "spec": {
@@ -30,13 +31,14 @@
     "metadata": {
         "name": "pgaudit",
         "labels": {
-            "name": "pgaudit"
+            "name": "pgaudit",
+            "cleanup": "$CCP_NAMESPACE-pgaudit"
         }
     },
     "spec": {
         "securityContext": {
             $CCP_SECURITY_CONTEXT
-            },
+        },
         "containers": [
             {
                 "name": "postgres",

--- a/examples/kube/pgaudit/run.sh
+++ b/examples/kube/pgaudit/run.sh
@@ -24,4 +24,7 @@ ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} configmap pgaudit-pgconf \
     --from-file ${DIR?}/configs/postgresql.conf \
     --from-file ${DIR?}/configs/pgaudit-test.sql
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap \
+    pgaudit-pgconf cleanup=${CCP_NAMESPACE?}-pgaudit
+
 expenv -f $DIR/pgaudit.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE} -f -

--- a/examples/kube/pgbadger/cleanup.sh
+++ b/examples/kube/pgbadger/cleanup.sh
@@ -15,6 +15,6 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod pgbadger
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service pgbadger
+cleanup "${CCP_NAMESPACE?}-pgbadger"
+
 $CCPROOT/examples/waitforterm.sh pgbadger ${CCP_CLI?}

--- a/examples/kube/pgbadger/pgbadger.json
+++ b/examples/kube/pgbadger/pgbadger.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "pgbadger",
         "labels": {
-            "name": "pgbadger"
+            "name": "pgbadger",
+            "cleanup": "$CCP_NAMESPACE-pgbadger"
         }
     },
     "spec": {
@@ -38,7 +39,8 @@
     "metadata": {
         "name": "pgbadger",
         "labels": {
-            "name": "pgbadger"
+            "name": "pgbadger",
+            "cleanup": "$CCP_NAMESPACE-pgbadger"
         }
     },
     "spec": {

--- a/examples/kube/pgbouncer/cleanup.sh
+++ b/examples/kube/pgbouncer/cleanup.sh
@@ -16,12 +16,7 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod pg-primary pg-replica
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod pgbouncer-primary pgbouncer-replica
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service pg-primary pg-replica
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service pgbouncer-primary pgbouncer-replica
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pgbouncer-secrets
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pgsql-secrets
+cleanup "${CCP_NAMESPACE?}-pgbouncer"
 
 $CCPROOT/examples/waitforterm.sh pgbouncer-primary ${CCP_CLI?}
 $CCPROOT/examples/waitforterm.sh pgbouncer-replica ${CCP_CLI?}

--- a/examples/kube/pgbouncer/pgbouncer-primary.json
+++ b/examples/kube/pgbouncer/pgbouncer-primary.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "pgbouncer-primary",
         "labels": {
-            "name": "pgbouncer-primary"
+            "name": "pgbouncer-primary",
+            "cleanup": "$CCP_NAMESPACE-pgbouncer"
         }
     },
     "spec": {
@@ -31,7 +32,8 @@
     "metadata": {
         "name": "pgbouncer-primary",
         "labels": {
-            "name": "pgbouncer-primary"
+            "name": "pgbouncer-primary",
+            "cleanup": "$CCP_NAMESPACE-pgbouncer"
         }
     },
     "spec": {

--- a/examples/kube/pgbouncer/pgbouncer-replica.json
+++ b/examples/kube/pgbouncer/pgbouncer-replica.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "pgbouncer-replica",
         "labels": {
-            "name": "pgbouncer-replica"
+            "name": "pgbouncer-replica",
+            "cleanup": "$CCP_NAMESPACE-pgbouncer"
         }
     },
     "spec": {
@@ -31,7 +32,8 @@
     "metadata": {
         "name": "pgbouncer-replica",
         "labels": {
-            "name": "pgbouncer-replica"
+            "name": "pgbouncer-replica",
+            "cleanup": "$CCP_NAMESPACE-pgbouncer"
         }
     },
     "spec": {

--- a/examples/kube/pgbouncer/primary.json
+++ b/examples/kube/pgbouncer/primary.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "pg-primary",
         "labels": {
-            "name": "pg-primary"
+            "name": "pg-primary",
+            "cleanup": "$CCP_NAMESPACE-pgbouncer"
         }
     },
     "spec": {
@@ -34,7 +35,8 @@
     "metadata": {
         "name": "pg-primary",
         "labels": {
-            "name": "pg-primary"
+            "name": "pg-primary",
+            "cleanup": "$CCP_NAMESPACE-pgbouncer"
         }
     },
     "spec": {
@@ -52,13 +54,11 @@
                     }
                 ],
                 "readinessProbe": {
-                    "exec": {
-                        "command": [
-                            "/opt/cpm/bin/readiness.sh"
-                        ]
+                    "tcpSocket": {
+                        "port": 5432
                     },
-                    "initialDelaySeconds": 40,
-                    "timeoutSeconds": 1
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 10
                 },
                 "livenessProbe": {
                     "exec": {
@@ -127,13 +127,6 @@
                         }
                     }
                 ],
-                "readinessProbe": {
-                    "tcpSocket": {
-                        "port": 5432
-                    },
-                    "initialDelaySeconds": 5,
-                    "periodSeconds": 10
-                },
                 "volumeMounts": [
                     {
                         "mountPath": "/pgdata",

--- a/examples/kube/pgbouncer/replica.json
+++ b/examples/kube/pgbouncer/replica.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "pg-replica",
         "labels": {
-            "name": "pg-replica"
+            "name": "pg-replica",
+            "cleanup": "$CCP_NAMESPACE-pgbouncer"
         }
     },
     "spec": {
@@ -34,7 +35,8 @@
     "metadata": {
         "name": "pg-replica",
         "labels": {
-            "name": "pg-replica"
+            "name": "pg-replica",
+            "cleanup": "$CCP_NAMESPACE-pgbouncer"
         }
     },
     "spec": {
@@ -52,13 +54,11 @@
                     }
                 ],
                 "readinessProbe": {
-                    "exec": {
-                        "command": [
-                            "/opt/cpm/bin/readiness.sh"
-                        ]
+                    "tcpSocket": {
+                        "port": 5432
                     },
-                    "initialDelaySeconds": 40,
-                    "timeoutSeconds": 1
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 10
                 },
                 "livenessProbe": {
                     "exec": {
@@ -126,13 +126,6 @@
                         }
                     }
                 ],
-                "readinessProbe": {
-                    "tcpSocket": {
-                        "port": 5432
-                    },
-                    "initialDelaySeconds": 5,
-                    "periodSeconds": 10
-                },
                 "volumeMounts": [
                     {
                         "mountPath": "/pgdata",

--- a/examples/kube/pgbouncer/run.sh
+++ b/examples/kube/pgbouncer/run.sh
@@ -22,10 +22,16 @@ $DIR/cleanup.sh
 ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} secret generic pgbouncer-secrets \
     --from-literal=pgbouncer-password='password'
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} secret \
+    pgbouncer-secrets cleanup=${CCP_NAMESPACE?}-pgbouncer
+
 ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} secret generic pgsql-secrets \
     --from-literal=pg-primary-password='password' \
     --from-literal=pg-password='password' \
     --from-literal=pg-root-password='password'
+
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} secret \
+    pgsql-secrets cleanup=${CCP_NAMESPACE?}-pgbouncer
 
 expenv -f $DIR/primary.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 expenv -f $DIR/replica.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/pgdump/cleanup.sh
+++ b/examples/kube/pgdump/cleanup.sh
@@ -15,9 +15,7 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job pgdump
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc pgdump-pgdata
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-pgdump-pgdata
+cleanup "${CCP_NAMESPACE?}-pgdump"
 
 $CCPROOT/examples/waitforterm.sh pgdump ${CCP_CLI?}
 

--- a/examples/kube/pgdump/pgdump-pv-nfs.json
+++ b/examples/kube/pgdump/pgdump-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-pgdump-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-pgdump-pgdata"
+            "name": "$CCP_NAMESPACE-pgdump-pgdata",
+            "cleanup": "$CCP_NAMESPACE-pgdump"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pgdump",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/pgdump/pgdump-pv.json
+++ b/examples/kube/pgdump/pgdump-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-pgdump-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-pgdump-pgdata"
+            "name": "$CCP_NAMESPACE-pgdump-pgdata",
+            "cleanup": "$CCP_NAMESPACE-pgdump"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pgdump"
         },

--- a/examples/kube/pgdump/pgdump-pvc-sc.json
+++ b/examples/kube/pgdump/pgdump-pvc-sc.json
@@ -2,17 +2,20 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "pgdump-pgdata"
+        "name": "pgdump-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-pgdump"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/pgdump/pgdump-pvc.json
+++ b/examples/kube/pgdump/pgdump-pvc.json
@@ -2,13 +2,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "pgdump-pgdata"
+        "name": "pgdump-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-pgdump"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-pgdump-pgdata"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-pgdump-pgdata"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"

--- a/examples/kube/pgdump/pgdump.json
+++ b/examples/kube/pgdump/pgdump.json
@@ -9,7 +9,8 @@
             "metadata": {
                 "name": "pgdump",
                 "labels": {
-                    "app": "pgdump"
+                    "app": "pgdump",
+                    "cleanup": "$CCP_NAMESPACE-pgdump"
                 }
             },
             "spec": {

--- a/examples/kube/pgpool/cleanup.sh
+++ b/examples/kube/pgpool/cleanup.sh
@@ -15,7 +15,4 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service pgpool
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment pgpool
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pgpool-secrets
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap pgpool-pgconf
+cleanup "${CCP_NAMESPACE?}-pgpool"

--- a/examples/kube/pgpool/pgpool.json
+++ b/examples/kube/pgpool/pgpool.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "pgpool",
         "labels": {
-            "name": "pgpool"
+            "name": "pgpool",
+            "cleanup": "$CCP_NAMESPACE-pgpool"
         }
     },
     "spec": {
@@ -30,7 +31,8 @@
     "metadata": {
         "name": "pgpool",
         "labels": {
-            "name": "pgpool"
+            "name": "pgpool",
+            "cleanup": "$CCP_NAMESPACE-pgpool"
         }
     },
     "spec": {
@@ -38,7 +40,8 @@
         "template": {
             "metadata": {
                 "labels": {
-                    "name": "pgpool"
+                    "name": "pgpool",
+                    "cleanup": "$CCP_NAMESPACE-pgpool"
                 }
             },
             "spec": {

--- a/examples/kube/pgpool/run.sh
+++ b/examples/kube/pgpool/run.sh
@@ -26,9 +26,15 @@ ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} secret generic pgpool-secrets \
 	--from-file=$DIR/configs/pgpool.conf \
 	--from-file=$DIR/configs/pool_passwd
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} secret \
+    pgpool-secrets cleanup=${CCP_NAMESPACE?}-pgpool
+
 ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} configmap pgpool-pgconf \
 	--from-file=$DIR/configs/pgpool.conf \
 	--from-file=hba=$DIR/configs/pool_hba.conf \
 	--from-file=psw=$DIR/configs/pool_passwd
+
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap \
+    pgpool-pgconf cleanup=${CCP_NAMESPACE?}-pgpool
 
 expenv -f $DIR/pgpool.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/pgrestore/cleanup.sh
+++ b/examples/kube/pgrestore/cleanup.sh
@@ -15,6 +15,6 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job pgrestore
+cleanup "${CCP_NAMESPACE?}-pgrestore"
 
 $CCPROOT/examples/waitforterm.sh pgrestore ${CCP_CLI?}

--- a/examples/kube/pgrestore/pgrestore.json
+++ b/examples/kube/pgrestore/pgrestore.json
@@ -1,62 +1,63 @@
 {
-     "apiVersion":"batch/v1",
-     "kind":"Job",
-     "metadata":{
-        "name":"pgrestore"
-     },
-     "spec":{
-        "template":{
-           "metadata":{
-              "name":"pgrestore",
-              "labels":{
-                 "app":"pgrestore"
-              }
-           },
-           "spec":{
-              "volumes":[
-                 {
-                    "name":"pgdata",
-                    "persistentVolumeClaim":{
-                       "claimName":"pgdump-pgdata"
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+        "name": "pgrestore"
+    },
+    "spec": {
+        "template": {
+            "metadata": {
+                "name": "pgrestore",
+                "labels": {
+                    "app": "pgrestore",
+                    "cleanup": "$CCP_NAMESPACE-pgrestore"
+                }
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "pgdata",
+                        "persistentVolumeClaim": {
+                            "claimName": "pgdump-pgdata"
+                        }
                     }
-                 }
-              ],
-              "securityContext":{
-                 $CCP_SECURITY_CONTEXT
-              },
-              "containers":[
-                 {
-                    "name":"pgrestore",
-                    "image":"$CCP_IMAGE_PREFIX/crunchy-pgrestore:$CCP_IMAGE_TAG",
-                    "volumeMounts":[
-                       {
-                          "mountPath":"/pgdata",
-                          "name":"pgdata",
-                          "readOnly":true
-                       }
-                    ],
-                    "env":[
-                       {
-                          "name":"PGRESTORE_HOST",
-                          "value":"primary"
-                       },
-                       {
-                          "name":"PGRESTORE_DB",
-                          "value":"postgres"
-                       },
-                       {
-                          "name":"PGRESTORE_USER",
-                          "value":"postgres"
-                       },
-                       {
-                          "name":"PGRESTORE_PASS",
-                          "value":"password"
-                       }
-                    ]
-                 }
-              ],
-              "restartPolicy":"Never"
-           }
+                ],
+                "securityContext": {
+                  $CCP_SECURITY_CONTEXT
+                },
+                "containers": [
+                    {
+                        "name": "pgrestore",
+                        "image": "$CCP_IMAGE_PREFIX/crunchy-pgrestore:$CCP_IMAGE_TAG",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/pgdata",
+                                "name": "pgdata",
+                                "readOnly": true
+                            }
+                        ],
+                        "env": [
+                            {
+                                "name": "PGRESTORE_HOST",
+                                "value": "primary"
+                            },
+                            {
+                                "name": "PGRESTORE_DB",
+                                "value": "postgres"
+                            },
+                            {
+                                "name": "PGRESTORE_USER",
+                                "value": "postgres"
+                            },
+                            {
+                                "name": "PGRESTORE_PASS",
+                                "value": "password"
+                            }
+                        ]
+                    }
+                ],
+                "restartPolicy": "Never"
+            }
         }
-     }
+    }
 }

--- a/examples/kube/pitr/backup-pitr-pv-nfs.json
+++ b/examples/kube/pitr/backup-pitr-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-backup-pitr-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-backup-pitr-pgdata"
+            "name": "$CCP_NAMESPACE-backup-pitr-pgdata",
+            "cleanup": "$CCP_NAMESPACE-backup-pitr"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backup-pitr",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/pitr/backup-pitr-pv.json
+++ b/examples/kube/pitr/backup-pitr-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-backup-pitr-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-backup-pitr-pgdata"
+            "name": "$CCP_NAMESPACE-backup-pitr-pgdata",
+            "cleanup": "$CCP_NAMESPACE-backup-pitr"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-backup-pitr"
         },

--- a/examples/kube/pitr/backup-pitr-pvc-sc.json
+++ b/examples/kube/pitr/backup-pitr-pvc-sc.json
@@ -2,17 +2,20 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "backup-pitr-pgdata"
+        "name": "backup-pitr-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backup-pitr"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/pitr/backup-pitr-pvc.json
+++ b/examples/kube/pitr/backup-pitr-pvc.json
@@ -2,21 +2,24 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "backup-pitr-pgdata"
+        "name": "backup-pitr-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-backup-pitr"
+        }
     },
     "spec": {
-      "selector": {
-        "matchLabels": {
-          "name": "$CCP_NAMESPACE-backup-pitr-pgdata"
+        "selector": {
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-backup-pitr-pgdata"
+            }
+        },
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      },
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
-      }
     }
 }

--- a/examples/kube/pitr/backup-pitr.json
+++ b/examples/kube/pitr/backup-pitr.json
@@ -9,7 +9,8 @@
             "metadata": {
                 "name": "backup-pitr",
                 "labels": {
-                    "app": "backup-pitr"
+                    "app": "backup-pitr",
+                    "cleanup": "$CCP_NAMESPACE-backup-pitr"
                 }
             },
             "spec": {

--- a/examples/kube/pitr/cleanup.sh
+++ b/examples/kube/pitr/cleanup.sh
@@ -16,16 +16,9 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod restore-pitr pitr
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service restore-pitr pitr
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job backup-pitr
-
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc pitr-pgdata pitr-pgwal backup-pitr-pgdata restore-pitr-pgdata recover-pvc
-if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-pitr-pgdata \
-    $CCP_NAMESPACE-pitr-pgwal $CCP_NAMESPACE-backup-pitr-pgdata \
-    $CCP_NAMESPACE-restore-pitr-pgdata $CCP_NAMESPACE-recover-pv
-fi
+cleanup "${CCP_NAMESPACE?}-restore-pitr"
+cleanup "${CCP_NAMESPACE?}-backup-pitr"
+cleanup "${CCP_NAMESPACE?}-pitr"
 
 dir_check_rm "pitr"
 dir_check_rm "backup-pitr"

--- a/examples/kube/pitr/pitr-pv-nfs.json
+++ b/examples/kube/pitr/pitr-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-pitr-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-pitr-pgdata"
+            "name": "$CCP_NAMESPACE-pitr-pgdata",
+            "cleanup": "$CCP_NAMESPACE-pitr"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pitr",
             "server": "$CCP_NFS_IP"
@@ -26,14 +29,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-pitr-pgwal",
         "labels": {
-            "name": "$CCP_NAMESPACE-pitr-pgwal"
+            "name": "$CCP_NAMESPACE-pitr-pgwal",
+            "cleanup": "$CCP_NAMESPACE-pitr"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pitr",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/pitr/pitr-pv.json
+++ b/examples/kube/pitr/pitr-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-pitr-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-pitr-pgdata"
+            "name": "$CCP_NAMESPACE-pitr-pgdata",
+            "cleanup": "$CCP_NAMESPACE-pitr"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pitr"
         },
@@ -25,14 +28,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-pitr-pgwal",
         "labels": {
-            "name": "$CCP_NAMESPACE-pitr-pgwal"
+            "name": "$CCP_NAMESPACE-pitr-pgwal",
+            "cleanup": "$CCP_NAMESPACE-pitr"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-pitr"
         },

--- a/examples/kube/pitr/pitr-pvc-sc.json
+++ b/examples/kube/pitr/pitr-pvc-sc.json
@@ -2,18 +2,21 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "pitr-pgwal"
+        "name": "pitr-pgwal",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-pitr"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }
 
@@ -21,17 +24,20 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "pitr-pgdata"
+        "name": "pitr-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-pitr"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/pitr/pitr-pvc.json
+++ b/examples/kube/pitr/pitr-pvc.json
@@ -2,22 +2,25 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "pitr-pgwal"
+        "name": "pitr-pgwal",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-pitr"
+        }
     },
     "spec": {
-      "selector": {
-        "matchLabels": {
-          "name": "$CCP_NAMESPACE-pitr-pgwal"
+        "selector": {
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-pitr-pgwal"
+            }
+        },
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      },
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
-      }
     }
 }
 
@@ -25,21 +28,24 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "pitr-pgdata"
+        "name": "pitr-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-pitr"
+        }
     },
     "spec": {
-      "selector": {
-        "matchLabels": {
-          "name": "$CCP_NAMESPACE-pitr-pgdata"
+        "selector": {
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-pitr-pgdata"
+            }
+        },
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      },
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
-      }
     }
 }

--- a/examples/kube/pitr/pitr.json
+++ b/examples/kube/pitr/pitr.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "pitr",
         "labels": {
-            "name": "pitr"
+            "name": "pitr",
+            "cleanup": "$CCP_NAMESPACE-pitr"
         }
     },
     "spec": {
@@ -33,12 +34,13 @@
     "metadata": {
         "name": "pitr",
         "labels": {
-            "name": "pitr"
+            "name": "pitr",
+            "cleanup": "$CCP_NAMESPACE-pitr"
         }
     },
     "spec": {
         "securityContext": {
-             $CCP_SECURITY_CONTEXT
+            $CCP_SECURITY_CONTEXT
         },
         "containers": [
             {

--- a/examples/kube/pitr/restore-pitr-pv-nfs.json
+++ b/examples/kube/pitr/restore-pitr-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-recover-pv",
         "labels": {
-            "name": "$CCP_NAMESPACE-recover-pv"
+            "name": "$CCP_NAMESPACE-recover-pv",
+            "cleanup": "$CCP_NAMESPACE-restore-pitr"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-restore-pitr",
             "server": "$CCP_NFS_IP"
@@ -26,14 +29,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-restore-pitr-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-restore-pitr-pgdata"
+            "name": "$CCP_NAMESPACE-restore-pitr-pgdata",
+            "cleanup": "$CCP_NAMESPACE-restore-pitr"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-restore-pitr",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/pitr/restore-pitr-pv.json
+++ b/examples/kube/pitr/restore-pitr-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-recover-pv",
         "labels": {
-            "name": "$CCP_NAMESPACE-recover-pv"
+            "name": "$CCP_NAMESPACE-recover-pv",
+            "cleanup": "$CCP_NAMESPACE-restore-pitr"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-restore-pitr"
         },
@@ -25,14 +28,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-restore-pitr-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-restore-pitr-pgdata"
+            "name": "$CCP_NAMESPACE-restore-pitr-pgdata",
+            "cleanup": "$CCP_NAMESPACE-restore-pitr"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-restore-pitr"
         },

--- a/examples/kube/pitr/restore-pitr-pvc-sc.json
+++ b/examples/kube/pitr/restore-pitr-pvc-sc.json
@@ -2,18 +2,21 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "restore-pitr-pgdata"
+        "name": "restore-pitr-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-restore-pitr"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }
 
@@ -21,17 +24,20 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "recover-pvc"
+        "name": "recover-pvc",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-restore-pitr"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/pitr/restore-pitr-pvc.json
+++ b/examples/kube/pitr/restore-pitr-pvc.json
@@ -2,22 +2,25 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "restore-pitr-pgdata"
+        "name": "restore-pitr-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-restore-pitr"
+        }
     },
     "spec": {
-      "selector": {
-        "matchLabels": {
-          "name": "$CCP_NAMESPACE-restore-pitr-pgdata"
+        "selector": {
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-restore-pitr-pgdata"
+            }
+        },
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      },
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
-      }
     }
 }
 
@@ -25,13 +28,16 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "recover-pvc"
+        "name": "recover-pvc",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-restore-pitr"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-recover-pv"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-recover-pv"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"

--- a/examples/kube/pitr/restore-pitr.json
+++ b/examples/kube/pitr/restore-pitr.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "restore-pitr",
         "labels": {
-            "name": "restore-pitr"
+            "name": "restore-pitr",
+            "cleanup": "$CCP_NAMESPACE-restore-pitr"
         }
     },
     "spec": {
@@ -33,12 +34,13 @@
     "metadata": {
         "name": "restore-pitr",
         "labels": {
-            "name": "restore-pitr"
+            "name": "restore-pitr",
+            "cleanup": "$CCP_NAMESPACE-restore-pitr"
         }
     },
     "spec": {
         "securityContext": {
-             $CCP_SECURITY_CONTEXT
+            $CCP_SECURITY_CONTEXT
         },
         "volumes": [
             {

--- a/examples/kube/pitr/run-backup-pitr.sh
+++ b/examples/kube/pitr/run-backup-pitr.sh
@@ -18,13 +18,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job backup-pitr
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc backup-pitr-pgdata
-if [[ -z "$CCP_STORAGE_CLASS" ]]
-then
-    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv backup-pitr-pgdata
-fi
-
+cleanup "${CCP_NAMESPACE?}-backup-pitr"
 dir_check_rm "backup-pitr"
 create_storage "backup-pitr"
 if [[ $? -ne 0 ]]

--- a/examples/kube/pitr/run-restore-pitr.sh
+++ b/examples/kube/pitr/run-restore-pitr.sh
@@ -18,17 +18,12 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} svc restore-pitr
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod restore-pitr pitr
+cleanup "${CCP_NAMESPACE?}-restore-pitr"
+
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod,svc pitr
 
 $CCPROOT/examples/waitforterm.sh pitr ${CCP_CLI?}
 $CCPROOT/examples/waitforterm.sh restore-pitr ${CCP_CLI?}
-
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc recover-pvc restore-pitr-pgdata
-if [[ -z "$CCP_STORAGE_CLASS" ]]
-then
-    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv ${CCP_NAMESPACE?}-recover-pv ${CCP_NAMESPACE?}-restore-pitr-pgdata
-fi
 
 dir_check_rm "restore-pitr"
 create_storage "restore-pitr"

--- a/examples/kube/pitr/run-sql.sh
+++ b/examples/kube/pitr/run-sql.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-psql -h pitr -U postgres postgres -f $DIR/cmds.sql
+psql -h 172.30.98.6 -U postgres postgres -f $DIR/cmds.sql

--- a/examples/kube/postgres-gis/cleanup.sh
+++ b/examples/kube/postgres-gis/cleanup.sh
@@ -15,6 +15,6 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployments,pods,service -l name=postgres-gis
+cleanup "${CCP_NAMESPACE?}-postgres-gis"
 
 $CCPROOT/examples/waitforterm.sh postgres-gis ${CCP_CLI?}

--- a/examples/kube/postgres-gis/postgres-gis.json
+++ b/examples/kube/postgres-gis/postgres-gis.json
@@ -1,166 +1,166 @@
 {
-    "kind": "Service",
+   "kind": "Service",
+   "apiVersion": "v1",
+   "metadata": {
+       "name": "postgres-gis",
+       "labels": {
+           "name": "postgres-gis",
+           "cleanup": "$CCP_NAMESPACE-postgres-gis"
+       }
+   },
+   "spec": {
+       "ports": [
+           {
+               "protocol": "TCP",
+               "port": 5432,
+               "targetPort": 5432,
+               "nodePort": 0
+           }
+       ],
+       "selector": {
+           "name": "postgres-gis"
+       }
+   },
+   "status": {
+       "loadBalancer": {}
+   }
+}
+
+{
+    "kind": "Pod",
     "apiVersion": "v1",
     "metadata": {
         "name": "postgres-gis",
         "labels": {
-            "name": "postgres-gis"
+            "name": "postgres-gis",
+            "cleanup": "$CCP_NAMESPACE-postgres-gis"
         }
-    },
-    "spec": {
-        "ports": [{
-            "protocol": "TCP",
-            "port": 5432,
-            "targetPort": 5432,
-            "nodePort": 0
-        }],
-        "selector": {
-            "name": "postgres-gis"
-        }
-    },
-    "status": {
-        "loadBalancer": {}
-    }
-}
-
-{
-    "kind":"Pod",
-    "apiVersion":"v1",
-    "metadata":{
-      "name":"postgres-gis",
-      "labels":{
-         "name":"postgres-gis"
-      }
     },
     "spec": {
         "securityContext": {
-           $CCP_SECURITY_CONTEXT
-        	},
-      "containers":[
-         {
-            "name":"postgres-gis",
-            "image":"$CCP_IMAGE_PREFIX/crunchy-postgres-gis:$CCP_IMAGE_TAG",
-            "ports":[
-               {
-                  "containerPort":5432,
-                  "protocol":"TCP"
-               }
-            ],
-            "readinessProbe": {
-                "exec": {
-                    "command": [
-                        "/opt/cpm/bin/readiness.sh"
-                    ]
+            $CCP_SECURITY_CONTEXT
+        },
+        "containers": [
+            {
+                "name": "postgres-gis",
+                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres-gis:$CCP_IMAGE_TAG",
+                "ports": [
+                    {
+                        "containerPort": 5432,
+                        "protocol": "TCP"
+                    }
+                ],
+                "readinessProbe": {
+                    "exec": {
+                        "command": [
+                            "/opt/cpm/bin/readiness.sh"
+                        ]
+                    },
+                    "initialDelaySeconds": 40,
+                    "timeoutSeconds": 1
                 },
-                "initialDelaySeconds": 40,
-                "timeoutSeconds": 1
-            },
-            "livenessProbe": {
-                "exec": {
-                    "command": [
-                        "/opt/cpm/bin/liveness.sh"
-                    ]
+                "livenessProbe": {
+                    "exec": {
+                        "command": [
+                            "/opt/cpm/bin/liveness.sh"
+                        ]
+                    },
+                    "initialDelaySeconds": 40,
+                    "timeoutSeconds": 1
                 },
-                "initialDelaySeconds": 40,
-                "timeoutSeconds": 1
+                "env": [
+                    {
+                        "name": "VOLUME_NAME",
+                        "value": "/pgdata"
+                    },
+                    {
+                        "name": "TEMP_BUFFERS",
+                        "value": "9MB"
+                    },
+                    {
+                        "name": "PGHOST",
+                        "value": "/tmp"
+                    },
+                    {
+                        "name": "MAX_CONNECTIONS",
+                        "value": "101"
+                    },
+                    {
+                        "name": "SHARED_BUFFERS",
+                        "value": "128MB"
+                    },
+                    {
+                        "name": "MAX_WAL_SENDERS",
+                        "value": "7"
+                    },
+                    {
+                        "name": "WORK_MEM",
+                        "value": "5MB"
+                    },
+                    {
+                        "name": "PG_PRIMARY_USER",
+                        "value": "primaryuser"
+                    },
+                    {
+                        "name": "PG_PRIMARY_HOST",
+                        "value": "postgres-gis"
+                    },
+                    {
+                        "name": "PG_PRIMARY_PORT",
+                        "value": "5432"
+                    },
+                    {
+                        "name": "PG_PRIMARY_PASSWORD",
+                        "value": "password"
+                    },
+                    {
+                        "name": "PG_MODE",
+                        "value": "primary"
+                    },
+                    {
+                        "name": "PG_USER",
+                        "value": "testuser"
+                    },
+                    {
+                        "name": "PG_PASSWORD",
+                        "value": "password"
+                    },
+                    {
+                        "name": "PG_ROOT_PASSWORD",
+                        "value": "password"
+                    },
+                    {
+                        "name": "PG_DATABASE",
+                        "value": "userdb"
+                    },
+                    {
+                        "name": "CONTAINER_NAME",
+                        "value": "postgres-gis"
+                    }
+                ],
+                "volumeMounts": [
+                    {
+                        "mountPath": "/pgdata",
+                        "name": "pgdata",
+                        "readOnly": false
+                    },
+                    {
+                        "mountPath": "/backup",
+                        "name": "backup",
+                        "readOnly": true
+                    }
+                ]
+            }
+        ],
+        "volumes": [
+            {
+                "name": "pgdata",
+                "emptyDir": {}
             },
-            "env":[
-               {
-                  "name":"VOLUME_NAME",
-                  "value":"/pgdata"
-               },
-               {
-                  "name":"TEMP_BUFFERS",
-                  "value":"9MB"
-               },
-               {
-                  "name":"PGHOST",
-                  "value":"/tmp"
-               },
-               {
-                  "name":"MAX_CONNECTIONS",
-                  "value":"101"
-               },
-               {
-                  "name":"SHARED_BUFFERS",
-                  "value":"128MB"
-               },
-               {
-                  "name":"MAX_WAL_SENDERS",
-                  "value":"7"
-               },
-               {
-                  "name":"WORK_MEM",
-                  "value":"5MB"
-               },
-               {
-                  "name":"PG_PRIMARY_USER",
-                  "value":"primaryuser"
-               },
-               {
-                  "name":"PG_PRIMARY_HOST",
-                  "value":"postgres-gis"
-               },
-               {
-                  "name":"PG_PRIMARY_PORT",
-                  "value":"5432"
-               },
-               {
-                  "name":"PG_PRIMARY_PASSWORD",
-                  "value":"password"
-               },
-               {
-                  "name":"PG_MODE",
-                  "value":"primary"
-               },
-               {
-                  "name":"PG_USER",
-                  "value":"testuser"
-               },
-               {
-                  "name":"PG_PASSWORD",
-                  "value":"password"
-               },
-               {
-                  "name":"PG_ROOT_PASSWORD",
-                  "value":"password"
-               },
-               {
-                  "name":"PG_DATABASE",
-                  "value":"userdb"
-               },
-               {
-                  "name":"CONTAINER_NAME",
-                  "value":"postgres-gis"
-               }
-            ],
-            "volumeMounts":[
-               {
-                  "mountPath":"/pgdata",
-                  "name":"pgdata",
-                  "readOnly":false
-               },
-               {
-                  "mountPath":"/backup",
-                  "name":"backup",
-                  "readOnly":true
-               }
-            ]
-         }
-      ],
-      "volumes":[
-         {
-            "name":"pgdata",
-            "emptyDir":{
-
+            {
+                "name": "backup",
+                "emptyDir": {}
             }
-         },
-         {
-            "name":"backup",
-            "emptyDir":{
-
-            }
-         }
-      ]
+        ]
     }
 }

--- a/examples/kube/primary-deployment/cleanup.sh
+++ b/examples/kube/primary-deployment/cleanup.sh
@@ -15,18 +15,6 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment primary-deployment
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} statefulsets replica-deployment
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap primary-deployment-pgconf
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pgprimary-secret
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service primary-deployment replica-deployment
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc primary-deployment-pgdata replica-deployment-pgdata replica2-deployment-pgdata
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc -l name=replica-deployment
-
-if [ -z "$CCP_STORAGE_CLASS" ]
-then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-primary-deployment-pgdata \
-    $CCP_NAMESPACE-replica-deployment-pgdata $CCP_NAMESPACE-replica2-deployment-pgdata
-fi
+cleanup "${CCP_NAMESPACE?}-primary-deployment"
 
 dir_check_rm "primary-deployment"

--- a/examples/kube/primary-deployment/primary-deployment-pv-nfs.json
+++ b/examples/kube/primary-deployment/primary-deployment-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment",
             "server": "$CCP_NFS_IP"
@@ -26,14 +29,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-replica-deployment-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-replica-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-replica-deployment-pgdata",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment",
             "server": "$CCP_NFS_IP"
@@ -48,14 +54,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-replica2-deployment-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-replica2-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-replica2-deployment-pgdata",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/primary-deployment/primary-deployment-pv.json
+++ b/examples/kube/primary-deployment/primary-deployment-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment"
         },
@@ -25,14 +28,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-replica-deployment-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-replica-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-replica-deployment-pgdata",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment"
         },
@@ -46,14 +52,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-replica2-deployment-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-replica2-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-replica2-deployment-pgdata",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary-deployment"
         },

--- a/examples/kube/primary-deployment/primary-deployment-pvc-sc.json
+++ b/examples/kube/primary-deployment/primary-deployment-pvc-sc.json
@@ -2,17 +2,21 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "primary-deployment-pgdata"
+        "name": "primary-deployment-pgdata",
+        "labels": {
+            "name": "primary-deployment",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/primary-deployment/primary-deployment-pvc.json
+++ b/examples/kube/primary-deployment/primary-deployment-pvc.json
@@ -2,21 +2,25 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "primary-deployment-pgdata"
+        "name": "primary-deployment-pgdata",
+        "labels": {
+            "name": "primary-deployment",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
+        }
     },
     "spec": {
-      "selector": {
-        "matchLabels": {
-          "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
+        "selector": {
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
+            }
+        },
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      },
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
-      }
     }
 }

--- a/examples/kube/primary-deployment/primary-deployment.json
+++ b/examples/kube/primary-deployment/primary-deployment.json
@@ -1,9 +1,13 @@
 {
-    "apiVersion": "v1",
     "kind": "Secret",
+    "apiVersion": "v1",
     "type": "Opaque",
     "metadata": {
-        "name": "pgprimary-secret"
+        "name": "pgprimary-secret",
+        "labels": {
+            "name": "primary-deployment",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
+        }
     },
     "stringData": {
         "PG_USER": "testuser",
@@ -21,7 +25,8 @@
     "metadata": {
         "name": "primary-deployment",
         "labels": {
-            "name": "primary-deployment"
+            "name": "primary-deployment",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
         }
     },
     "spec": {
@@ -47,7 +52,8 @@
     "metadata": {
         "name": "primary-deployment",
         "labels": {
-            "name": "primary-deployment"
+            "name": "primary-deployment",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
         }
     },
     "spec": {
@@ -55,7 +61,8 @@
         "template": {
             "metadata": {
                 "labels": {
-                    "name": "primary-deployment"
+                    "name": "primary-deployment",
+                    "cleanup": "$CCP_NAMESPACE-primary-deployment"
                 }
             },
             "spec": {

--- a/examples/kube/primary-deployment/replica-statefulset-sc.json
+++ b/examples/kube/primary-deployment/replica-statefulset-sc.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "replica-deployment",
         "labels": {
-            "name": "replica-deployment"
+            "name": "replica-deployment",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
         }
     },
     "spec": {
@@ -29,7 +30,11 @@
     "apiVersion": "apps/v1beta1",
     "metadata": {
         "name": "replica-deployment",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "labels": {
+            "name": "replica-deployment",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
+        }
     },
     "spec": {
         "replicas": 1,
@@ -43,7 +48,8 @@
             "metadata": {
                 "creationTimestamp": null,
                 "labels": {
-                    "name": "replica-deployment"
+                    "name": "replica-deployment",
+                    "cleanup": "$CCP_NAMESPACE-primary-deployment"
                 }
             },
             "spec": {
@@ -180,7 +186,11 @@
         "volumeClaimTemplates": [
             {
                 "metadata": {
-                    "name": "pgdata"
+                    "name": "pgdata",
+                    "labels": {
+                        "name": "replica-deployment",
+                        "cleanup": "$CCP_NAMESPACE-primary-deployment"
+                    }
                 },
                 "spec": {
                     "accessModes": [

--- a/examples/kube/primary-deployment/replica-statefulset.json
+++ b/examples/kube/primary-deployment/replica-statefulset.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "replica-deployment",
         "labels": {
-            "name": "replica-deployment"
+            "name": "replica-deployment",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
         }
     },
     "spec": {
@@ -29,7 +30,11 @@
     "apiVersion": "apps/v1beta1",
     "metadata": {
         "name": "replica-deployment",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "labels": {
+            "name": "replica-deployment",
+            "cleanup": "$CCP_NAMESPACE-primary-deployment"
+        }
     },
     "spec": {
         "replicas": 1,
@@ -43,7 +48,8 @@
             "metadata": {
                 "creationTimestamp": null,
                 "labels": {
-                    "name": "replica-deployment"
+                    "name": "replica-deployment",
+                    "cleanup": "$CCP_NAMESPACE-primary-deployment"
                 }
             },
             "spec": {
@@ -179,7 +185,11 @@
         "volumeClaimTemplates": [
             {
                 "metadata": {
-                    "name": "pgdata"
+                    "name": "pgdata",
+                    "labels": {
+                        "name": "replica-deployment",
+                        "cleanup": "$CCP_NAMESPACE-primary-deployment"
+                    }
                 },
                 "spec": {
                     "accessModes": [

--- a/examples/kube/primary-deployment/run.sh
+++ b/examples/kube/primary-deployment/run.sh
@@ -30,6 +30,9 @@ ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} configmap primary-deployment-pg
   --from-file ${DIR?}/configs/pg_hba.conf \
   --from-file ${DIR?}/configs/setup.sql
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap \
+    primary-deployment-pgconf cleanup=${CCP_NAMESPACE?}-primary-deployment
+
 expenv -f $DIR/primary-deployment.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 
 if [[ ! -z ${CCP_STORAGE_CLASS} ]]

--- a/examples/kube/primary-replica-dc/cleanup.sh
+++ b/examples/kube/primary-replica-dc/cleanup.sh
@@ -15,8 +15,4 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} scale --replicas=0 deployment/replica-dc
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment replica-dc
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod primary-dc
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service primary-dc
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service replica-dc
+cleanup "${CCP_NAMESPACE?}-primary-replica-dc"

--- a/examples/kube/primary-replica-dc/primary-replica-dc.json
+++ b/examples/kube/primary-replica-dc/primary-replica-dc.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "primary-dc",
         "labels": {
-            "name": "primary-dc"
+            "name": "primary-dc",
+            "cleanup": "$CCP_NAMESPACE-primary-replica-dc"
         }
     },
     "spec": {
@@ -30,7 +31,8 @@
     "metadata": {
         "name": "replica-dc",
         "labels": {
-            "name": "replica-dc"
+            "name": "replica-dc",
+            "cleanup": "$CCP_NAMESPACE-primary-replica-dc"
         }
     },
     "spec": {
@@ -56,7 +58,8 @@
     "metadata": {
         "name": "primary-dc",
         "labels": {
-            "name": "primary-dc"
+            "name": "primary-dc",
+            "cleanup": "$CCP_NAMESPACE-primary-replica-dc"
         }
     },
     "spec": {
@@ -159,7 +162,8 @@
     "metadata": {
         "name": "replica-dc",
         "labels": {
-            "name": "replica-dc"
+            "name": "replica-dc",
+            "cleanup": "$CCP_NAMESPACE-primary-replica-dc"
         }
     },
     "spec": {
@@ -172,7 +176,8 @@
         "template": {
             "metadata": {
                 "labels": {
-                    "name": "replica-dc"
+                    "name": "replica-dc",
+                    "cleanup": "$CCP_NAMESPACE-primary-replica-dc"
                 }
             },
             "spec": {

--- a/examples/kube/primary-replica/cleanup.sh
+++ b/examples/kube/primary-replica/cleanup.sh
@@ -15,12 +15,8 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod pr-replica
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod pr-replica-2
-sleep  2
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service pr-replica
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service pr-primary
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod pr-primary
+cleanup "${CCP_NAMESPACE?}-primary-replica"
+
 $CCPROOT/examples/waitforterm.sh pr-primary ${CCP_CLI?}
 $CCPROOT/examples/waitforterm.sh pr-replica ${CCP_CLI?}
 $CCPROOT/examples/waitforterm.sh pr-replica-2 ${CCP_CLI?}

--- a/examples/kube/primary-replica/primary-replica.json
+++ b/examples/kube/primary-replica/primary-replica.json
@@ -4,16 +4,19 @@
     "metadata": {
         "name": "pr-primary",
         "labels": {
-            "name": "pr-primary"
+            "name": "pr-primary",
+            "cleanup": "$CCP_NAMESPACE-primary-replica"
         }
     },
     "spec": {
-        "ports": [{
-            "protocol": "TCP",
-            "port": 5432,
-            "targetPort": 5432,
-            "nodePort": 0
-        }],
+        "ports": [
+            {
+                "protocol": "TCP",
+                "port": 5432,
+                "targetPort": 5432,
+                "nodePort": 0
+            }
+        ],
         "selector": {
             "name": "pr-primary"
         },
@@ -28,16 +31,19 @@
     "metadata": {
         "name": "pr-replica",
         "labels": {
-            "name": "pr-replica"
+            "name": "pr-replica",
+            "cleanup": "$CCP_NAMESPACE-primary-replica"
         }
     },
     "spec": {
-        "ports": [{
-            "protocol": "TCP",
-            "port": 5432,
-            "targetPort": 5432,
-            "nodePort": 0
-        }],
+        "ports": [
+            {
+                "protocol": "TCP",
+                "port": 5432,
+                "targetPort": 5432,
+                "nodePort": 0
+            }
+        ],
         "selector": {
             "name": "pr-replica"
         },
@@ -46,88 +52,107 @@
     }
 }
 
-
 {
     "kind": "Pod",
     "apiVersion": "v1",
     "metadata": {
         "name": "pr-primary",
         "labels": {
-            "name": "pr-primary"
+            "name": "pr-primary",
+            "cleanup": "$CCP_NAMESPACE-primary-replica"
         }
     },
     "spec": {
-        "containers": [{
-            "name": "postgres",
-            "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
-            "readinessProbe": {
-                "exec": {
-                    "command": [
-                        "/opt/cpm/bin/readiness.sh"
-                    ]
+        "containers": [
+            {
+                "name": "postgres",
+                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                "readinessProbe": {
+                    "exec": {
+                        "command": [
+                            "/opt/cpm/bin/readiness.sh"
+                        ]
+                    },
+                    "initialDelaySeconds": 40,
+                    "timeoutSeconds": 1
                 },
-                "initialDelaySeconds": 40,
-                "timeoutSeconds": 1
-            },
-            "livenessProbe": {
-                "exec": {
-                    "command": [
-                        "/opt/cpm/bin/liveness.sh"
-                    ]
+                "livenessProbe": {
+                    "exec": {
+                        "command": [
+                            "/opt/cpm/bin/liveness.sh"
+                        ]
+                    },
+                    "initialDelaySeconds": 40,
+                    "timeoutSeconds": 1
                 },
-                "initialDelaySeconds": 40,
-                "timeoutSeconds": 1
-            },
-
-            "ports": [{
-                "containerPort": 5432,
-                "protocol": "TCP"
-            }],
-            "env": [{
-                "name": "PGHOST",
-                "value": "/tmp"
-            }, {
-                "name": "PG_PRIMARY_USER",
-                "value": "primaryuser"
-            }, {
-                "name": "PG_PRIMARY_PORT",
-                "value": "5432"
-            }, {
-                "name": "PG_MODE",
-                "value": "primary"
-            }, {
-                "name": "PG_PRIMARY_PASSWORD",
-                "value": "password"
-            }, {
-                "name": "PG_USER",
-                "value": "testuser"
-            }, {
-                "name": "PG_PASSWORD",
-                "value": "password"
-            }, {
-                "name": "PG_DATABASE",
-                "value": "userdb"
-            }, {
-                "name": "PG_ROOT_PASSWORD",
-                "value": "password"
-            }],
-            "volumeMounts": [{
-                "mountPath": "/pgdata",
+                "ports": [
+                    {
+                        "containerPort": 5432,
+                        "protocol": "TCP"
+                    }
+                ],
+                "env": [
+                    {
+                        "name": "PGHOST",
+                        "value": "/tmp"
+                    },
+                    {
+                        "name": "PG_PRIMARY_USER",
+                        "value": "primaryuser"
+                    },
+                    {
+                        "name": "PG_PRIMARY_PORT",
+                        "value": "5432"
+                    },
+                    {
+                        "name": "PG_MODE",
+                        "value": "primary"
+                    },
+                    {
+                        "name": "PG_PRIMARY_PASSWORD",
+                        "value": "password"
+                    },
+                    {
+                        "name": "PG_USER",
+                        "value": "testuser"
+                    },
+                    {
+                        "name": "PG_PASSWORD",
+                        "value": "password"
+                    },
+                    {
+                        "name": "PG_DATABASE",
+                        "value": "userdb"
+                    },
+                    {
+                        "name": "PG_ROOT_PASSWORD",
+                        "value": "password"
+                    }
+                ],
+                "volumeMounts": [
+                    {
+                        "mountPath": "/pgdata",
+                        "name": "pgdata",
+                        "readOnly": false
+                    },
+                    {
+                        "mountPath": "/backup",
+                        "name": "backup",
+                        "readOnly": true
+                    }
+                ]
+            }
+        ],
+        "volumes": [
+            {
                 "name": "pgdata",
-                "readOnly": false
-            }, {
-                "mountPath": "/backup",
+                "emptyDir": {}
+            },
+            {
                 "name": "backup",
-                "readOnly": true
-            }]
-        }],
-        "volumes": [{
-            "name": "pgdata",
-            "emptyDir": {}
-        }, {
-            "name": "backup",
-            "emptyDir": {}
-        }]
+                "emptyDir": {}
+            }
+        ]
     }
 }
 
@@ -138,84 +163,105 @@
         "name": "pr-replica",
         "labels": {
             "name": "pr-replica",
-            "replicatype": "trigger"
+            "replicatype": "trigger",
+            "cleanup": "$CCP_NAMESPACE-primary-replica"
         }
     },
     "spec": {
-        "containers": [{
-            "name": "postgres",
-            "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
-            "readinessProbe": {
-                "exec": {
-                    "command": [
-                        "/opt/cpm/bin/readiness.sh"
-                    ]
+        "containers": [
+            {
+                "name": "postgres",
+                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                "readinessProbe": {
+                    "exec": {
+                        "command": [
+                            "/opt/cpm/bin/readiness.sh"
+                        ]
+                    },
+                    "initialDelaySeconds": 70,
+                    "timeoutSeconds": 1
                 },
-                "initialDelaySeconds": 70,
-                "timeoutSeconds": 1
-            },
-            "livenessProbe": {
-                "exec": {
-                    "command": [
-                        "/opt/cpm/bin/liveness.sh"
-                    ]
+                "livenessProbe": {
+                    "exec": {
+                        "command": [
+                            "/opt/cpm/bin/liveness.sh"
+                        ]
+                    },
+                    "initialDelaySeconds": 70,
+                    "timeoutSeconds": 1
                 },
-                "initialDelaySeconds": 70,
-                "timeoutSeconds": 1
-            },
-
-            "ports": [{
-                "containerPort": 5432,
-                "protocol": "TCP"
-            }],
-            "env": [{
-                "name": "PGHOST",
-                "value": "/tmp"
-            }, {
-                "name": "PG_PRIMARY_HOST",
-                "value": "pr-primary"
-            }, {
-                "name": "PG_PRIMARY_USER",
-                "value": "primaryuser"
-            }, {
-                "name": "PG_PRIMARY_PORT",
-                "value": "5432"
-            }, {
-                "name": "PG_MODE",
-                "value": "replica"
-            }, {
-                "name": "PG_PRIMARY_PASSWORD",
-                "value": "password"
-            }, {
-                "name": "PG_USER",
-                "value": "testuser"
-            }, {
-                "name": "PG_PASSWORD",
-                "value": "password"
-            }, {
-                "name": "PG_DATABASE",
-                "value": "userdb"
-            }, {
-                "name": "PG_ROOT_PASSWORD",
-                "value": "password"
-            }],
-            "volumeMounts": [{
-                "mountPath": "/pgdata",
+                "ports": [
+                    {
+                        "containerPort": 5432,
+                        "protocol": "TCP"
+                    }
+                ],
+                "env": [
+                    {
+                        "name": "PGHOST",
+                        "value": "/tmp"
+                    },
+                    {
+                        "name": "PG_PRIMARY_HOST",
+                        "value": "pr-primary"
+                    },
+                    {
+                        "name": "PG_PRIMARY_USER",
+                        "value": "primaryuser"
+                    },
+                    {
+                        "name": "PG_PRIMARY_PORT",
+                        "value": "5432"
+                    },
+                    {
+                        "name": "PG_MODE",
+                        "value": "replica"
+                    },
+                    {
+                        "name": "PG_PRIMARY_PASSWORD",
+                        "value": "password"
+                    },
+                    {
+                        "name": "PG_USER",
+                        "value": "testuser"
+                    },
+                    {
+                        "name": "PG_PASSWORD",
+                        "value": "password"
+                    },
+                    {
+                        "name": "PG_DATABASE",
+                        "value": "userdb"
+                    },
+                    {
+                        "name": "PG_ROOT_PASSWORD",
+                        "value": "password"
+                    }
+                ],
+                "volumeMounts": [
+                    {
+                        "mountPath": "/pgdata",
+                        "name": "pgdata",
+                        "readOnly": false
+                    },
+                    {
+                        "mountPath": "/backup",
+                        "name": "backup",
+                        "readOnly": true
+                    }
+                ]
+            }
+        ],
+        "volumes": [
+            {
                 "name": "pgdata",
-                "readOnly": false
-            }, {
-                "mountPath": "/backup",
+                "emptyDir": {}
+            },
+            {
                 "name": "backup",
-                "readOnly": true
-            }]
-        }],
-        "volumes": [{
-            "name": "pgdata",
-            "emptyDir": {}
-        }, {
-            "name": "backup",
-            "emptyDir": {}
-        }]
+                "emptyDir": {}
+            }
+        ]
     }
 }
 
@@ -226,83 +272,104 @@
         "name": "pr-replica-2",
         "labels": {
             "name": "pr-replica",
-            "replicatype": "trigger"
+            "replicatype": "trigger",
+            "cleanup": "$CCP_NAMESPACE-primary-replica"
         }
     },
     "spec": {
-        "containers": [{
-            "name": "postgres",
-            "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
-            "readinessProbe": {
-                "exec": {
-                    "command": [
-                        "/opt/cpm/bin/readiness.sh"
-                    ]
+        "containers": [
+            {
+                "name": "postgres",
+                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                "readinessProbe": {
+                    "exec": {
+                        "command": [
+                            "/opt/cpm/bin/readiness.sh"
+                        ]
+                    },
+                    "initialDelaySeconds": 50,
+                    "timeoutSeconds": 1
                 },
-                "initialDelaySeconds": 50,
-                "timeoutSeconds": 1
-            },
-            "livenessProbe": {
-                "exec": {
-                    "command": [
-                        "/opt/cpm/bin/liveness.sh"
-                    ]
+                "livenessProbe": {
+                    "exec": {
+                        "command": [
+                            "/opt/cpm/bin/liveness.sh"
+                        ]
+                    },
+                    "initialDelaySeconds": 50,
+                    "timeoutSeconds": 1
                 },
-                "initialDelaySeconds": 50,
-                "timeoutSeconds": 1
-            },
-
-            "ports": [{
-                "containerPort": 5432,
-                "protocol": "TCP"
-            }],
-            "env": [{
-                "name": "PGHOST",
-                "value": "/tmp"
-            }, {
-                "name": "PG_PRIMARY_HOST",
-                "value": "pr-primary"
-            }, {
-                "name": "PG_PRIMARY_USER",
-                "value": "primaryuser"
-            }, {
-                "name": "PG_PRIMARY_PORT",
-                "value": "5432"
-            }, {
-                "name": "PG_MODE",
-                "value": "replica"
-            }, {
-                "name": "PG_PRIMARY_PASSWORD",
-                "value": "password"
-            }, {
-                "name": "PG_USER",
-                "value": "testuser"
-            }, {
-                "name": "PG_PASSWORD",
-                "value": "password"
-            }, {
-                "name": "PG_DATABASE",
-                "value": "userdb"
-            }, {
-                "name": "PG_ROOT_PASSWORD",
-                "value": "password"
-            }],
-            "volumeMounts": [{
-                "mountPath": "/pgdata",
+                "ports": [
+                    {
+                        "containerPort": 5432,
+                        "protocol": "TCP"
+                    }
+                ],
+                "env": [
+                    {
+                        "name": "PGHOST",
+                        "value": "/tmp"
+                    },
+                    {
+                        "name": "PG_PRIMARY_HOST",
+                        "value": "pr-primary"
+                    },
+                    {
+                        "name": "PG_PRIMARY_USER",
+                        "value": "primaryuser"
+                    },
+                    {
+                        "name": "PG_PRIMARY_PORT",
+                        "value": "5432"
+                    },
+                    {
+                        "name": "PG_MODE",
+                        "value": "replica"
+                    },
+                    {
+                        "name": "PG_PRIMARY_PASSWORD",
+                        "value": "password"
+                    },
+                    {
+                        "name": "PG_USER",
+                        "value": "testuser"
+                    },
+                    {
+                        "name": "PG_PASSWORD",
+                        "value": "password"
+                    },
+                    {
+                        "name": "PG_DATABASE",
+                        "value": "userdb"
+                    },
+                    {
+                        "name": "PG_ROOT_PASSWORD",
+                        "value": "password"
+                    }
+                ],
+                "volumeMounts": [
+                    {
+                        "mountPath": "/pgdata",
+                        "name": "pgdata",
+                        "readOnly": false
+                    },
+                    {
+                        "mountPath": "/backup",
+                        "name": "backup",
+                        "readOnly": true
+                    }
+                ]
+            }
+        ],
+        "volumes": [
+            {
                 "name": "pgdata",
-                "readOnly": false
-            }, {
-                "mountPath": "/backup",
+                "emptyDir": {}
+            },
+            {
                 "name": "backup",
-                "readOnly": true
-            }]
-        }],
-        "volumes": [{
-            "name": "pgdata",
-            "emptyDir": {}
-        }, {
-            "name": "backup",
-            "emptyDir": {}
-        }]
+                "emptyDir": {}
+            }
+        ]
     }
 }

--- a/examples/kube/primary/cleanup.sh
+++ b/examples/kube/primary/cleanup.sh
@@ -15,13 +15,7 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service primary
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod primary
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc primary-pgdata
-
-if [ -z "$CCP_STORAGE_CLASS" ]; then
-    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-primary-pgdata
-fi
+cleanup "${CCP_NAMESPACE?}-primary"
 
 $CCPROOT/examples/waitforterm.sh primary ${CCP_CLI?}
 

--- a/examples/kube/primary/primary-pv-nfs.json
+++ b/examples/kube/primary/primary-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-primary-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-primary-pgdata"
+            "name": "$CCP_NAMESPACE-primary-pgdata",
+            "cleanup": "$CCP_NAMESPACE-primary"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/primary/primary-pv.json
+++ b/examples/kube/primary/primary-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-primary-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-primary-pgdata"
+            "name": "$CCP_NAMESPACE-primary-pgdata",
+            "cleanup": "$CCP_NAMESPACE-primary"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-primary"
         },

--- a/examples/kube/primary/primary-pvc-sc.json
+++ b/examples/kube/primary/primary-pvc-sc.json
@@ -2,18 +2,20 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "primary-pgdata"
+        "name": "primary-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-primary"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }
-

--- a/examples/kube/primary/primary-pvc.json
+++ b/examples/kube/primary/primary-pvc.json
@@ -2,21 +2,24 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "primary-pgdata"
+        "name": "primary-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-primary"
+        }
     },
     "spec": {
-      "selector": {
-        "matchLabels": {
-          "name": "$CCP_NAMESPACE-primary-pgdata"
+        "selector": {
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-primary-pgdata"
+            }
+        },
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      },
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
-      }
     }
 }

--- a/examples/kube/primary/primary.json
+++ b/examples/kube/primary/primary.json
@@ -1,25 +1,27 @@
 {
-        "kind": "Service",
-        "apiVersion": "v1",
-        "metadata": {
-            "name": "primary",
-            "labels": {
-                "name": "primary"
-            }
-        },
-        "spec": {
-            "ports": [{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "primary",
+        "labels": {
+            "name": "primary"
+        }
+    },
+    "spec": {
+        "ports": [
+            {
                 "protocol": "TCP",
                 "port": 5432,
                 "targetPort": 5432,
                 "nodePort": 0
-            }],
-            "selector": {
-                "name": "primary"
-            },
-            "type": "ClusterIP",
-            "sessionAffinity": "None"
-        }
+            }
+        ],
+        "selector": {
+            "name": "primary"
+        },
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+    }
 }
 
 {
@@ -29,7 +31,8 @@
         "name": "primary",
         "namespace": "$CCP_NAMESPACE",
         "labels": {
-            "name": "primary"
+            "name": "primary",
+            "cleanup": "$CCP_NAMESPACE-primary"
         }
     },
     "spec": {

--- a/examples/kube/restore/cleanup.sh
+++ b/examples/kube/restore/cleanup.sh
@@ -15,13 +15,7 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod restore
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service restore
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc restore-pgdata
-
-if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-restore-pgdata
-fi
+cleanup "${CCP_NAMESPACE?}-restore"
 
 $CCPROOT/examples/waitforterm.sh restore ${CCP_CLI?}
 

--- a/examples/kube/restore/restore-pv-nfs.json
+++ b/examples/kube/restore/restore-pv-nfs.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-restore-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-restore-pgdata"
+            "name": "$CCP_NAMESPACE-restore-pgdata",
+            "cleanup": "$CCP_NAMESPACE-restore"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "nfs": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-restore",
             "server": "$CCP_NFS_IP"

--- a/examples/kube/restore/restore-pv.json
+++ b/examples/kube/restore/restore-pv.json
@@ -4,14 +4,17 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-restore-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-restore-pgdata"
+            "name": "$CCP_NAMESPACE-restore-pgdata",
+            "cleanup": "$CCP_NAMESPACE-restore"
         }
     },
     "spec": {
         "capacity": {
             "storage": "$CCP_STORAGE_CAPACITY"
         },
-        "accessModes": ["$CCP_STORAGE_MODE"],
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
         "hostPath": {
             "path": "$CCP_STORAGE_PATH/$CCP_NAMESPACE-restore"
         },

--- a/examples/kube/restore/restore-pvc-sc.json
+++ b/examples/kube/restore/restore-pvc-sc.json
@@ -2,17 +2,21 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "restore-pgdata"
+        "name": "restore-pgdata",
+        "labels": {
+            "name": "restore",
+            "cleanup": "$CCP_NAMESPACE-restore"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/restore/restore-pvc.json
+++ b/examples/kube/restore/restore-pvc.json
@@ -2,13 +2,17 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-        "name": "restore-pgdata"
+        "name": "restore-pgdata",
+        "labels": {
+            "name": "restore",
+            "cleanup": "$CCP_NAMESPACE-restore"
+        }
     },
     "spec": {
         "selector": {
-          "matchLabels": {
-            "name": "$CCP_NAMESPACE-restore-pgdata"
-          }
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-restore-pgdata"
+            }
         },
         "accessModes": [
             "$CCP_STORAGE_MODE"

--- a/examples/kube/restore/restore.json
+++ b/examples/kube/restore/restore.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "restore",
         "labels": {
-            "name": "restore"
+            "name": "restore",
+            "cleanup": "$CCP_NAMESPACE-restore"
         }
     },
     "spec": {
@@ -30,7 +31,8 @@
     "metadata": {
         "name": "restore",
         "labels": {
-            "name": "restore"
+            "name": "restore",
+            "cleanup": "$CCP_NAMESPACE-restore"
         }
     },
     "spec": {

--- a/examples/kube/scheduler/add-schedules.sh
+++ b/examples/kube/scheduler/add-schedules.sh
@@ -15,6 +15,6 @@ ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} configmap backrest-schedule-dif
 ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} configmap pgbasebackup-backup \
     --from-file=/tmp/schedule-pgbasebackup.json
 
-${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap backrest-schedule-full crunchy-scheduler=true
-${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap backrest-schedule-diff crunchy-scheduler=true
-${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap pgbasebackup-backup crunchy-scheduler=true
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap backrest-schedule-full crunchy-scheduler=true cleanup=${CCP_NAMESPACE?}-scheduler
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap backrest-schedule-diff crunchy-scheduler=true cleanup=${CCP_NAMESPACE?}-scheduler
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap pgbasebackup-backup crunchy-scheduler=true cleanup=${CCP_NAMESPACE?}-scheduler

--- a/examples/kube/scheduler/cleanup.sh
+++ b/examples/kube/scheduler/cleanup.sh
@@ -15,12 +15,7 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap -l crunchy-scheduler=true
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap scheduler-backup-template
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job primary-backup-pgbasebackup
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod scheduler
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret primary-primaryuser-secret
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} clusterrolebinding,clusterrole,sa,rolebinding scheduler-sa scheduler-sa-edit
+cleanup "${CCP_NAMESPACE?}-scheduler"
 
 $CCPROOT/examples/waitforterm.sh scheduler ${CCP_CLI?}
 

--- a/examples/kube/scheduler/primary/cleanup.sh
+++ b/examples/kube/scheduler/primary/cleanup.sh
@@ -15,17 +15,6 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment primary-deployment
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} configmap primary-deployment-pgconf
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pgprimary-secret
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service primary-deployment
-
-# primary-deployment-backup is used for basebackup schedules - don't delete
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc primary-deployment-pgdata primary-deployment-br primary-deployment-backup
-
-if [ -z "$CCP_STORAGE_CLASS" ]
-then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-primary-deployment-pgdata $CCP_NAMESPACE-primary-deployment-br $CCP_NAMESPACE-primary-deployment-backup
-fi
+cleanup "${CCP_NAMESPACE?}-primary-scheduler"
 
 dir_check_rm "primary-deployment"

--- a/examples/kube/scheduler/primary/primary-deployment-pv-nfs.json
+++ b/examples/kube/scheduler/primary/primary-deployment-pv-nfs.json
@@ -4,7 +4,9 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
+            "cleanup": "$CCP_NAMESPACE-primary-scheduler"
+
         }
     },
     "spec": {
@@ -26,7 +28,8 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-primary-deployment-br",
         "labels": {
-            "name": "$CCP_NAMESPACE-primary-deployment-br"
+            "name": "$CCP_NAMESPACE-primary-deployment-br",
+            "cleanup": "$CCP_NAMESPACE-primary-scheduler"
         }
     },
     "spec": {
@@ -48,7 +51,8 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-primary-deployment-backup",
         "labels": {
-            "name": "$CCP_NAMESPACE-primary-deployment-backup"
+            "name": "$CCP_NAMESPACE-primary-deployment-backup",
+            "cleanup": "$CCP_NAMESPACE-primary-scheduler"
         }
     },
     "spec": {

--- a/examples/kube/scheduler/primary/primary-deployment-pv.json
+++ b/examples/kube/scheduler/primary/primary-deployment-pv.json
@@ -4,7 +4,9 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
+            "name": "$CCP_NAMESPACE-primary-deployment-pgdata",
+            "cleanup": "$CCP_NAMESPACE-primary-scheduler"
+
         }
     },
     "spec": {
@@ -25,7 +27,8 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-primary-deployment-br",
         "labels": {
-            "name": "$CCP_NAMESPACE-primary-deployment-br"
+            "name": "$CCP_NAMESPACE-primary-deployment-br",
+            "cleanup": "$CCP_NAMESPACE-primary-scheduler"
         }
     },
     "spec": {
@@ -46,7 +49,8 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-primary-deployment-backup",
         "labels": {
-            "name": "$CCP_NAMESPACE-primary-deployment-backup"
+            "name": "$CCP_NAMESPACE-primary-deployment-backup",
+            "cleanup": "$CCP_NAMESPACE-primary-scheduler"
         }
     },
     "spec": {

--- a/examples/kube/scheduler/primary/primary-deployment-pvc-sc.json
+++ b/examples/kube/scheduler/primary/primary-deployment-pvc-sc.json
@@ -2,18 +2,21 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "primary-deployment-pgdata"
+        "name": "primary-deployment-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-primary-scheduler"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }
 
@@ -21,18 +24,21 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "primary-deployment-br"
+        "name": "primary-deployment-br",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-primary-scheduler"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }
 
@@ -40,17 +46,20 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "primary-deployment-backup"
+        "name": "primary-deployment-backup",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-primary-scheduler"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/scheduler/primary/primary-deployment-pvc.json
+++ b/examples/kube/scheduler/primary/primary-deployment-pvc.json
@@ -2,22 +2,25 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "primary-deployment-pgdata"
+        "name": "primary-deployment-pgdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-primary-scheduler"
+        }
     },
     "spec": {
-      "selector": {
-        "matchLabels": {
-          "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
+        "selector": {
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-primary-deployment-pgdata"
+            }
+        },
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      },
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
-      }
     }
 }
 
@@ -25,22 +28,25 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "primary-deployment-br"
+        "name": "primary-deployment-br",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-primary-scheduler"
+        }
     },
     "spec": {
-      "selector": {
-        "matchLabels": {
-          "name": "$CCP_NAMESPACE-primary-deployment-br"
+        "selector": {
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-primary-deployment-br"
+            }
+        },
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      },
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
-      }
     }
 }
 
@@ -48,21 +54,24 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "primary-deployment-backup"
+        "name": "primary-deployment-backup",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-primary-scheduler"
+        }
     },
     "spec": {
-      "selector": {
-        "matchLabels": {
-          "name": "$CCP_NAMESPACE-primary-deployment-backup"
+        "selector": {
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-primary-deployment-backup"
+            }
+        },
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      },
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
-      }
     }
 }

--- a/examples/kube/scheduler/primary/primary-deployment.json
+++ b/examples/kube/scheduler/primary/primary-deployment.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "primary-deployment",
         "labels": {
-            "name": "primary-deployment"
+            "name": "primary-deployment",
+            "cleanup": "$CCP_NAMESPACE-primary-scheduler"
         }
     },
     "spec": {
@@ -30,7 +31,8 @@
     "metadata": {
         "name": "primary-deployment",
         "labels": {
-            "name": "primary-deployment"
+            "name": "primary-deployment",
+            "cleanup": "$CCP_NAMESPACE-primary-scheduler"
         }
     },
     "spec": {
@@ -38,7 +40,8 @@
         "template": {
             "metadata": {
                 "labels": {
-                    "name": "primary-deployment"
+                    "name": "primary-deployment",
+                    "cleanup": "$CCP_NAMESPACE-primary-scheduler"
                 }
             },
             "spec": {

--- a/examples/kube/scheduler/primary/run.sh
+++ b/examples/kube/scheduler/primary/run.sh
@@ -28,8 +28,14 @@ fi
 ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} configmap primary-deployment-pgconf \
   --from-file ${DIR?}/configs/pgbackrest.conf
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap \
+    primary-deployment-pgconf cleanup=${CCP_NAMESPACE?}-primary-scheduler
+
 ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} secret generic pgprimary-secret \
     --from-literal=username='primaryuser' \
     --from-literal=password='password'
+
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} secret \
+    pgprimary-secret cleanup=${CCP_NAMESPACE?}-primary-scheduler
 
 expenv -f $DIR/primary-deployment.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/scheduler/run.sh
+++ b/examples/kube/scheduler/run.sh
@@ -23,5 +23,8 @@ expenv -f $DIR/configs/backup-template.json > /tmp/backup-template.json
 ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} configmap scheduler-backup-template \
     --from-file /tmp/backup-template.json
 
+${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap \
+    scheduler-backup-template cleanup=${CCP_NAMESPACE?}-scheduler
+
 expenv -f $DIR/scheduler-sa.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 expenv -f $DIR/scheduler.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/scheduler/scheduler-sa.json
+++ b/examples/kube/scheduler/scheduler-sa.json
@@ -3,7 +3,11 @@
     "kind": "ClusterRole",
     "metadata": {
         "name": "scheduler-sa",
-        "namespace": "$CCP_NAMESPACE"
+        "namespace": "$CCP_NAMESPACE",
+        "labels": {
+            "name": "scheduler",
+            "cleanup": "$CCP_NAMESPACE-scheduler"
+        }
     },
     "rules": [
         {
@@ -84,7 +88,11 @@
     "kind": "ServiceAccount",
     "metadata": {
         "name": "scheduler-sa",
-        "namespace": "$CCP_NAMESPACE"
+        "namespace": "$CCP_NAMESPACE",
+        "labels": {
+            "name": "scheduler",
+            "cleanup": "$CCP_NAMESPACE-scheduler"
+        }
     }
 }
 
@@ -92,7 +100,11 @@
     "apiVersion": "rbac.authorization.k8s.io/v1beta1",
     "kind": "ClusterRoleBinding",
     "metadata": {
-        "name": "scheduler-sa"
+        "name": "scheduler-sa",
+        "labels": {
+            "name": "scheduler",
+            "cleanup": "$CCP_NAMESPACE-scheduler"
+        }
     },
     "roleRef": {
         "apiGroup": "rbac.authorization.k8s.io",

--- a/examples/kube/scheduler/scheduler.json
+++ b/examples/kube/scheduler/scheduler.json
@@ -5,7 +5,8 @@
         "name": "scheduler",
         "namespace": "$CCP_NAMESPACE",
         "labels": {
-            "name": "scheduler"
+            "name": "scheduler",
+            "cleanup": "$CCP_NAMESPACE-scheduler"
         }
     },
     "spec": {

--- a/examples/kube/secret/cleanup.sh
+++ b/examples/kube/secret/cleanup.sh
@@ -15,6 +15,4 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} secret pguser-secret pgprimary-secret pgroot-secret
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod secret
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service secret
+cleanup "${CCP_NAMESPACE?}-secret"

--- a/examples/kube/secret/secret.json
+++ b/examples/kube/secret/secret.json
@@ -2,8 +2,11 @@
     "apiVersion": "v1",
     "kind": "Secret",
     "metadata": {
-    	"name": "pgprimary-secret"
-	},
+    	"name": "pgprimary-secret",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-secret"
+        }
+    },
     "data": {
         "username": "cHJpbWFyeXVzZXI=",
         "password": "cGFzc3dvcmQ="
@@ -14,8 +17,11 @@
     "apiVersion": "v1",
     "kind": "Secret",
     "metadata": {
-    	"name": "pgroot-secret"
-	},
+        "name": "pgroot-secret",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-secret"
+        }
+    },
     "data": {
         "username": "cG9zdGdyZXM=",
         "password": "cGFzc3dvcmQ="
@@ -26,8 +32,11 @@
     "apiVersion": "v1",
     "kind": "Secret",
     "metadata": {
-    	"name": "pguser-secret"
-	},
+    	"name": "pguser-secret",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-secret"
+        }
+    },
     "data": {
         "username": "cGd1c2VyMQ==",
         "password": "cGFzc3dvcmQ="
@@ -40,7 +49,8 @@
     "metadata": {
         "name": "secret",
         "labels": {
-            "name": "secret"
+            "name": "secret",
+            "cleanup": "$CCP_NAMESPACE-secret"
         }
     },
     "spec": {
@@ -69,7 +79,8 @@
     "metadata": {
         "name": "secret",
         "labels": {
-            "name": "secret"
+            "name": "secret",
+            "cleanup": "$CCP_NAMESPACE-secret"
         }
     },
     "spec": {

--- a/examples/kube/statefulset/cleanup.sh
+++ b/examples/kube/statefulset/cleanup.sh
@@ -15,15 +15,6 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} statefulset statefulset
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} sa,role,rolebindings statefulset-sa
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc -l 'app=statefulset'
-
-if [[ -z "$CCP_STORAGE_CLASS" ]]
-then
-    ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv -l "name=$CCP_NAMESPACE-statefulset-pgdata"
-fi
-
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service statefulset-primary statefulset-replica
+cleanup "${CCP_NAMESPACE?}-statefulset"
 
 dir_check_rm "statefulset"

--- a/examples/kube/statefulset/statefulset-pv-nfs.json
+++ b/examples/kube/statefulset/statefulset-pv-nfs.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-statefulset-pgdata-0",
         "labels": {
-            "name": "$CCP_NAMESPACE-statefulset-pgdata"
+            "name": "$CCP_NAMESPACE-statefulset-pgdata",
+            "cleanup": "$CCP_NAMESPACE-statefulset"
         }
     },
     "spec": {
@@ -26,7 +27,8 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-statefulset-pgdata-1",
         "labels": {
-            "name": "$CCP_NAMESPACE-statefulset-pgdata"
+            "name": "$CCP_NAMESPACE-statefulset-pgdata",
+            "cleanup": "$CCP_NAMESPACE-statefulset"
         }
     },
     "spec": {
@@ -48,7 +50,8 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-statefulset-pgdata-2",
         "labels": {
-            "name": "$CCP_NAMESPACE-statefulset-pgdata"
+            "name": "$CCP_NAMESPACE-statefulset-pgdata",
+            "cleanup": "$CCP_NAMESPACE-statefulset"
         }
     },
     "spec": {

--- a/examples/kube/statefulset/statefulset-pv.json
+++ b/examples/kube/statefulset/statefulset-pv.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "statefulset-pgdata-0",
         "labels": {
-            "name": "$CCP_NAMESPACE-statefulset-pgdata"
+            "name": "$CCP_NAMESPACE-statefulset-pgdata",
+            "cleanup": "$CCP_NAMESPACE-statefulset"
         }
     },
     "spec": {
@@ -25,7 +26,8 @@
     "metadata": {
         "name": "statefulset-pgdata-1",
         "labels": {
-            "name": "$CCP_NAMESPACE-statefulset-pgdata"
+            "name": "$CCP_NAMESPACE-statefulset-pgdata",
+            "cleanup": "$CCP_NAMESPACE-statefulset"
         }
     },
     "spec": {
@@ -46,7 +48,8 @@
     "metadata": {
         "name": "statefulset-pgdata-2",
         "labels": {
-            "name": "$CCP_NAMESPACE-statefulset-pgdata"
+            "name": "$CCP_NAMESPACE-statefulset-pgdata",
+            "cleanup": "$CCP_NAMESPACE-statefulset"
         }
     },
     "spec": {
@@ -60,4 +63,3 @@
         "persistentVolumeReclaimPolicy": "Retain"
     }
 }
-

--- a/examples/kube/statefulset/statefulset-sa.json
+++ b/examples/kube/statefulset/statefulset-sa.json
@@ -3,7 +3,10 @@
     "kind": "Role",
     "metadata": {
         "name": "statefulset-sa",
-        "namespace": "$CCP_NAMESPACE"
+        "namespace": "$CCP_NAMESPACE",
+	"labels": {
+            "cleanup": "$CCP_NAMESPACE-statefulset"
+	}
     },
     "rules": [
         {
@@ -27,7 +30,10 @@
     "kind": "ServiceAccount",
     "metadata": {
         "name": "statefulset-sa",
-        "namespace": "$CCP_NAMESPACE"
+        "namespace": "$CCP_NAMESPACE",
+	"labels": {
+            "cleanup": "$CCP_NAMESPACE-statefulset"
+	}
     }
 }
 
@@ -35,7 +41,10 @@
     "apiVersion": "rbac.authorization.k8s.io/v1beta1",
     "kind": "RoleBinding",
     "metadata": {
-        "name": "statefulset-sa"
+        "name": "statefulset-sa",
+	"labels": {
+            "cleanup": "$CCP_NAMESPACE-statefulset"
+	}
     },
     "roleRef": {
         "apiGroup": "rbac.authorization.k8s.io",

--- a/examples/kube/statefulset/statefulset-sc.json
+++ b/examples/kube/statefulset/statefulset-sc.json
@@ -2,7 +2,11 @@
     "apiVersion": "apps/v1beta1",
     "kind": "StatefulSet",
     "metadata": {
-        "name": "statefulset"
+        "name": "statefulset",
+        "labels": {
+            "app": "statefulset",
+            "cleanup": "$CCP_NAMESPACE-statefulset"
+        }
     },
     "spec": {
         "serviceName": "statefulset",
@@ -10,7 +14,8 @@
         "template": {
             "metadata": {
                 "labels": {
-                    "app": "statefulset"
+                    "app": "statefulset",
+                    "cleanup": "$CCP_NAMESPACE-statefulset"
                 }
             },
             "spec": {
@@ -114,7 +119,11 @@
         "volumeClaimTemplates": [
             {
                 "metadata": {
-                    "name": "pgdata"
+                    "name": "pgdata",
+                    "labels": {
+                        "app": "statefulset",
+                        "cleanup": "$CCP_NAMESPACE-statefulset"
+                    }
                 },
                 "spec": {
                     "accessModes": [

--- a/examples/kube/statefulset/statefulset-services.json
+++ b/examples/kube/statefulset/statefulset-services.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "statefulset-primary",
         "labels": {
-            "name": "statefulset-primary"
+            "name": "statefulset-primary",
+            "cleanup": "$CCP_NAMESPACE-statefulset"
         }
     },
     "spec": {
@@ -30,7 +31,8 @@
     "metadata": {
         "name": "statefulset-replica",
         "labels": {
-            "name": "statefulset-replica"
+            "name": "statefulset-replica",
+            "cleanup": "$CCP_NAMESPACE-statefulset"
         }
     },
     "spec": {

--- a/examples/kube/statefulset/statefulset.json
+++ b/examples/kube/statefulset/statefulset.json
@@ -2,7 +2,11 @@
     "apiVersion": "apps/v1beta1",
     "kind": "StatefulSet",
     "metadata": {
-        "name": "statefulset"
+        "name": "statefulset",
+        "labels": {
+            "app": "statefulset",
+            "cleanup": "$CCP_NAMESPACE-statefulset"
+        }
     },
     "spec": {
         "serviceName": "statefulset",
@@ -10,13 +14,15 @@
         "template": {
             "metadata": {
                 "labels": {
-                    "app": "statefulset"
+                    "app": "statefulset",
+                    "cleanup": "$CCP_NAMESPACE-statefulset"
                 }
             },
             "spec": {
                 "serviceAccount": "statefulset-sa",
                 "securityContext": {
                     $CCP_SECURITY_CONTEXT
+
                 },
                 "containers": [
                     {
@@ -114,7 +120,11 @@
         "volumeClaimTemplates": [
             {
                 "metadata": {
-                    "name": "pgdata"
+                    "name": "pgdata",
+                    "labels": {
+                        "app": "statefulset",
+                        "cleanup": "$CCP_NAMESPACE-statefulset"
+                    }
                 },
                 "spec": {
                     "accessModes": [

--- a/examples/kube/sync/cleanup.sh
+++ b/examples/kube/sync/cleanup.sh
@@ -15,9 +15,7 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod replicasync replicaasync
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod primarysync
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service primarysync
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service replicasync
+cleanup "${CCP_NAMESPACE?}-sync"
+
 $CCPROOT/examples/waitforterm.sh primarysync ${CCP_CLI?}
 $CCPROOT/examples/waitforterm.sh replicasync ${CCP_CLI?}

--- a/examples/kube/sync/sync.json
+++ b/examples/kube/sync/sync.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "primarysync",
         "labels": {
-            "name": "primarysync"
+            "name": "primarysync",
+            "cleanup": "$CCP_NAMESPACE-sync"
         }
     },
     "spec": {
@@ -30,7 +31,8 @@
     "metadata": {
         "name": "replicasync",
         "labels": {
-            "name": "replicasync"
+            "name": "replicasync",
+            "cleanup": "$CCP_NAMESPACE-sync"
         }
     },
     "spec": {
@@ -56,7 +58,8 @@
     "metadata": {
         "name": "primarysync",
         "labels": {
-            "name": "primarysync"
+            "name": "primarysync",
+            "cleanup": "$CCP_NAMESPACE-sync"
         }
     },
     "spec": {
@@ -163,7 +166,8 @@
     "metadata": {
         "name": "replicasync",
         "labels": {
-            "name": "replicasync"
+            "name": "replicasync",
+            "cleanup": "$CCP_NAMESPACE-sync"
         }
     },
     "spec": {
@@ -274,7 +278,8 @@
     "metadata": {
         "name": "replicaasync",
         "labels": {
-            "name": "replicasync"
+            "name": "replicasync",
+            "cleanup": "$CCP_NAMESPACE-sync"
         }
     },
     "spec": {

--- a/examples/kube/upgrade/cleanup.sh
+++ b/examples/kube/upgrade/cleanup.sh
@@ -15,12 +15,6 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} service primary primary-upgrade
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod primary primary-upgrade
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job upgrade
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pvc upgrade-pgnewdata
-if [ -z "$CCP_STORAGE_CLASS" ]; then
-  ${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pv $CCP_NAMESPACE-upgrade-pgnewdata
-fi
+cleanup "${CCP_NAMESPACE?}-upgrade"
 
 dir_check_rm "upgrade"

--- a/examples/kube/upgrade/primary-upgraded.json
+++ b/examples/kube/upgrade/primary-upgraded.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "primary-upgrade",
         "labels": {
-            "name": "primary-upgrade"
+            "name": "primary-upgrade",
+            "cleanup": "$CCP_NAMESPACE-upgrade"
         }
     },
     "spec": {
@@ -30,7 +31,8 @@
     "metadata": {
         "name": "primary-upgrade",
         "labels": {
-            "name": "primary-upgrade"
+            "name": "primary-upgrade",
+            "cleanup": "$CCP_NAMESPACE-upgrade"
         }
     },
     "spec": {

--- a/examples/kube/upgrade/upgrade-pv-nfs.json
+++ b/examples/kube/upgrade/upgrade-pv-nfs.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-upgrade-pgnewdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-upgrade-pgnewdata"
+            "name": "$CCP_NAMESPACE-upgrade-pgnewdata",
+            "cleanup": "$CCP_NAMESPACE-upgrade"
         }
     },
     "spec": {

--- a/examples/kube/upgrade/upgrade-pv.json
+++ b/examples/kube/upgrade/upgrade-pv.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "$CCP_NAMESPACE-upgrade-pgnewdata",
         "labels": {
-            "name": "$CCP_NAMESPACE-upgrade-pgnewdata"
+            "name": "$CCP_NAMESPACE-upgrade-pgnewdata",
+            "cleanup": "$CCP_NAMESPACE-upgrade"
         }
     },
     "spec": {

--- a/examples/kube/upgrade/upgrade-pvc-sc.json
+++ b/examples/kube/upgrade/upgrade-pvc-sc.json
@@ -2,17 +2,20 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "upgrade-pgnewdata"
+        "name": "upgrade-pgnewdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-upgrade"
+        }
     },
     "spec": {
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "storageClassName": "$CCP_STORAGE_CLASS",
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "storageClassName": "$CCP_STORAGE_CLASS",
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      }
     }
 }

--- a/examples/kube/upgrade/upgrade-pvc.json
+++ b/examples/kube/upgrade/upgrade-pvc.json
@@ -2,21 +2,24 @@
     "kind": "PersistentVolumeClaim",
     "apiVersion": "v1",
     "metadata": {
-      "name": "upgrade-pgnewdata"
+        "name": "upgrade-pgnewdata",
+        "labels": {
+            "cleanup": "$CCP_NAMESPACE-upgrade"
+        }
     },
     "spec": {
-      "selector": {
-        "matchLabels": {
-          "name": "$CCP_NAMESPACE-upgrade-pgnewdata"
+        "selector": {
+            "matchLabels": {
+                "name": "$CCP_NAMESPACE-upgrade-pgnewdata"
+            }
+        },
+        "accessModes": [
+            "$CCP_STORAGE_MODE"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "$CCP_STORAGE_CAPACITY"
+            }
         }
-      },
-      "accessModes": [
-        "$CCP_STORAGE_MODE"
-      ],
-      "resources": {
-        "requests": {
-          "storage": "$CCP_STORAGE_CAPACITY"
-        }
-      }
     }
 }

--- a/examples/kube/upgrade/upgrade.json
+++ b/examples/kube/upgrade/upgrade.json
@@ -2,14 +2,19 @@
     "apiVersion": "batch/v1",
     "kind": "Job",
     "metadata": {
-        "name": "upgrade"
+        "name": "upgrade",
+        "labels": {
+            "app": "upgrade",
+            "cleanup": "$CCP_NAMESPACE-upgrade"
+        }
     },
     "spec": {
         "template": {
             "metadata": {
                 "name": "upgrade",
                 "labels": {
-                    "app": "upgrade"
+                    "app": "upgrade",
+                    "cleanup": "$CCP_NAMESPACE-upgrade"
                 }
             },
             "spec": {

--- a/examples/kube/vacuum/cleanup.sh
+++ b/examples/kube/vacuum/cleanup.sh
@@ -15,4 +15,4 @@
 source ${CCPROOT}/examples/common.sh
 echo_info "Cleaning up.."
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} job vacuum
+cleanup "${CCP_NAMESPACE?}-vacuum"

--- a/examples/kube/vacuum/vacuum.json
+++ b/examples/kube/vacuum/vacuum.json
@@ -2,14 +2,19 @@
     "apiVersion": "batch/v1",
     "kind": "Job",
     "metadata": {
-        "name": "vacuum"
+        "name": "vacuum",
+        "labels": {
+            "app": "vacuum",
+            "cleanup": "$CCP_NAMESPACE-vacuum"
+        }
     },
     "spec": {
         "template": {
             "metadata": {
                 "name": "vacuum",
                 "labels": {
-                    "app": "vacuum"
+                    "app": "vacuum",
+                    "cleanup": "$CCP_NAMESPACE-vacuum"
                 }
             },
             "spec": {


### PR DESCRIPTION
This changes all examples in the `kube` directory to do a cleanup via a label (`cleanup: $CCP_NAMESPACE-EXAMPLE-NAME`) (#690).  I've added a function in the common example library to make this much easier.

For now RBAC is included in this cleanup.  Once we overhaul all the examples with RBAC we can remove the the RBAC objects from the cleanup function.