### PR TITLE
Add optional pg_ctl start parameters env

### DIFF
--- a/bin/postgres/start.sh
+++ b/bin/postgres/start.sh
@@ -296,7 +296,10 @@ function initialize_primary() {
         echo "Starting database.." >> /tmp/start-db.log
 
         echo_info "Temporarily starting database to run setup.sql.."
-        pg_ctl -D ${PGDATA?} -o "-c listen_addresses=''" start
+        pg_ctl -D ${PGDATA?} -o "-c listen_addresses='' ${PG_CTL_OPTS:-}" start \
+            2> /tmp/pgctl.stderr
+        err_check "$?" "Temporarily Starting PostgreSQL (primary)" \
+            "Unable to start PostgreSQL: \n$(cat /tmp/pgctl.stderr)"
 
         echo_info "Waiting for PostgreSQL to start.."
         while true; do

--- a/hugo/content/container-specifications/crunchy-postgres-gis.md
+++ b/hugo/content/container-specifications/crunchy-postgres-gis.md
@@ -1,6 +1,6 @@
 ---
 title: "crunchy-postgres-gis"
-date: 
+date:
 draft: false
 weight: 152
 ---
@@ -65,6 +65,7 @@ The crunchy-postgres-gis Docker image contains the following packages (versions 
 **XLOGDIR**|None| Set this value to configure PostgreSQL to send WAL to the `/pgwal` volume (by default WAL is stored in `/pgdata`)
 **PGBACKREST**|false| Set this value to `true` in order to enable and initialize pgBackRest in the container
 **BACKREST_SKIP_CREATE_STANZA**|false| Set this value to `true` in order to skip the configuration check and the automatic creation of a stanza while initializing pgBackRest in the container
+**PG_CTL_OPTS**|None| Set this value to supply custom `pg_ctl` options (ex: `-c shared_preload_libraries=pgaudit`) during the initialization phase the container start.
 
 ## Volumes
 

--- a/hugo/content/container-specifications/crunchy-postgres.md
+++ b/hugo/content/container-specifications/crunchy-postgres.md
@@ -1,6 +1,6 @@
 ---
 title: "crunchy-postgres"
-date: 
+date:
 draft: false
 weight: 150
 ---
@@ -64,6 +64,7 @@ The crunchy-postgres Docker image contains the following packages (versions vary
 **XLOGDIR**|None| Set this value to configure PostgreSQL to send WAL to the `/pgwal` volume (by default WAL is stored in `/pgdata`)
 **PGBACKREST**|false| Set this value to `true` in order to enable and initialize pgBackRest in the container
 **BACKREST_SKIP_CREATE_STANZA**|false| Set this value to `true` in order to skip the configuration check and the automatic creation of a stanza while initializing pgBackRest in the container
+**PG_CTL_OPTS**|None| Set this value to supply custom `pg_ctl` options (ex: `-c shared_preload_libraries=pgaudit`) during the initialization phase the container start.
 
 ## Volumes
 


### PR DESCRIPTION
As per #980, there's a small edge case bug where `setup.sql` might create an extension but requires that extension to be loaded into `shared_preload_libraries`.  In order to support this I've added a `PG_CTL_OPTS` environment variable that can be used to configure `pg_ctl start` with additional options when starting the temporary database.

Multiple `-c` options can be defined in this variable.

[CH2032]