### PR TITLE
Added inter-pod affinity to replica deployment in primary-replica

### DIFF
--- a/examples/kube/primary-replica/replica.json
+++ b/examples/kube/primary-replica/replica.json
@@ -45,6 +45,26 @@
                 }
             },
             "spec": {
+                "affinity": {
+                    "podAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "labelSelector": {
+                                    "matchExpressions": [
+                                        {
+                                            "key": "name",
+                                            "operator": "In",
+                                            "values": [
+                                                "pr-replica"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "topologyKey": "kubernetes.io/hostname"
+                            }
+                        ]
+                    }
+                },
                 "containers": [
                     {
                         "name": "postgres",


### PR DESCRIPTION
Added inter-pod affinity to the replica deployment in the primary-replica example.  This ensures that all replica pods are scheduled and deployed on the same node, therefore preventing `Multi-Attach error for volume` errors when scaling the replica deployment on GKE and using GKE default storage.

Since GKE default storage only supports access mode ReadWriteOnce, more than one pod can only share a PV if those pods are scheduled and deployed on the same node.  Since the primary-replica example has multiple pods (i.e. multiple replica pods) utilizing the same PV, errors are thrown if the replicas end up on separate nodes when using a multi-node cluster.  It is therefore necessary to deploy the pods on the same node, where they can then share the same PV.

Addresses [ch1734]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
`Multi-Attach error for volume` errors are thrown when scaling the primary-replica deployment on a multi-node GKE cluster that utilizes GKE default storage.


**What is the new behavior (if this is a feature change)?**
Inter-pod affinity is used to ensure all replica pods are deployed to the same node, therefore ensuring those pods will be able to utilize the same PV when using GKE default storage.


**Other information**:
N/A