### PR TITLE
Added Env Var PG_USER to the Pod Definition for the Secret Example

### DIFF
--- a/examples/kube/secret/secret.json
+++ b/examples/kube/secret/secret.json
@@ -131,6 +131,15 @@
                     {
                         "name": "PG_DATABASE",
                         "value": "userdb"
+                    },
+                    {
+                        "name": "PG_USER",
+                        "valueFrom": {
+                            "secretKeyRef": {
+                                "name": "pguser-secret",
+                                "key": "username"
+                            }
+                        }
                     }
                 ],
                 "volumeMounts": [


### PR DESCRIPTION
Added env var PG_USER to the pod definition for the secret example.  This prevents failed readiness probes when running this example, such as the following

```
Warning Unhealthy 1m kubelet, gke-centos7-2-3-0-rc3-default-pool-958b4462-zhwv Readiness probe failed: Thu Jan 10 20:29:54 UTC 2019 INFO: Setting PGROOT to /usr/pgsql-10.
psql: FATAL: role "--port=5432" does not exist
Warning Unhealthy 1m kubelet, gke-centos7-2-3-0-rc3-default-pool-958b4462-zhwv Readiness probe failed: Thu Jan 10 20:30:04 UTC 2019 INFO: Setting PGROOT to /usr/pgsql-10.
```
Addresses [ch1745]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Readiness probes fail when running the secret example due to a malformed psql command in the readiness script, which is the result of a missing PG_USER env var.



**What is the new behavior (if this is a feature change)?**
The PG_USER env var is now set in the pod created for the secret example, forming a proper psql command in the readnienss script and therefore allowing the readiness probe to succeed.


**Other information**:
N/A