### PR TITLE
Refactor backrest examples to use deployments

### DIFF
--- a/examples/kube/backrest/async-archiving/backrest.json
+++ b/examples/kube/backrest/async-archiving/backrest.json
@@ -26,8 +26,8 @@
 }
 
 {
-    "kind": "Pod",
-    "apiVersion": "v1",
+    "kind": "Deployment",
+    "apiVersion": "extensions/v1beta1",
     "metadata": {
         "name": "backrest-async-archive",
         "labels": {
@@ -36,125 +36,149 @@
         }
     },
     "spec": {
-        "securityContext": {
-            $CCP_SECURITY_CONTEXT
-        },
-        "containers": [
-            {
-                "name": "backrest",
-                "securityContext": {
-                    "privileged": false
-                },
-                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
-                "readinessProbe": {
-                    "exec": {
-                        "command": [
-                            "/opt/cpm/bin/readiness.sh"
-                        ]
-                    },
-                    "initialDelaySeconds": 70,
-                    "timeoutSeconds": 1
-                },
-                "livenessProbe": {
-                    "exec": {
-                        "command": [
-                            "/opt/cpm/bin/liveness.sh"
-                        ]
-                    },
-                    "initialDelaySeconds": 70,
-                    "timeoutSeconds": 1
-                },
-                "ports": [
-                    {
-                        "containerPort": 5432,
-                        "protocol": "TCP"
-                    }
-                ],
-                "env": [
-                    {
-                        "name": "PG_PRIMARY_USER",
-                        "value": "primaryuser"
-                    },
-                    {
-                        "name": "PG_PRIMARY_PORT",
-                        "value": "5432"
-                    },
-                    {
-                        "name": "PG_MODE",
-                        "value": "primary"
-                    },
-                    {
-                        "name": "PG_PRIMARY_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "PGHOST",
-                        "value": "/tmp"
-                    },
-                    {
-                        "name": "PG_USER",
-                        "value": "testuser"
-                    },
-                    {
-                        "name": "PG_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "PG_DATABASE",
-                        "value": "userdb"
-                    },
-                    {
-                        "name": "PG_ROOT_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "ARCHIVE_TIMEOUT",
-                        "value": "60"
-                    },
-                    {
-                        "name": "PGBACKREST",
-                        "value": "true"
-                    },
-                    {
-                        "name": "PGBACKREST_ARCHIVE_ASYNC",
-                        "value": "y"
-                    },
-                    {
-                        "name": "PGBACKREST_PROCESS_MAX",
-                        "value": "3"
-                    },
-                    {
-                        "name": "PGBACKREST_COMPRESS_LEVEL",
-                        "value": "3"
-                    }
-                ],
-                "volumeMounts": [
-                    {
-                        "mountPath": "/pgdata",
-                        "name": "pgdata",
-                        "readOnly": false
-                    },
-                    {
-                        "mountPath": "/backrestrepo",
-                        "name": "backrestrepo",
-                        "readOnly": false
-                    }
-                ]
-            }
-        ],
-        "volumes": [
-            {
-                "name": "backrestrepo",
-                "persistentVolumeClaim": {
-                    "claimName": "br-aa-backups"
+        "replicas": 1,
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "backrest-async-archive",
+                    "cleanup": "$CCP_NAMESPACE-backrest-async-archive"
                 }
             },
-            {
-                "name": "pgdata",
-                "persistentVolumeClaim": {
-                    "claimName": "br-aa-pgdata"
+            "spec": {
+                "containers": [
+                    {
+                        "name": "backrest",
+                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                        "readinessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/opt/cpm/bin/readiness.sh"
+                                ]
+                            },
+                            "initialDelaySeconds": 40,
+                            "timeoutSeconds": 1
+                        },
+                        "livenessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/opt/cpm/bin/liveness.sh"
+                                ]
+                            },
+                            "initialDelaySeconds": 40,
+                            "timeoutSeconds": 1
+                        },
+                        "env": [
+                            {
+                                "name": "PG_PRIMARY_USER",
+                                "value": "primaryuser"
+                            },
+                            {
+                                "name": "PG_PRIMARY_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "PG_MODE",
+                                "value": "primary"
+                            },
+                            {
+                                "name": "PG_PRIMARY_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "PGHOST",
+                                "value": "/tmp"
+                            },
+                            {
+                                "name": "PG_USER",
+                                "value": "testuser"
+                            },
+                            {
+                                "name": "PG_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "PG_DATABASE",
+                                "value": "userdb"
+                            },
+                            {
+                                "name": "PG_ROOT_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "ARCHIVE_TIMEOUT",
+                                "value": "60"
+                            },
+                            {
+                                "name": "PGBACKREST",
+                                "value": "true"
+                            },
+                            {
+                                "name": "PGBACKREST_ARCHIVE_ASYNC",
+                                "value": "y"
+                            },
+                            {
+                                "name": "PGBACKREST_PROCESS_MAX",
+                                "value": "3"
+                            },
+                            {
+                                "name": "PGBACKREST_COMPRESS_LEVEL",
+                                "value": "3"
+                            },  
+                            {                         
+                                "name": "PGDATA_PATH_OVERRIDE",
+                                "value": "backrest-async-archive"
+                            }
+                        ],
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/pgdata",
+                                "name": "pgdata",
+                                "readOnly": false
+                            },
+                            {
+                                "mountPath": "/backrestrepo",
+                                "name": "backrestrepo",
+                                "readOnly": false
+                            }
+                        ],
+                        "ports": [
+                            {
+                                "containerPort": 5432,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {},
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "backrestrepo",
+                        "persistentVolumeClaim": {
+                            "claimName": "br-aa-backups"
+                        }
+                    },
+                    {
+                        "name": "pgdata",
+                        "persistentVolumeClaim": {
+                            "claimName": "br-aa-pgdata"
+                        }
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "securityContext": {
+                    $CCP_SECURITY_CONTEXT
                 }
             }
-        ]
+        },
+        "strategy": {
+            "type": "RollingUpdate",
+            "rollingUpdate": {
+                "maxUnavailable": 1,
+                "maxSurge": 1
+            }
+        }
     }
 }

--- a/examples/kube/backrest/backup/backrest.json
+++ b/examples/kube/backrest/backup/backrest.json
@@ -26,8 +26,8 @@
 }
 
 {
-    "kind": "Pod",
-    "apiVersion": "v1",
+    "kind": "Deployment",
+    "apiVersion": "extensions/v1beta1",
     "metadata": {
         "name": "backrest",
         "labels": {
@@ -36,131 +36,141 @@
         }
     },
     "spec": {
-        "securityContext": {
-            $CCP_SECURITY_CONTEXT
-        },
-        "containers": [
-            {
-                "name": "backrest",
-                "securityContext": {
-                    "privileged": false
-                },
-                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
-                "readinessProbe": {
-                    "exec": {
-                        "command": [
-                            "/opt/cpm/bin/readiness.sh"
-                        ]
-                    },
-                    "initialDelaySeconds": 70,
-                    "timeoutSeconds": 1
-                },
-                "livenessProbe": {
-                    "exec": {
-                        "command": [
-                            "/opt/cpm/bin/liveness.sh"
-                        ]
-                    },
-                    "initialDelaySeconds": 70,
-                    "timeoutSeconds": 1
-                },
-                "ports": [
+        "replicas": 1,
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "backrest",
+                    "cleanup": "$CCP_NAMESPACE-backrest"
+                }
+            },
+            "spec": {
+                "containers": [
                     {
-                        "containerPort": 5432,
-                        "protocol": "TCP"
+                        "name": "backrest",
+                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                        "readinessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/opt/cpm/bin/readiness.sh"
+                                ]
+                            },
+                            "initialDelaySeconds": 40,
+                            "timeoutSeconds": 1
+                        },
+                        "livenessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/opt/cpm/bin/liveness.sh"
+                                ]
+                            },
+                            "initialDelaySeconds": 40,
+                            "timeoutSeconds": 1
+                        },
+                        "env": [
+                            {
+                                "name": "PG_PRIMARY_USER",
+                                "value": "primaryuser"
+                            },
+                            {
+                                "name": "PG_PRIMARY_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "PG_MODE",
+                                "value": "primary"
+                            },
+                            {
+                                "name": "PG_PRIMARY_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "PGHOST",
+                                "value": "/tmp"
+                            },
+                            {
+                                "name": "PG_USER",
+                                "value": "testuser"
+                            },
+                            {
+                                "name": "PG_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "PG_DATABASE",
+                                "value": "userdb"
+                            },
+                            {
+                                "name": "PG_ROOT_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "ARCHIVE_TIMEOUT",
+                                "value": "60"
+                            },
+                            {
+                                "name": "PGBACKREST",
+                                "value": "true"
+                            },
+                            {
+                                "name": "PGBACKREST",
+                                "value": "true"
+                            },
+                            {
+                                "name": "PGDATA_PATH_OVERRIDE",
+                                "value": "backrest"
+                            }
+                        ],
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/pgdata",
+                                "name": "pgdata",
+                                "readOnly": false
+                            },
+                            {
+                                "mountPath": "/backrestrepo",
+                                "name": "backrestrepo",
+                                "readOnly": false
+                            }
+                        ],
+                        "ports": [
+                            {
+                                "containerPort": 5432,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {},
+                        "imagePullPolicy": "IfNotPresent"
                     }
                 ],
-                "env": [
+                "volumes": [
                     {
-                        "name": "PG_PRIMARY_USER",
-                        "value": "primaryuser"
-                    },
-                    {
-                        "name": "PG_PRIMARY_PORT",
-                        "value": "5432"
-                    },
-                    {
-                        "name": "PG_MODE",
-                        "value": "primary"
-                    },
-                    {
-                        "name": "PG_PRIMARY_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "PGHOST",
-                        "value": "/tmp"
-                    },
-                    {
-                        "name": "PG_USER",
-                        "value": "testuser"
-                    },
-                    {
-                        "name": "PG_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "PG_DATABASE",
-                        "value": "userdb"
-                    },
-                    {
-                        "name": "PG_ROOT_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "ARCHIVE_TIMEOUT",
-                        "value": "60"
-                    },
-                    {
-                        "name": "PGBACKREST",
-                        "value": "true"
-                    }
-                ],
-                "volumeMounts": [
-                    {
-                        "mountPath": "/pgdata",
-                        "name": "pgdata",
-                        "readOnly": false
-                    },
-                    {
-                        "mountPath": "/backup",
-                        "name": "backup",
-                        "readOnly": true
-                    },
-                    {
-                        "mountPath": "/pgconf",
-                        "name": "pgconf",
-                        "readOnly": true
-                    },
-                    {
-                        "mountPath": "/backrestrepo",
                         "name": "backrestrepo",
-                        "readOnly": false
+                        "persistentVolumeClaim": {
+                            "claimName": "br-backups"
+                        }
+                    },
+                    {
+                        "name": "pgdata",
+                        "persistentVolumeClaim": {
+                            "claimName": "br-pgdata"
+                        }
                     }
-                ]
-            }
-        ],
-        "volumes": [
-            {
-                "name": "pgconf",
-                "emptyDir": {}
-            },
-            {
-                "name": "backrestrepo",
-                "persistentVolumeClaim": {
-                    "claimName": "br-backups"
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "securityContext": {
+                    $CCP_SECURITY_CONTEXT
                 }
-            },
-            {
-                "name": "pgdata",
-                "persistentVolumeClaim": {
-                    "claimName": "br-pgdata"
-                }
-            },
-            {
-                "name": "backup",
-                "emptyDir": {}
             }
-        ]
+        },
+        "strategy": {
+            "type": "RollingUpdate",
+            "rollingUpdate": {
+                "maxUnavailable": 1,
+                "maxSurge": 1
+            }
+        }
     }
 }

--- a/examples/kube/backrest/delta/backrest-restored.json
+++ b/examples/kube/backrest/delta/backrest-restored.json
@@ -18,7 +18,7 @@
             }
         ],
         "selector": {
-            "name": "backrest-env"
+            "name": "backrest-delta-restored"
         },
         "type": "ClusterIP",
         "sessionAffinity": "None"
@@ -26,8 +26,8 @@
 }
 
 {
-    "kind": "Pod",
-    "apiVersion": "v1",
+    "kind": "Deployment",
+    "apiVersion": "extensions/v1beta1",
     "metadata": {
         "name": "backrest-delta-restored",
         "labels": {
@@ -36,122 +36,145 @@
         }
     },
     "spec": {
-        "securityContext": {
-            $CCP_SECURITY_CONTEXT
-        },
-        "containers": [
-            {
-                "name": "backrest",
-                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
-                "readinessProbe": {
-                    "exec": {
-                        "command": [
-                            "/opt/cpm/bin/readiness.sh"
-                        ]
-                    },
-                    "initialDelaySeconds": 40,
-                    "timeoutSeconds": 1
-                },
-                "livenessProbe": {
-                    "exec": {
-                        "command": [
-                            "/opt/cpm/bin/liveness.sh"
-                        ]
-                    },
-                    "initialDelaySeconds": 40,
-                    "timeoutSeconds": 1
-                },
-                "ports": [
-                    {
-                        "containerPort": 5432,
-                        "protocol": "TCP"
-                    }
-                ],
-                "env": [
-                    {
-                        "name": "PG_PRIMARY_USER",
-                        "value": "primaryuser"
-                    },
-                    {
-                        "name": "PG_PRIMARY_PORT",
-                        "value": "5432"
-                    },
-                    {
-                        "name": "PG_MODE",
-                        "value": "primary"
-                    },
-                    {
-                        "name": "PG_PRIMARY_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "PGHOST",
-                        "value": "/tmp"
-                    },
-                    {
-                        "name": "PG_USER",
-                        "value": "testuser"
-                    },
-                    {
-                        "name": "PG_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "PG_DATABASE",
-                        "value": "userdb"
-                    },
-                    {
-                        "name": "PG_ROOT_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "ARCHIVE_TIMEOUT",
-                        "value": "60"
-                    },
-                    {
-                        "name": "PGBACKREST",
-                        "value": "true"
-                    },
-                    {
-                        "name": "PGBACKREST_PG1_PATH",
-                        "value": "/pgdata/backrest"
-                    },
-                    {
-                        "name": "PGBACKREST_REPO1_PATH",
-                        "value": "/backrestrepo/backrest-backups"
-                    },
-                    {
-                        "name": "PGDATA_PATH_OVERRIDE",
-                        "value": "backrest"
-                    }
-                ],
-                "volumeMounts": [
-                    {
-                        "mountPath": "/pgdata",
-                        "name": "pgdata",
-                        "readOnly": false
-                    },
-                    {
-                        "mountPath": "/backrestrepo",
-                        "name": "backrestrepo",
-                        "readOnly": false
-                    }
-                ]
-            }
-        ],
-        "volumes": [
-            {
-                "name": "backrestrepo",
-                "persistentVolumeClaim": {
-                    "claimName": "br-backups"
+        "replicas": 1,
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "backrest-delta-restored",
+                    "cleanup": "$CCP_NAMESPACE-backrest-delta-restore"
                 }
             },
-            {
-                "name": "pgdata",
-                "persistentVolumeClaim": {
-                    "claimName": "br-pgdata"
+            "spec": {
+                "containers": [
+                    {
+                        "name": "backrest",
+                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                        "readinessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/opt/cpm/bin/readiness.sh"
+                                ]
+                            },
+                            "initialDelaySeconds": 40,
+                            "timeoutSeconds": 1
+                        },
+                        "livenessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/opt/cpm/bin/liveness.sh"
+                                ]
+                            },
+                            "initialDelaySeconds": 40,
+                            "timeoutSeconds": 1
+                        },
+                        "env": [
+                            {
+                                "name": "PG_PRIMARY_USER",
+                                "value": "primaryuser"
+                            },
+                            {
+                                "name": "PG_PRIMARY_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "PG_MODE",
+                                "value": "primary"
+                            },
+                            {
+                                "name": "PG_PRIMARY_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "PGHOST",
+                                "value": "/tmp"
+                            },
+                            {
+                                "name": "PG_USER",
+                                "value": "testuser"
+                            },
+                            {
+                                "name": "PG_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "PG_DATABASE",
+                                "value": "userdb"
+                            },
+                            {
+                                "name": "PG_ROOT_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "ARCHIVE_TIMEOUT",
+                                "value": "60"
+                            },
+                            {
+                                "name": "PGBACKREST",
+                                "value": "true"
+                            },
+                            {
+                                "name": "PGBACKREST_PG1_PATH",
+                                "value": "/pgdata/backrest"
+                            },
+                            {
+                                "name": "PGBACKREST_REPO1_PATH",
+                                "value": "/backrestrepo/backrest-backups"
+                            },
+                            {
+                                "name": "PGDATA_PATH_OVERRIDE",
+                                "value": "backrest"
+                            }
+                        ],
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/pgdata",
+                                "name": "pgdata",
+                                "readOnly": false
+                            },
+                            {
+                                "mountPath": "/backrestrepo",
+                                "name": "backrestrepo",
+                                "readOnly": false
+                            }
+                        ],
+                        "ports": [
+                            {
+                                "containerPort": 5432,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {},
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "backrestrepo",
+                        "persistentVolumeClaim": {
+                            "claimName": "br-backups"
+                        }
+                    },
+                    {
+                        "name": "pgdata",
+                        "persistentVolumeClaim": {
+                            "claimName": "br-pgdata"
+                        }
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "securityContext": {
+                    $CCP_SECURITY_CONTEXT
                 }
             }
-        ]
+        },
+        "strategy": {
+            "type": "RollingUpdate",
+            "rollingUpdate": {
+                "maxUnavailable": 1,
+                "maxSurge": 1
+            }
+        }
     }
 }

--- a/examples/kube/backrest/delta/cleanup.sh
+++ b/examples/kube/backrest/delta/cleanup.sh
@@ -18,6 +18,6 @@ echo_info "Cleaning up.."
 cleanup "$CCP_NAMESPACE-backrest-delta-restore"
 
 # Cleanup backrest pods if they're running from backup examples
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod,service backrest
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment,service backrest
 
 $CCPROOT/examples/waitforterm.sh backrest-delta-restored ${CCP_CLI?}

--- a/examples/kube/backrest/delta/run.sh
+++ b/examples/kube/backrest/delta/run.sh
@@ -22,7 +22,9 @@ then
     exit 1
 fi
 
-${CCP_CLI?} exec --namespace=${CCP_NAMESPACE?} -ti backrest date >/dev/null
+pod=$(${CCP_CLI?} get pods --namespace=${CCP_NAMESPACE?} --no-headers -l name=backrest | awk '{print $1}')
+
+${CCP_CLI?} exec --namespace=${CCP_NAMESPACE?} -ti ${pod?} date >/dev/null
 if [[ $? -ne 0 ]]
 then
     echo_err "The backup example must be running prior to using this example."
@@ -32,6 +34,6 @@ fi
 ${DIR}/cleanup.sh
 
 # Cleanup backrest pods if they're running from backup examples
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod,service backrest
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment,service backrest
 
 expenv -f $DIR/delta-restore.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/examples/kube/backrest/full/backrest-restored.json
+++ b/examples/kube/backrest/full/backrest-restored.json
@@ -26,8 +26,8 @@
 }
 
 {
-    "kind": "Pod",
-    "apiVersion": "v1",
+    "kind": "Deployment",
+    "apiVersion": "extensions/v1beta1",
     "metadata": {
         "name": "backrest-full-restored",
         "labels": {
@@ -36,114 +36,141 @@
         }
     },
     "spec": {
-        "securityContext": {
-            $CCP_SECURITY_CONTEXT
-        },
-        "containers": [
-            {
-                "name": "backrest",
-                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
-                "readinessProbe": {
-                    "exec": {
-                        "command": [
-                            "/opt/cpm/bin/readiness.sh"
-                        ]
-                    },
-                    "initialDelaySeconds": 40,
-                    "timeoutSeconds": 1
-                },
-                "livenessProbe": {
-                    "exec": {
-                        "command": [
-                            "/opt/cpm/bin/liveness.sh"
-                        ]
-                    },
-                    "initialDelaySeconds": 40,
-                    "timeoutSeconds": 1
-                },
-                "ports": [
-                    {
-                        "containerPort": 5432,
-                        "protocol": "TCP"
-                    }
-                ],
-                "env": [
-                    {
-                        "name": "PG_PRIMARY_USER",
-                        "value": "primaryuser"
-                    },
-                    {
-                        "name": "PG_PRIMARY_PORT",
-                        "value": "5432"
-                    },
-                    {
-                        "name": "PG_MODE",
-                        "value": "primary"
-                    },
-                    {
-                        "name": "PG_PRIMARY_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "PGHOST",
-                        "value": "/tmp"
-                    },
-                    {
-                        "name": "PG_USER",
-                        "value": "testuser"
-                    },
-                    {
-                        "name": "PG_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "PG_DATABASE",
-                        "value": "userdb"
-                    },
-                    {
-                        "name": "PG_ROOT_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "ARCHIVE_TIMEOUT",
-                        "value": "60"
-                    },
-                    {
-                        "name": "PGBACKREST",
-                        "value": "true"
-                    },
-                    {
-                        "name": "PGBACKREST_REPO1_PATH",
-                        "value": "/backrestrepo/backrest-backups"
-                    }
-                ],
-                "volumeMounts": [
-                    {
-                        "mountPath": "/pgdata",
-                        "name": "pgdata",
-                        "readOnly": false
-                    },
-                    {
-                        "mountPath": "/backrestrepo",
-                        "name": "backrestrepo",
-                        "readOnly": false
-                    }
-                ]
-            }
-        ],
-        "volumes": [
-            {
-                "name": "backrestrepo",
-                "persistentVolumeClaim": {
-                    "claimName": "br-backups"
+        "replicas": 1,
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "backrest-full-restored",
+                    "cleanup": "$CCP_NAMESPACE-backrest-full-restore"
                 }
             },
-            {
-                "name": "pgdata",
-                "persistentVolumeClaim": {
-                    "claimName": "br-new-pgdata"
+            "spec": {
+                "containers": [
+                    {
+                        "name": "backrest",
+                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                        "readinessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/opt/cpm/bin/readiness.sh"
+                                ]
+                            },
+                            "initialDelaySeconds": 40,
+                            "timeoutSeconds": 1
+                        },
+                        "livenessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/opt/cpm/bin/liveness.sh"
+                                ]
+                            },
+                            "initialDelaySeconds": 40,
+                            "timeoutSeconds": 1
+                        },
+                        "env": [
+                            {
+                                "name": "PG_PRIMARY_USER",
+                                "value": "primaryuser"
+                            },
+                            {
+                                "name": "PG_PRIMARY_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "PG_MODE",
+                                "value": "primary"
+                            },
+                            {
+                                "name": "PG_PRIMARY_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "PGHOST",
+                                "value": "/tmp"
+                            },
+                            {
+                                "name": "PG_USER",
+                                "value": "testuser"
+                            },
+                            {
+                                "name": "PG_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "PG_DATABASE",
+                                "value": "userdb"
+                            },
+                            {
+                                "name": "PG_ROOT_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "ARCHIVE_TIMEOUT",
+                                "value": "60"
+                            },
+                            {
+                                "name": "PGBACKREST",
+                                "value": "true"
+                            },
+                            {
+                                "name": "PGBACKREST_REPO1_PATH",
+                                "value": "/backrestrepo/backrest-backups"
+                            },
+                            {
+                                "name": "PGDATA_PATH_OVERRIDE",
+                                "value": "backrest-full-restored"
+                            }
+                        ],
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/pgdata",
+                                "name": "pgdata",
+                                "readOnly": false
+                            },
+                            {
+                                "mountPath": "/backrestrepo",
+                                "name": "backrestrepo",
+                                "readOnly": false
+                            }
+                        ],
+                        "ports": [
+                            {
+                                "containerPort": 5432,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {},
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "backrestrepo",
+                        "persistentVolumeClaim": {
+                            "claimName": "br-backups"
+                        }
+                    },
+                    {
+                        "name": "pgdata",
+                        "persistentVolumeClaim": {
+                            "claimName": "br-new-pgdata"
+                        }
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "securityContext": {
+                    $CCP_SECURITY_CONTEXT
                 }
             }
-        ]
+        },
+        "strategy": {
+            "type": "RollingUpdate",
+            "rollingUpdate": {
+                "maxUnavailable": 1,
+                "maxSurge": 1
+            }
+        }
     }
 }

--- a/examples/kube/backrest/full/cleanup.sh
+++ b/examples/kube/backrest/full/cleanup.sh
@@ -17,7 +17,7 @@ echo_info "Cleaning up.."
 
 cleanup "$CCP_NAMESPACE-backrest-full-restore"
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod,service backrest 
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment,service backrest 
 
 $CCPROOT/examples/waitforterm.sh backrest-full-restored ${CCP_CLI?}
 

--- a/examples/kube/backrest/full/run.sh
+++ b/examples/kube/backrest/full/run.sh
@@ -16,7 +16,9 @@ source ${CCPROOT}/examples/common.sh
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-${CCP_CLI?} exec --namespace=${CCP_NAMESPACE?} -ti backrest date >/dev/null
+pod=$(${CCP_CLI?} get pods --namespace=${CCP_NAMESPACE?} --no-headers -l name=backrest | awk '{print $1}')
+
+${CCP_CLI?} exec --namespace=${CCP_NAMESPACE?} -ti ${pod?} date >/dev/null
 if [[ $? -ne 0 ]]
 then
     echo_err "The backup example must be running prior to using this example."

--- a/examples/kube/backrest/pitr/backrest-restored.json
+++ b/examples/kube/backrest/pitr/backrest-restored.json
@@ -18,7 +18,7 @@
             }
         ],
         "selector": {
-            "name": "backrest"
+            "name": "backrest-pitr-restored"
         },
         "type": "ClusterIP",
         "sessionAffinity": "None"
@@ -26,8 +26,8 @@
 }
 
 {
-    "kind": "Pod",
-    "apiVersion": "v1",
+    "kind": "Deployment",
+    "apiVersion": "extensions/v1beta1",
     "metadata": {
         "name": "backrest-pitr-restored",
         "labels": {
@@ -36,114 +36,141 @@
         }
     },
     "spec": {
-        "securityContext": {
-            $CCP_SECURITY_CONTEXT
-        },
-        "containers": [
-            {
-                "name": "backrest",
-                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
-                "readinessProbe": {
-                    "exec": {
-                        "command": [
-                            "/opt/cpm/bin/readiness.sh"
-                        ]
-                    },
-                    "initialDelaySeconds": 40,
-                    "timeoutSeconds": 1
-                },
-                "livenessProbe": {
-                    "exec": {
-                        "command": [
-                            "/opt/cpm/bin/liveness.sh"
-                        ]
-                    },
-                    "initialDelaySeconds": 40,
-                    "timeoutSeconds": 1
-                },
-                "ports": [
-                    {
-                        "containerPort": 5432,
-                        "protocol": "TCP"
-                    }
-                ],
-                "env": [
-                    {
-                        "name": "PG_PRIMARY_USER",
-                        "value": "primaryuser"
-                    },
-                    {
-                        "name": "PG_PRIMARY_PORT",
-                        "value": "5432"
-                    },
-                    {
-                        "name": "PG_MODE",
-                        "value": "primary"
-                    },
-                    {
-                        "name": "PG_PRIMARY_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "PGHOST",
-                        "value": "/tmp"
-                    },
-                    {
-                        "name": "PG_USER",
-                        "value": "testuser"
-                    },
-                    {
-                        "name": "PG_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "PG_DATABASE",
-                        "value": "userdb"
-                    },
-                    {
-                        "name": "PG_ROOT_PASSWORD",
-                        "value": "password"
-                    },
-                    {
-                        "name": "ARCHIVE_TIMEOUT",
-                        "value": "60"
-                    },
-                    {
-                        "name": "PGBACKREST",
-                        "value": "true"
-                    },
-                    {
-                        "name": "PGBACKREST_REPO1_PATH",
-                        "value": "/backrestrepo/backrest-backups"
-                    }
-                ],
-                "volumeMounts": [
-                    {
-                        "mountPath": "/pgdata",
-                        "name": "pgdata",
-                        "readOnly": false
-                    },
-                    {
-                        "mountPath": "/backrestrepo",
-                        "name": "backrestrepo",
-                        "readOnly": false
-                    }
-                ]
-            }
-        ],
-        "volumes": [
-            {
-                "name": "backrestrepo",
-                "persistentVolumeClaim": {
-                    "claimName": "br-backups"
+        "replicas": 1,
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "backrest-pitr-restored",
+                    "cleanup": "$CCP_NAMESPACE-backrest-pitr-restore"
                 }
             },
-            {
-                "name": "pgdata",
-                "persistentVolumeClaim": {
-                    "claimName": "br-pgdata"
+            "spec": {
+                "containers": [
+                    {
+                        "name": "backrest",
+                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                        "readinessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/opt/cpm/bin/readiness.sh"
+                                ]
+                            },
+                            "initialDelaySeconds": 40,
+                            "timeoutSeconds": 1
+                        },
+                        "livenessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/opt/cpm/bin/liveness.sh"
+                                ]
+                            },
+                            "initialDelaySeconds": 40,
+                            "timeoutSeconds": 1
+                        },
+                        "env": [
+                            {
+                                "name": "PG_PRIMARY_USER",
+                                "value": "primaryuser"
+                            },
+                            {
+                                "name": "PG_PRIMARY_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "PG_MODE",
+                                "value": "primary"
+                            },
+                            {
+                                "name": "PG_PRIMARY_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "PGHOST",
+                                "value": "/tmp"
+                            },
+                            {
+                                "name": "PG_USER",
+                                "value": "testuser"
+                            },
+                            {
+                                "name": "PG_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "PG_DATABASE",
+                                "value": "userdb"
+                            },
+                            {
+                                "name": "PG_ROOT_PASSWORD",
+                                "value": "password"
+                            },
+                            {
+                                "name": "ARCHIVE_TIMEOUT",
+                                "value": "60"
+                            },
+                            {
+                                "name": "PGBACKREST",
+                                "value": "true"
+                            },
+                            {
+                                "name": "PGBACKREST_REPO1_PATH",
+                                "value": "/backrestrepo/backrest-backups"
+                            },
+                            {
+                                "name": "PGDATA_PATH_OVERRIDE",
+                                "value": "backrest"
+                            }
+                        ],
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/pgdata",
+                                "name": "pgdata",
+                                "readOnly": false
+                            },
+                            {
+                                "mountPath": "/backrestrepo",
+                                "name": "backrestrepo",
+                                "readOnly": false
+                            }
+                        ],
+                        "ports": [
+                            {
+                                "containerPort": 5432,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {},
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "backrestrepo",
+                        "persistentVolumeClaim": {
+                            "claimName": "br-backups"
+                        }
+                    },
+                    {
+                        "name": "pgdata",
+                        "persistentVolumeClaim": {
+                            "claimName": "br-pgdata"
+                        }
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "securityContext": {
+                    $CCP_SECURITY_CONTEXT
                 }
             }
-        ]
+        },
+        "strategy": {
+            "type": "RollingUpdate",
+            "rollingUpdate": {
+                "maxUnavailable": 1,
+                "maxSurge": 1
+            }
+        }
     }
 }

--- a/examples/kube/backrest/pitr/cleanup.sh
+++ b/examples/kube/backrest/pitr/cleanup.sh
@@ -17,6 +17,6 @@ echo_info "Cleaning up.."
 
 cleanup "$CCP_NAMESPACE-backrest-pitr-restore"
 
-${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} pod,service backrest
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} deployment,service backrest
 
 $CCPROOT/examples/waitforterm.sh backrest-pitr-restored ${CCP_CLI?}

--- a/examples/kube/backrest/pitr/run.sh
+++ b/examples/kube/backrest/pitr/run.sh
@@ -22,7 +22,9 @@ then
     exit 1
 fi
 
-${CCP_CLI?} exec --namespace=${CCP_NAMESPACE?} -ti backrest date >/dev/null
+pod=$(${CCP_CLI?} get pods --namespace=${CCP_NAMESPACE?} --no-headers -l name=backrest | awk '{print $1}')
+
+${CCP_CLI?} exec --namespace=${CCP_NAMESPACE?} -ti ${pod?} date >/dev/null
 if [[ $? -ne 0 ]]
 then
     echo_err "The backup example must be running prior to using this example."

--- a/hugo/content/container-specifications/crunchy-backrest-restore.md
+++ b/hugo/content/container-specifications/crunchy-backrest-restore.md
@@ -33,7 +33,7 @@ The crunchy-backrest-restore Docker image contains the following packages (versi
 ### Optional
 **Name**|**Default**|**Description**
 :-----|:-----|:-----
-**PGBACKREST_DELTA **|None|Enables pgBackRest delta restore mode.  Used when a user needs to restore to a volume that already contains PostgreSQL data files.
+**PGBACKREST_DELTA**|None|Enables pgBackRest delta restore mode.  Used when a user needs to restore to a volume that already contains PostgreSQL data files.
 **PGBACKREST_TARGET**|None|PostgreSQL timestamp used when restoring up to a point in time. Required for Point In Time Recovery (PITR) restores.
 **PGBACKREST_PG1_PATH**|None|Path where PostgreSQL data directory can be found.  This variable can also be used to setup a new PostgreSQL data directory on an empty volume.
 **BACKREST_CUSTOM_OPTS**|None|Custom pgBackRest options can be added here to customize pgBackRest restores.


### PR DESCRIPTION
Refactored backrest examples to use deployments to fix test cases in the harness on OCP.  Additionally update the documentation to reflect this.

[CH349]
[CH2103]