### PR TITLE
Added Port Option to all psql Commands in pgmonitor.sh

### DIFF
--- a/bin/postgres/pgmonitor.sh
+++ b/bin/postgres/pgmonitor.sh
@@ -4,7 +4,7 @@ source /opt/cpm/bin/common_lib.sh
 export PGHOST="${PGHOST:-/tmp}"
 
 pgisready 'postgres' ${PGHOST?} "${PG_PRIMARY_PORT}" 'postgres'
-VERSION=$(psql -d postgres -qtAX -c "SELECT current_setting('server_version_num')")
+VERSION=$(psql --port="${PG_PRIMARY_PORT}" -d postgres -qtAX -c "SELECT current_setting('server_version_num')")
 
 if (( ${VERSION?} > 90500 )) && (( ${VERSION?} < 100000 ))
 then
@@ -20,12 +20,12 @@ fi
 # TODO Add ON_ERROR_STOP and single transaction when
 # upstream pgmonitor changes setup SQL to check if the
 # role exists prior to creating it.
-psql -U postgres -d postgres \
+psql -U postgres --port="${PG_PRIMARY_PORT}" -d postgres \
     < ${function_file?} > /tmp/pgmonitor.stdout 2> /tmp/pgmonitor.stderr
 
 err_check "$?" "pgMonitor Setup" "Could not load pgMonitor functions: \n$(cat /tmp/pgmonitor.stderr)"
 
-psql -U postgres -d postgres \
+psql -U postgres --port="${PG_PRIMARY_PORT}" -d postgres \
     -c "ALTER ROLE ccp_monitoring PASSWORD '${PGMONITOR_PASSWORD?}'" \
     > /tmp/pgmonitor.stdout 2> /tmp/pgmonitor.stderr
 


### PR DESCRIPTION
Added the port option to all **psql** commands in **pgmonitor.sh** in order to set the port to the value provided for **PG_PRIMARY_PORT** when connecting to a PG DB during initialization of the **crunchy-postgres** container.

[ch743]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The **pgmonitor.sh** script fails during initialization of the **crunchy-postgres** container if a value other than 5432 is selected for environment variable **PG_PRIMARY_PORT**.


**What is the new behavior (if this is a feature change)?**
The **pgmonitor.sh** script now completes successfully during initialization of the **crunchy-postgres** container with any value specified environment variable **PG_PRIMARY_PORT**.


**Other information**:
N/A