### PR TITLE
Add env to disable Grafana dashboard installs

### DIFF
--- a/hugo/content/container-specifications/crunchy-grafana.md
+++ b/hugo/content/container-specifications/crunchy-grafana.md
@@ -50,6 +50,7 @@ The crunchy-grafana Docker image contains the following packages:
 ### Optional
 **Name**|**Default**|**Description**
 :-----|:-----|:-----
+**INSTALL_DASHBOARDS**|true|Set this option to false to prevent the Grafana container from installing the preinstalled pgMonitor PostgreSQL dashboards.
 **PROM_USER**|5s|Specifies the Prometheus username, if one is required.
 **PROM_PASS**|5s|Specifies the Prometheus password, if one is required.
 **CRUNCHY_DEBUG**|FALSE|Set this to true to enable debugging in logs. Note: this mode can reveal secrets in logs.


### PR DESCRIPTION
Deleting provisioned dashboards is not possible because they're baked into the container image.  As a compromise I added `INSTALL_DASHBOARDS=false` environment variable which prevents the dashboards from being installed and cleans up any that have been previously installed.

[CH1899]