### PR TITLE
Moved Archive Config to End of postgres Container Startup Script

### DIFF
--- a/conf/postgres/postgresql.conf.template
+++ b/conf/postgres/postgresql.conf.template
@@ -211,13 +211,13 @@ wal_level = hot_standby			# minimal, replica, or logical
 
 # - Archiving -
 
-archive_mode = ARCHIVE_MODE		# enables archiving; off, on, or always
+#archive_mode = off		# enables archiving; off, on, or always
 				# (change requires restart)
 #archive_command = ''		# command to use to archive a logfile segment
 				# placeholders: %p = path of file to archive
 				#               %f = file name only
 				# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
-archive_timeout = ARCHIVE_TIMEOUT		# force a logfile segment switch after this
+#archive_timeout = 0		# force a logfile segment switch after this
 				# number of seconds; 0 disables
 
 

--- a/conf/postgres/postgresql.conf.template.nopgaudit
+++ b/conf/postgres/postgresql.conf.template.nopgaudit
@@ -211,13 +211,13 @@ wal_level = hot_standby			# minimal, replica, or logical
 
 # - Archiving -
 
-archive_mode = ARCHIVE_MODE		# enables archiving; off, on, or always
+#archive_mode = off		# enables archiving; off, on, or always
 				# (change requires restart)
 #archive_command = ''		# command to use to archive a logfile segment
 				# placeholders: %p = path of file to archive
 				#               %f = file name only
 				# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
-archive_timeout = ARCHIVE_TIMEOUT		# force a logfile segment switch after this
+#archive_timeout = 0		# force a logfile segment switch after this
 				# number of seconds; 0 disables
 
 


### PR DESCRIPTION
Moved the archiving configuration to the end of the startup script for the crunchy-postgres and crunchy-postgres-gis containers.  This is to ensure archiving is not attempted (if enabled) during initialization of the database, which can lead to issues with the database shutting down via `pg_ctl stop` upon completion of the initialization process.

All archive commands, which includes `archive_mode`, `archive_timeout` and `archive_command`, are now set after initialization of the database, prior adding any custom configuration and starting the database for the final time.  This ensures that archiving is not attempted until the database is started for the final time.

[ch735]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The `pg_ctl stop` command sometimes fails during initialization of the crunchy-postgres or crunchy-postgres-gis containers as a result of a network connection initialized by pgbackrest to archive WAL using a remote pgBackRest repo.  This is often seen in certain environments when using pgo, since pgo utilizes a remote pgBackRest repo server for pushing archive logs.

**What is the new behavior (if this is a feature change)?**
All archive configuration has been moved to the end of the startup script for the crunchy-postgres and crunchy-postgres-gis containers, ensuring archiving is not attempted until the database is started for the final time.  This will ensure the `pg_ctl stop` command succeeds during initialization of the database.

**Other information**:
N/A