### PR TITLE
Added Option to Skip pgBackRest Stanza Creation in the postgres & postgres-gis Containers

### DIFF
--- a/bin/postgres/pgbackrest.sh
+++ b/bin/postgres/pgbackrest.sh
@@ -103,7 +103,7 @@ then
     echo_info "pgBackRest: Configuration is valid"
 fi
 
-# Create stanza ((PGBACKREST_SKIP_CREATE_STANZA=true))
+# Create stanza
 if [[ "${BACKREST_SKIP_CREATE_STANZA}" == "true" ]]
 then
     echo_info "pgBackRest: BACKREST_SKIP_CREATE_STANZA is 'true'.  Skipping stanza creation.." 

--- a/bin/postgres/pgbackrest.sh
+++ b/bin/postgres/pgbackrest.sh
@@ -103,8 +103,11 @@ then
     echo_info "pgBackRest: Configuration is valid"
 fi
 
-# Create stanza
-if pgbackrest info | grep -q 'missing stanza path'
+# Create stanza ((PGBACKREST_SKIP_CREATE_STANZA=true))
+if [[ "${BACKREST_SKIP_CREATE_STANZA}" == "true" ]]
+then
+    echo_info "pgBackRest: BACKREST_SKIP_CREATE_STANZA is 'true'.  Skipping stanza creation.." 
+elif pgbackrest info | grep -q 'missing stanza path'
 then
     echo_info "pgBackRest: The following pgbackrest env vars have been set:"
     ( set -o posix ; set | grep -oP "^PGBACKREST.*" )

--- a/bin/postgres/pgbackrest.sh
+++ b/bin/postgres/pgbackrest.sh
@@ -93,14 +93,19 @@ set_pgbackrest_env_vars
 create_pgbackrest_dirs
 
 # Check if configuration is valid
-echo_info "pgBackRest: Checking if configuration is valid.."
-pgbackrest info > /tmp/pgbackrest.stdout 2> /tmp/pgbackrest.stderr
-err=$?
-err_check ${err} "pgBackRest Configuration Check" \
-    "Error with pgBackRest configuration: \n$(cat /tmp/pgbackrest.stderr)"
-if [[ ${err} == 0 ]]
+if [[ "${BACKREST_SKIP_CREATE_STANZA}" == "true" ]]
 then
-    echo_info "pgBackRest: Configuration is valid"
+    echo_info "pgBackRest: BACKREST_SKIP_CREATE_STANZA is 'true'.  Skipping configuration check.."
+else
+    echo_info "pgBackRest: Checking if configuration is valid.."
+    pgbackrest info > /tmp/pgbackrest.stdout 2> /tmp/pgbackrest.stderr
+    err=$?
+    err_check ${err} "pgBackRest Configuration Check" \
+        "Error with pgBackRest configuration: \n$(cat /tmp/pgbackrest.stderr)"
+    if [[ ${err} == 0 ]]
+    then
+        echo_info "pgBackRest: Configuration is valid"
+    fi
 fi
 
 # Create stanza

--- a/hugo/content/container-specifications/crunchy-postgres-gis.md
+++ b/hugo/content/container-specifications/crunchy-postgres-gis.md
@@ -64,7 +64,7 @@ The crunchy-postgres-gis Docker image contains the following packages (versions 
 **WORK_MEM**|4MB|Set this value to configure `work_mem` in `postgresql.conf`
 **XLOGDIR**|None| Set this value to configure PostgreSQL to send WAL to the `/pgwal` volume (by default WAL is stored in `/pgdata`)
 **PGBACKREST**|false| Set this value to `true` in order to enable and initialize pgBackRest in the container
-**BACKREST_SKIP_CREATE_STANZA**|false| Set this value to `true` in order to skip the automatic creation of a stanza while initializing pgBackRest in the container
+**BACKREST_SKIP_CREATE_STANZA**|false| Set this value to `true` in order to skip the configuration check and the automatic creation of a stanza while initializing pgBackRest in the container
 
 ## Volumes
 

--- a/hugo/content/container-specifications/crunchy-postgres-gis.md
+++ b/hugo/content/container-specifications/crunchy-postgres-gis.md
@@ -63,6 +63,8 @@ The crunchy-postgres-gis Docker image contains the following packages (versions 
 **TEMP_BUFFERS**|8MB|Set this value to configure `temp_buffers` in `postgresql.conf`
 **WORK_MEM**|4MB|Set this value to configure `work_mem` in `postgresql.conf`
 **XLOGDIR**|None| Set this value to configure PostgreSQL to send WAL to the `/pgwal` volume (by default WAL is stored in `/pgdata`)
+**PGBACKREST**|false| Set this value to `true` in order to enable and initialize pgBackRest in the container
+**BACKREST_SKIP_CREATE_STANZA**|false| Set this value to `true` in order to skip the automatic creation of a stanza while initializing pgBackRest in the container
 
 ## Volumes
 
@@ -85,7 +87,6 @@ The following configuration files can be mounted to the `/pgconf` volume in the 
 `ca.crl`| Revocation list of the CA used by the server when using SSL authentication
 `pg_hba.conf`| Client authentication rules for the database
 `pg_ident.conf`| Mapping of external users (such as SSL certs, GSSAPI, LDAP) to database users
-`pgbackrest.conf`| pgBackRest configurations
 `postgresql.conf`| PostgreSQL settings
 `server.key`| Key used by the server when using SSL authentication
 `server.crt`| Certificate used by the server when using SSL authentication

--- a/hugo/content/container-specifications/crunchy-postgres.md
+++ b/hugo/content/container-specifications/crunchy-postgres.md
@@ -63,7 +63,7 @@ The crunchy-postgres Docker image contains the following packages (versions vary
 **WORK_MEM**|4MB|Set this value to configure `work_mem` in `postgresql.conf`
 **XLOGDIR**|None| Set this value to configure PostgreSQL to send WAL to the `/pgwal` volume (by default WAL is stored in `/pgdata`)
 **PGBACKREST**|false| Set this value to `true` in order to enable and initialize pgBackRest in the container
-**BACKREST_SKIP_CREATE_STANZA**|false| Set this value to `true` in order to skip the automatic creation of a stanza while initializing pgBackRest in the container
+**BACKREST_SKIP_CREATE_STANZA**|false| Set this value to `true` in order to skip the configuration check and the automatic creation of a stanza while initializing pgBackRest in the container
 
 ## Volumes
 

--- a/hugo/content/container-specifications/crunchy-postgres.md
+++ b/hugo/content/container-specifications/crunchy-postgres.md
@@ -62,6 +62,8 @@ The crunchy-postgres Docker image contains the following packages (versions vary
 **TEMP_BUFFERS**|8MB|Set this value to configure `temp_buffers` in `postgresql.conf`
 **WORK_MEM**|4MB|Set this value to configure `work_mem` in `postgresql.conf`
 **XLOGDIR**|None| Set this value to configure PostgreSQL to send WAL to the `/pgwal` volume (by default WAL is stored in `/pgdata`)
+**PGBACKREST**|false| Set this value to `true` in order to enable and initialize pgBackRest in the container
+**BACKREST_SKIP_CREATE_STANZA**|false| Set this value to `true` in order to skip the automatic creation of a stanza while initializing pgBackRest in the container
 
 ## Volumes
 
@@ -84,7 +86,6 @@ The following configuration files can be mounted to the `/pgconf` volume in the 
 `ca.crl`| Revocation list of the CA used by the server when using SSL authentication
 `pg_hba.conf`| Client authentication rules for the database
 `pg_ident.conf`| Mapping of external users (such as SSL certs, GSSAPI, LDAP) to database users
-`pgbackrest.conf`| pgBackRest configurations
 `postgresql.conf`| PostgreSQL settings
 `server.key`| Key used by the server when using SSL authentication
 `server.crt`| Certificate used by the server when using SSL authentication


### PR DESCRIPTION
Added an option to the crunchy-postgres and crunchy-postgres-gis containers to skip stanza creation while initializing pgBackRest.  This option comes in the form of the following environment variable, which can be set to `true` during deployment of the container in order to skip stanza creation:

```bash
BACKREST_SKIP_CREATE_STANZA=true
```

This allows the user and/or PGO to manually create a stanza, instead of relying on the stanza that is automatically created by default (i.e. a **db** stanza).

[ch690]
[ch704]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
A pgBackRest stanza is automatically created when pgBackrest is enabled in the crunchy-postgres and crunchy-postgres-gis containers.


**What is the new behavior (if this is a feature change)?**
There is now an option to skip the automicatic creation of a stanza when pgBackrest is enabled in the crunchy-postgres and crunchy-postgres-gis containers.


**Other information**:
N/A