### PR TITLE
Added the 'Client User Guide' for the Documentation Rewrite

### DIFF
--- a/hugo/content/client-user-guide/configurations.md
+++ b/hugo/content/client-user-guide/configurations.md
@@ -1,3 +1,0 @@
-# Local Configurations
-
-Local Machine configurations environment vars, gke login, etc

--- a/hugo/content/client-user-guide/introduction.md
+++ b/hugo/content/client-user-guide/introduction.md
@@ -1,3 +1,0 @@
-# Introduction
-
-Already have a Docker, Kubernetes / GKE or OCP environment start here.

--- a/hugo/content/client-user-guide/usage.md
+++ b/hugo/content/client-user-guide/usage.md
@@ -1,0 +1,51 @@
+# Running the Examples
+
+The Kubernetes and OpenShift examples in this guide have been designed using
+single-node Kubernetes/OCP clusters whose host machines provide any required supporting 
+infrastructure or services (e.g. local hostPath storage or access to an NFS share). Therefore, for
+the best results when running these examples, it is recommended that you utilize a single-node 
+architecture as well.
+
+Additionally, the examples located in the **kube** directory work on both Kubernetes and OpenShift.
+Please ensure the `CCP_CLI` environment variable is set to the correct binary for your environment,
+as shown below:
+
+```bash
+# Kubernetes
+export CCP_CLI=kubectl
+
+# OpenShift
+export CCP_CLI=oc
+```
+_**NOTE:** Set the `CCP_CLI` environment variable in `.bashrc` to ensure the examples will work
+properly in your environment_
+
+## Example Conventions
+
+The examples provided in Crunchy Container Suite are simple examples that
+are meant to demonstrate key Crunchy Container Suite features.  These
+examples can be used to build more production level deployments
+as dictated by user requirements specific to their operating
+environments.
+
+The examples generally follow these conventions:
+- There is a **run.sh** script that you will execute to start the example
+- There is a **cleanup.sh** script that you will execute to shutdown and cleanup the example
+- Each example will create resources such as Secrets, ConfigMaps, Services, and 
+PersistentVolumeClaims, all which follow a naming convention of 
+`<example name>-<optional description suffix>`. For example, an example called **primary** might 
+have a PersistentVolumeClaim called **primary-pgconf** to describe the purpose of that particular 
+PVC.
+- The folder names for each example give a clue as to which Container Suite feature it 
+demonstrates. For instance, the `examples/kube/pgaudit` example demonstrates how to enable the 
+**pg_audit** capability in the **crunchy-postgres** container.
+
+## Helpful Resources
+
+Here are some useful resources for finding the right commands to troubleshoot and modify containers
+in the various environments shown in this guide:
+
+- [Docker Cheat Sheet](http://www.bogotobogo.com/DevOps/Docker/Docker-Cheat-Sheet.php)
+- [Kubectl Cheat Sheet](https://kubernetes.io/docs/user-guide/kubectl-cheatsheet/)
+- [OpenShift Cheat Sheet](https://github.com/nekop/openshift-sandbox/blob/master/docs/command-cheatsheet.md)
+- [Helm Cheat Sheet](https://github.com/kubernetes/helm/blob/master/docs/using_helm.md)

--- a/hugo/content/client-user-guide/user-guide.md
+++ b/hugo/content/client-user-guide/user-guide.md
@@ -1,0 +1,82 @@
+# User Guide
+
+## Overview
+
+This guide is intended to get you up and running with the Crunchy Container Suite, and therefore
+provides guidance for deploying the Crunchy Container Suite within your own environment.  This 
+includes guidance for standing-up and configuring your environment in order to run Crunchy 
+Containers examples that can be found in the next section.
+
+Please see the following sections in order to properly setup and configure your environment for the
+Crunchy Container Suite (_**please feel free to skip any sections that have already been completed 
+within your environment**_):
+
+1. [Platform Installation](#platform-installation)
+1. [Crunchy Container Suite Installation](#crunchy-container-suite-installation)
+1. [Storage Configuration](#storage-configuration)
+1. [Example Guidance](#example-guidance)
+1. [Crunchy Container Suite Examples](#crunchy-container-suite-examples)
+
+Once your environment has been configured according to instructions provided above, you will be 
+able to run the Crunchy Container Suite examples. These examples will demonstrate the various 
+capabilities provided by the Crunchy Container Suite, including how to properly configure and 
+deploy the various containers within the suite, and then utilize the features and services provided
+by those containers.  The examples therefore demonstrate how the Crunchy Container Suite can be 
+utilized to effectively deploy a PostreSQL database cluster within your own environment, that meets
+your specific needs and contains the PostreSQL features and services that you require.
+
+## <a name="platform-installation"></a>Platform Installation
+
+In order to run the examples and deploy various container within the Crunchy Container Suite, you 
+will first need access to an environment containing one of the following supported platforms:
+
+- Docker 1.13+ (https://www.docker.com/)
+- Kubernetes 1.8+ (https://kubernetes.io/)
+- OpenShift Container Platform 3.11 (https://www.openshift.com/products/container-platform/)
+
+Links to the official website for each of these platform are provided above.  Please consult the 
+official documentation for instructions on how to install and configure these platforms in your
+environment.
+
+## <a name="crunchy-container-suite-installation"></a>Crunchy Container Suite Installation
+
+Once you have access to an environment containing one of the supported platforms, it is then 
+necessary to properly configure that environment in order to run the examples, and therefore deploy
+the various containers included in the Crunchy Container Suite.  This can be done by following
+the Crunchy Container Suite [Installation Guide](../installation-guide/installation-guide.md).  
+
+Please note that as indicated within the 
+[Installation Guide](../installation-guide/installation-guide.md), certain steps may require 
+administrative access and/or privileges.  Therefore, please work with your local System 
+Administrator(s) as needed to setup and configure your environment according to the steps defined
+within this guide.  Additionally, certain steps are only applicable to certain platforms and/or
+environments, so please be sure to follow all instructions that are applicable to your target
+environment.
+
+## <a name="storage-configuration"></a>Storage Configuration
+
+Once you have completed all applicable steps in the 
+[Installation Guide](../installation-guide/installation-guide.md), you can then proceed with 
+configuring storage in your environment.  The specific forms of storage supported by the Crunchy
+Containers Suite, as well as instructions for configuring and enabling those forms of storage, can 
+be found in the [Storage Configuration](../installation-guide/storage-configuration.md) guide.
+Therefore, please review and follow steps in the 
+[Storage Configuration](../installation-guide/storage-configuration.md) guide in order to properly
+configure storage in your environment according to your specific storage needs.
+
+## <a name="example-guidance"></a>Example Guidance
+
+With the [Installation Guide](../installation-guide/installation-guide.md) and 
+[Storage Configuration](../installation-guide/storage-configuration.md) complete, you are almost
+ready to run the examples.  However, prior to doing so it is recommended that you first review the
+documentation for [Running the Examples](usage.md), which describes various conventions utilized in
+the examples, while also providing any other information, resources and guidance relevant to 
+successfully running the Crunchy Container Suite examples in your environment.  The documentation 
+for running the examples can be found [here](usage.md).
+
+## <a name="crunchy-container-suite-examples"></a>Crunchy Container Suite Examples
+
+Now that your environment has been properly configured for the Crunchy Container Suite and you have
+reviewed the guidance for [Running the Examples](usage.md), you are ready to run the Crunchy 
+Container Suite examples.  Therefore, please proceed to the next section in order to find the 
+examples that can now be run in your environment.

--- a/hugo/content/client-user-guide/using.md
+++ b/hugo/content/client-user-guide/using.md
@@ -1,3 +1,0 @@
-# Using Crunchy Containers
-
-How to use Crunchy Containers

--- a/hugo/content/installation-guide/storage-configuration.md
+++ b/hugo/content/installation-guide/storage-configuration.md
@@ -1,0 +1,130 @@
+# Storage Configuration
+
+## Available Storage Types
+
+The Crunchy Container Suite is officially tested using two different storage backends:
+
+- hostPath (single node testing)
+- NFS (single and multi-node testing)
+
+Other storage backends work as well, including GCE, EBS, ScaleIO, and
+others, but may require you to modify various examples or configuration.
+
+The Crunchy Container Suite is tested, developed, and examples are 
+provided that use the various storage types listed above.  This 
+ensures that customers have a high degree of choices when it comes 
+to choosing a volume type.  HostPath and NFS allow precise host path
+choices for where database volumes are persisted.  HostPath and NFS
+also allow governance models where volume creation is performed
+by an administrator instead of the application/developer team.
+
+Where customers desire a dynamic form of volume creation (e.g. self service),
+storage classes are also supported within the example set.
+
+Environment variables are set to determine how and what storage
+is to be used.
+
+_**NOTE:** When running the examples using HostPath or NFS storage, the run scripts 
+provided in the examples will create directories using the following pattern:_
+```bash
+$CCP_STORAGE_PATH/$CCP_NAMESPACE-<EXAMPLE_NAME>
+```
+
+## HostPath
+
+HostPath is the simplest storage backend to setup. It is only feasible
+on a single node but is sufficient for testing the examples.  In your `.bashrc`
+file, add the following variables to specify the proper settings for your
+the HostPath storage volume:
+```bash
+export CCP_SECURITY_CONTEXT=""
+export CCP_STORAGE_PATH=/data
+export CCP_STORAGE_MODE=ReadWriteMany
+export CCP_STORAGE_CAPACITY=400M
+```
+
+_**NOTE:** It may be necessary to grant your user in OpenShift or Kubernetes the
+rights to modify the **hostaccess** SCC. This can be done with the following command:_
+```bash
+oadm policy add-scc-to-user hostaccess $(oc whoami)
+```
+
+## NFS
+
+NFS can also be utilized as a storage mechanism.  Instructions for setting up a NFS can be 
+found in the **Configuration Notes for NFS** section below.
+
+For testing with NFS, include the following variables in your **.bashrc** file, providing 
+the proper configuration details for your NFS:
+```bash
+export CCP_SECURITY_CONTEXT='"supplementalGroups": [65534]'
+export CCP_STORAGE_PATH=/nfsfileshare
+export CCP_NFS_IP=<IP OF NFS SERVER>
+export CCP_STORAGE_MODE=ReadWriteMany
+export CCP_STORAGE_CAPACITY=400M
+```
+
+In the example above the group ownership of the NFS mount is assumed to be
+**nfsnobody** or **65534**.  Additionally, it is recommended that root not be squashed on
+the NFS share (using `no_root_squash`) in order to ensure the proper directories can be
+created, modified and removed as needed for the various container examples.
+
+Additionally, the examples in the Crunchy Container suite need access to the NFS in order to create
+the directories utilized by the examples.  The NFS should therefore be mounted locally so that the 
+`run.sh` scripts contained within the examples can complete the proper setup.
+
+### Configuration Notes for NFS
+
+- Most of the Crunchy containers run as the postgres UID (26), but you
+will notice that when `supplementalGroups` is specified, the pod
+will include the `nfsnobody` group in the list of groups for the pod user
+- If you are running your NFS system with SELinux in enforcing mode, you will need to run the 
+following command to allow NFS write permissions:
+
+    ```bash
+    sudo setsebool -P virt_use_nfs 1
+    ```
+- Detailed instructions for setting up a NFS server on Centos 7 can be found using the following link: 
+    
+    http://www.itzgeek.com/how-tos/linux/centos-how-tos/how-to-setup-nfs-server-on-centos-7-rhel-7-fedora-22.html
+
+- If you are running your client on a VM, you will need to
+add **insecure** to the exportfs file on the NFS server due to the way port
+translation is done between the VM host and the VM instance.  For more details on this bug, please see the 
+following link:
+
+    http://serverfault.com/questions/107546/mount-nfs-access-denied-by-server-while-mounting
+
+- A suggested best practice for tuning NFS for PostgreSQL is to configure the PostgreSQL fstab
+mount options like so:
+
+    ```bash
+    proto=tcp,suid,rw,vers=3,proto=tcp,timeo=600,retrans=2,hard,fg,rsize=8192,wsize=8192
+    ```
+
+    And to then change your network options as follows:
+    ```bash
+    MTU=9000
+    ```
+- If interested in mounting the same NFS share multiple times on the same mount point,
+look into the [noac mount option](https://www.novell.com/support/kb/doc.php?id=7010210)
+
+## Dynamic Storage
+
+Dynamic storage classes can be used for the examples.  There
+are various providers and solutions for dynamic storage, so please consult 
+the Kubernetes documentation for additional details regarding supported 
+storage choices.  The environment variable `CCP_STORAGE_CLASS` is used
+in the examples to determine whether or not to create a PersistentVolume
+manually, or if it will be created dynamically using a StorageClass.  In
+the case of GKE, the default StorageClass is named **default**.  Storage
+class names are determined by the Kubernetes administrator and can vary.
+
+Using block storage requires a security context to be set
+as follows:
+```bash
+export CCP_SECURITY_CONTEXT='"fsGroup":26'
+export CCP_STORAGE_CLASS=standard
+export CCP_STORAGE_MODE=ReadWriteOnce
+export CCP_STORAGE_CAPACITY=400M
+```


### PR DESCRIPTION
Added the **Client User Guide** to Crunchy Container Suite documentation as part of the current documentation rewrite.  The user guide walks the user through the steps required to configure their own environment to run Crunchy Container Suite examples, therefore allowing them to deploy the containers contained within the Crunchy Container Suite within their own environment.  This includes providing the user with guidance for the following:
- Installing a platform supported by the Crunchy Container Suite
- Configuring their environment using the Installation Guide
- Configuring a storage solution using the Storage Configuration guide
- Guidance for running the examples (conventions and other applicable guidance)

[ch189]
