### PR TITLE
Refactored scheduler-sa to use a role

### DIFF
--- a/examples/kube/scheduler/scheduler-sa.json
+++ b/examples/kube/scheduler/scheduler-sa.json
@@ -1,6 +1,6 @@
 {
     "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-    "kind": "ClusterRole",
+    "kind": "Role",
     "metadata": {
         "name": "scheduler-sa",
         "namespace": "$CCP_NAMESPACE",
@@ -15,7 +15,6 @@
                 ""
             ],
             "resources": [
-                "namespaces",
                 "pods",
                 "configmaps",
                 "deployments",
@@ -40,8 +39,6 @@
                 "list",
                 "watch",
                 "create",
-                "update",
-                "patch",
                 "delete"
             ]
         },
@@ -52,16 +49,6 @@
             ],
             "resources": [
                 "deployments"
-            ],
-            "verbs": [
-                "get",
-                "list",
-                "watch"
-            ]
-        },
-        {
-            "nonResourceURLs": [
-                "/apis"
             ],
             "verbs": [
                 "get",
@@ -98,7 +85,7 @@
 
 {
     "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-    "kind": "ClusterRoleBinding",
+    "kind": "RoleBinding",
     "metadata": {
         "name": "scheduler-sa",
         "labels": {
@@ -108,7 +95,7 @@
     },
     "roleRef": {
         "apiGroup": "rbac.authorization.k8s.io",
-        "kind": "ClusterRole",
+        "kind": "Role",
         "name": "scheduler-sa"
     },
     "subjects": [


### PR DESCRIPTION
As per #942, I've reduced the Scheduler service account to use a Role/RoleBinding instead of ClusterRole/ClusterRoleBinding.  Since scheduler only operates within a namespace, it doesn't require cluster privileges at this time.