### PR TITLE
Add missing cleanup label from scheduler job

### DIFF
--- a/examples/kube/scheduler/configs/backup-template.json
+++ b/examples/kube/scheduler/configs/backup-template.json
@@ -6,7 +6,8 @@
         "labels": {
             "vendor": "crunchydata",
             "pgbackup": "true",
-            "pg-cluster": "{{.Name}}"
+            "pg-cluster": "{{.Name}}",
+            "cleanup": "$CCP_NAMESPACE-scheduler"
         }
     },
     "spec": {
@@ -16,7 +17,8 @@
                 "labels": {
                     "vendor": "crunchydata",
                     "pgbackup": "true",
-                    "pg-cluster": "{{.Name}}"
+                    "pg-cluster": "{{.Name}}",
+                    "cleanup": "$CCP_NAMESPACE-scheduler"
                 }
             },
             "spec": {


### PR DESCRIPTION
The backup template used by scheduler needed the cleanup label so the jobs are cleaned up after its deleted.