### PR TITLE
Fixed Issue with PG_PRIMARY_PORT & Added PG_PORT to the pgbouncer Container

### DIFF
--- a/bin/pgbouncer/start.sh
+++ b/bin/pgbouncer/start.sh
@@ -63,8 +63,9 @@ else
     sed -i "s/RESERVE_POOL_TIMEOUT/${RESERVE_POOL_TIMEOUT:-5}/g" ${CONF_DIR?}/pgbouncer.ini
     sed -i "s/QUERY_TIMEOUT/${QUERY_TIMEOUT:-0}/g" ${CONF_DIR?}/pgbouncer.ini
     sed -i "s/IGNORE_STARTUP_PARAMETERS/${IGNORE_STARTUP_PARAMETERS:-extra_float_digits}/g" ${CONF_DIR?}/pgbouncer.ini
+    sed -i "s/PG_PORT/${PG_PORT:-5432}/g" ${CONF_DIR?}/pgbouncer.ini
 
-    echo "${PG_SERVICE}:5432:*:pgbouncer:${PGBOUNCER_PASSWORD}" >> /tmp/.pgpass
+    echo "${PG_SERVICE}:${PG_PORT:-5432}:*:pgbouncer:${PGBOUNCER_PASSWORD}" >> /tmp/.pgpass
 fi
 
 export PGPASSFILE=/tmp/.pgpass

--- a/bin/postgres/liveness.sh
+++ b/bin/postgres/liveness.sh
@@ -24,4 +24,4 @@ then
     hostname=${PGHOST}
 fi
 
-$PGROOT/bin/pg_isready -h ${hostname?} --dbname=postgres --username=$PG_USER
+$PGROOT/bin/pg_isready -h ${hostname?} --port="${PG_PRIMARY_PORT}" --dbname=postgres --username=$PG_USER

--- a/bin/postgres/pgbouncer.sh
+++ b/bin/postgres/pgbouncer.sh
@@ -4,15 +4,15 @@ source /opt/cpm/bin/common_lib.sh
 export PGHOST="${PGHOST:-/tmp}"
 enable_debugging
 
-pgisready 'postgres' ${PGHOST?} 5432 'postgres'
+pgisready 'postgres' ${PGHOST?} "${PG_PRIMARY_PORT}" 'postgres'
 
 echo_info "pgBouncer enabled.  Running setup SQL.."
 cp /opt/cpm/bin/pgbouncer.sql /tmp
 sed -i "s/PGBOUNCER_PASSWORD/${PGBOUNCER_PASSWORD?}/g" /tmp/pgbouncer.sql
 
-for DB in $(psql -t -c "SELECT datname FROM pg_database WHERE datname NOT IN ('template0', 'template1')")
+for DB in $(psql --port="${PG_PRIMARY_PORT}" -t -c "SELECT datname FROM pg_database WHERE datname NOT IN ('template0', 'template1')")
 do
-    psql -U postgres -d ${DB?} \
+    psql -U postgres -d ${DB?} --port="${PG_PRIMARY_PORT}" \
         --single-transaction \
         -v ON_ERROR_STOP=1 < /tmp/pgbouncer.sql > /tmp/pgbouncer.stdout 2> /tmp/pgbouncer.stderr
     err_check "$?" "pgBouncer User Setup" "Could not create pgBouncer user: \n$(cat /tmp/pgbouncer.stderr)"

--- a/bin/postgres/pgmonitor.sh
+++ b/bin/postgres/pgmonitor.sh
@@ -3,7 +3,7 @@
 source /opt/cpm/bin/common_lib.sh
 export PGHOST="${PGHOST:-/tmp}"
 
-pgisready 'postgres' ${PGHOST?} 5432 'postgres'
+pgisready 'postgres' ${PGHOST?} "${PG_PRIMARY_PORT}" 'postgres'
 VERSION=$(psql -d postgres -qtAX -c "SELECT current_setting('server_version_num')")
 
 if (( ${VERSION?} > 90500 )) && (( ${VERSION?} < 100000 ))

--- a/bin/postgres/readiness.sh
+++ b/bin/postgres/readiness.sh
@@ -17,4 +17,4 @@ source /opt/cpm/bin/common_lib.sh
 enable_debugging
 source /opt/cpm/bin/setenv.sh
 
-$PGROOT/bin/psql -f /opt/cpm/bin/readiness.sql -U $PG_USER postgres
+$PGROOT/bin/psql -f /opt/cpm/bin/readiness.sql -U $PG_USER --port="${PG_PRIMARY_PORT}" postgres

--- a/bin/postgres/start.sh
+++ b/bin/postgres/start.sh
@@ -230,6 +230,7 @@ function fill_conf_file() {
     sed -i "s/MAX_WAL_SENDERS/${MAX_WAL_SENDERS:-6}/g" /tmp/postgresql.conf
     sed -i "s/ARCHIVE_MODE/${ARCHIVE_MODE:-off}/g" /tmp/postgresql.conf
     sed -i "s/ARCHIVE_TIMEOUT/${ARCHIVE_TIMEOUT:-0}/g" /tmp/postgresql.conf
+    sed -i "s/PG_PRIMARY_PORT/${PG_PRIMARY_PORT}/g" /tmp/postgresql.conf
 }
 
 function create_pgpass() {
@@ -319,6 +320,7 @@ function initialize_primary() {
         while true; do
             pg_isready \
             --host=/tmp \
+            --port=${PG_PRIMARY_PORT} \
             --username=${PG_PRIMARY_USER?} \
             --timeout=2
             if [ $? -eq 0 ]; then
@@ -345,7 +347,7 @@ function initialize_primary() {
         # Set PGHOST to use the socket in /tmp. unix_socket_directory is changed
         # to use /tmp instead of /var/run.
         export PGHOST=/tmp
-        psql -U postgres < /tmp/setup.sql
+        psql -U postgres -p "${PG_PRIMARY_PORT}" < /tmp/setup.sql
         if [ -f /pgconf/audit.sql ]; then
             echo_info "Using pgaudit_analyze audit.sql from /pgconf.."
             psql -U postgres < /pgconf/audit.sql

--- a/conf/pgbouncer/pgbouncer.ini
+++ b/conf/pgbouncer/pgbouncer.ini
@@ -1,5 +1,5 @@
 [databases]
-* = host=PG_SERVICE port=5432 auth_user=pgbouncer
+* = host=PG_SERVICE port=PG_PORT auth_user=pgbouncer
 
 [pgbouncer]
 listen_port = 6432

--- a/conf/postgres/postgresql.conf.template
+++ b/conf/postgres/postgresql.conf.template
@@ -60,7 +60,7 @@ listen_addresses = '*'		# what IP address(es) to listen on;
 					# comma-separated list of addresses;
 					# defaults to 'localhost'; use '*' for all
 					# (change requires restart)
-port = 5432				# (change requires restart)
+port = PG_PRIMARY_PORT				# (change requires restart)
 max_connections = MAX_CONNECTIONS			# (change requires restart)
 #superuser_reserved_connections = 3	# (change requires restart)
 unix_socket_directories = '/tmp'	# comma-separated list of directories

--- a/conf/postgres/postgresql.conf.template.nopgaudit
+++ b/conf/postgres/postgresql.conf.template.nopgaudit
@@ -60,7 +60,7 @@ listen_addresses = '*'		# what IP address(es) to listen on;
 					# comma-separated list of addresses;
 					# defaults to 'localhost'; use '*' for all
 					# (change requires restart)
-port = 5432				# (change requires restart)
+port = PG_PRIMARY_PORT				# (change requires restart)
 max_connections = MAX_CONNECTIONS			# (change requires restart)
 #superuser_reserved_connections = 3	# (change requires restart)
 unix_socket_directories = '/tmp'	# comma-separated list of directories

--- a/hugo/content/container-specifications/crunchy-pgbouncer.md
+++ b/hugo/content/container-specifications/crunchy-pgbouncer.md
@@ -51,4 +51,5 @@ The crunchy-pgbouncer Docker image contains the following packages (versions var
 **RESERVE_POOL_TIMEOUT**|5|If a client has not been serviced in this many seconds, pgbouncer enables use of additional connections from reserve pool. 0 disables.
 **QUERY_TIMEOUT**|0|Queries running longer than that are canceled.
 **IGNORE_STARTUP_PARAMETERS**|extra_float_digits|Set to ignore particular parameters in startup packets.
+**PG_PORT**|5432|The port to use when connecting to the database.
 **CRUNCHY_DEBUG**|FALSE|Set this to true to enable debugging in logs. Note: this mode can reveal secrets in logs.


### PR DESCRIPTION
Fixed the current issue with PG_PRIMARY_PORT that was preventing the user from running the PG DB on a port other than 5432.  The value specified PG_PRIMARY_PORT will now be properly applied during deployment, with the PG DB then listening on the specific port configured using this environment variable.

Also added a new environment variable called PG_PORT the pgbouncer container, which allows the user to specify the a non-standard port (e.g. a port other than 5432) when connecting to a PG DB using pgbouncer.  Therefore, if the user specifies a non-standard port using PG_PRIMARY_PORT when deploying the PG DB, this env var can then be used to ensure pgbouncer can successfully connect to that DB.

[ch743]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The PG_PRIMARY_PORT env var is not applied properly during deployment of a PG DB, and instead always defaults to 5432.

Also, pgbouncer is unable to use a port other than 5432 when connecting to a PG DB.


**What is the new behavior (if this is a feature change)?**
The PG_PRIMARY_PORT env var is now applied properly during deployment of a PG DB, allowing the user to specify a custom port for their PG DB.

Also, pgbouncer is now able to use a port other than 5432 when connecting to a PG DB.


**Other information**:
N/A