### PR TITLE
Make the pgAdmin4 URL Configurable

### DIFF
--- a/bin/pgadmin4/start-pgadmin4.sh
+++ b/bin/pgadmin4/start-pgadmin4.sh
@@ -48,6 +48,11 @@ fi
 
 cp /opt/cpm/conf/config_local.py /var/lib/pgadmin/config_local.py
 
+if [[ -z "${SERVER_PATH}" ]]
+then
+    sed -i "/RedirectMatch/d" /var/lib/pgadmin/pgadmin.conf
+fi
+sed -i "s|SERVER_PATH|${SERVER_PATH:-/}|g" /var/lib/pgadmin/pgadmin.conf
 sed -i "s|SERVER_PORT|${SERVER_PORT:-5050}|g" /var/lib/pgadmin/pgadmin.conf
 sed -i "s/^DEFAULT_SERVER_PORT.*/DEFAULT_SERVER_PORT = ${SERVER_PORT:-5050}/" /var/lib/pgadmin/config_local.py
 sed -i "s|\"pg\":.*|\"pg\": \"/usr/pgsql-${PGVERSION?}/bin\",|g" /var/lib/pgadmin/config_local.py

--- a/conf/pgadmin4/pgadmin-http.conf
+++ b/conf/pgadmin4/pgadmin-http.conf
@@ -1,7 +1,7 @@
 <VirtualHost *:SERVER_PORT>
 	LoadModule wsgi_module modules/mod_wsgi.so
 	WSGIDaemonProcess pgadmin processes=1 threads=25
-	WSGIScriptAlias / /usr/lib/python2.7/site-packages/pgadmin4-web/pgAdmin4.wsgi
+	WSGIScriptAlias SERVER_PATH /usr/lib/python2.7/site-packages/pgadmin4-web/pgAdmin4.wsgi
 
 	<Directory /usr/lib/python2.7/site-packages/pgadmin4-web/>
 		WSGIProcessGroup pgadmin
@@ -18,4 +18,6 @@
 			Allow from ::1
 		</IfModule>
 	</Directory>
+
+    RedirectMatch ^/$ SERVER_PATH
 </VirtualHost>

--- a/conf/pgadmin4/pgadmin-https.conf
+++ b/conf/pgadmin4/pgadmin-https.conf
@@ -1,4 +1,5 @@
 <VirtualHost *:SERVER_PORT>
+
     LoadModule ssl_module modules/mod_ssl.so
 	LoadModule wsgi_module modules/mod_wsgi.so
     
@@ -9,7 +10,7 @@
     SSLCertificateKeyFile "/certs/server.key"
 
 	WSGIDaemonProcess pgadmin processes=1 threads=25
-	WSGIScriptAlias / /usr/lib/python2.7/site-packages/pgadmin4-web/pgAdmin4.wsgi
+	WSGIScriptAlias SERVER_PATH /usr/lib/python2.7/site-packages/pgadmin4-web/pgAdmin4.wsgi
 
 	<Directory /usr/lib/python2.7/site-packages/pgadmin4-web/>
 		WSGIProcessGroup pgadmin
@@ -26,4 +27,6 @@
 			Allow from ::1
 		</IfModule>
 	</Directory>
+
+    RedirectMatch ^/$ SERVER_PATH
 </VirtualHost>

--- a/hugo/content/container-specifications/crunchy-pgadmin4.md
+++ b/hugo/content/container-specifications/crunchy-pgadmin4.md
@@ -41,6 +41,7 @@ The crunchy-pgadmin4 Docker image contains the following packages (versions vary
 **PGADMIN_SETUP_EMAIL**|None|Set this value to the email address used for pgAdmin4 login.
 **PGADMIN_SETUP_PASSWORD**|None|Set this value to a password used for pgAdmin4 login. This should be a strong password.
 **SERVER_PORT**|5050|Set this value to a change the port pgAdmin4 listens on.
+**SERVER_PATH**|/|Set this value to customize the path of the URL that will be utilized to access the pgAdmin4 web application.
 **ENABLE_TLS**|FALSE|Set this value to true to enable HTTPS on the pgAdmin4 container. This requires a `server.key` and `server.crt` to be mounted on the `/certs` directory.
 
 ### Optional


### PR DESCRIPTION
Added a new environment variable called **SERVER_PATH** to the crunchy-pgadmin4 container in order to make the URL for pgAdmin4 configurable.  With this change the default path for the pgAdmin4 URL remains `/`, and **SERVER_PATH** can then be utilized set the path portion of the URL to a specific/custom value.

For instance, by default the user would access pgAdmin4 using the following URL:

```
http://127.0.0.1:5050
```

However, if **SERVER_PATH** is set as follows:

```bash
SERVER_PATH=/pgadmin4
```

...the user would then access pgAdmin4 using the following URL:

```
http://127.0.0.1:5050/pgadmin4
```

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The path of the URL for the pgAdmin4 web application defaults to `/`, and cannot be customized.

[ch735]

**What is the new behavior (if this is a feature change)?**
The user can customize the path of the URL that is utilized to access the pgAdmin4 web application.


**Other information**:
N/A