### PR TITLE
Add missing cleanup label on primary service

### DIFF
--- a/examples/kube/primary/primary.json
+++ b/examples/kube/primary/primary.json
@@ -4,7 +4,8 @@
     "metadata": {
         "name": "primary",
         "labels": {
-            "name": "primary"
+            "name": "primary",
+            "cleanup": "$CCP_NAMESPACE-primary"
         }
     },
     "spec": {


### PR DESCRIPTION
A cleanup label on the primary service got dropped when formatting JSON files.