### PR TITLE
Lock in pgBackRest Version Number at v2.08

### DIFF
--- a/centos7/10/Dockerfile.backrest-restore.centos7
+++ b/centos7/10/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm" BACKREST_VERSION="2.08"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -27,7 +27,7 @@ RUN yum -y update && yum -y install epel-release \
  && yum -y clean all
 
 RUN yum -y install postgresql10-server  \
- && yum -y install pgbackrest \
+ && yum -y install pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/10/Dockerfile.postgres-gis.centos7
+++ b/centos7/10/Dockerfile.postgres-gis.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres-gis" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm" BACKREST_VERSION="2.08"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -28,7 +28,7 @@ RUN yum -y update && yum -y install epel-release \
  && yum -y install postgresql10-server postgresql10-contrib postgresql10 \
     R-core libRmath plr10 \
     pgaudit12_10 \
-    pgbackrest \
+    pgbackrest-"${BACKREST_VERSION}" \
     postgis24_10 postgis24_10-client \
  && yum -y clean all
 

--- a/centos7/10/Dockerfile.postgres.centos7
+++ b/centos7/10/Dockerfile.postgres.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm" BACKREST_VERSION="2.08"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -29,7 +29,7 @@ RUN yum -y update \
     psmisc openssh-server openssh-clients \
  && yum -y install postgresql10-server postgresql10-contrib postgresql10 \
     pgaudit12_10 \
-    pgbackrest \
+    pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/11/Dockerfile.backrest-restore.centos7
+++ b/centos7/11/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.08"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -27,7 +27,7 @@ RUN yum -y update && yum -y install epel-release \
  && yum -y clean all
 
 RUN yum -y install postgresql11-server  \
- && yum -y install pgbackrest \
+ && yum -y install pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/11/Dockerfile.postgres-gis.centos7
+++ b/centos7/11/Dockerfile.postgres-gis.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres-gis" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.08"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -28,7 +28,7 @@ RUN yum -y update && yum -y install epel-release \
  && yum -y install postgresql11-server postgresql11-contrib postgresql11 \
     R-core libRmath plr11 \
     pgaudit13_11 \
-    pgbackrest \
+    pgbackrest-"${BACKREST_VERSION}" \
     postgis24_11 postgis24_11-client \
  && yum -y clean all
 

--- a/centos7/11/Dockerfile.postgres.centos7
+++ b/centos7/11/Dockerfile.postgres.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.08"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -29,7 +29,7 @@ RUN yum -y update \
     psmisc openssh-server openssh-clients \
  && yum -y install postgresql11-server postgresql11-contrib postgresql11 \
     pgaudit13_11 \
-    pgbackrest \
+    pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/9.5/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.5/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm" BACKREST_VERSION="2.08"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -27,7 +27,7 @@ RUN yum -y update && yum -y install epel-release \
  && yum -y clean all
 
 RUN yum -y install postgresql95-server \
- && yum -y install pgbackrest \
+ && yum -y install pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/9.5/Dockerfile.postgres-gis.centos7
+++ b/centos7/9.5/Dockerfile.postgres-gis.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres-gis" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm" BACKREST_VERSION="2.08"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -28,7 +28,7 @@ RUN yum -y update && yum -y install epel-release \
  && yum -y install postgresql95-server postgresql95-contrib postgresql95 \
     R-core libRmath plr95 \
     pgaudit_95 \
-    pgbackrest \
+    pgbackrest-"${BACKREST_VERSION}" \
     postgis22_95 postgis22_95-client  \
  && yum -y clean all
 

--- a/centos7/9.5/Dockerfile.postgres.centos7
+++ b/centos7/9.5/Dockerfile.postgres.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm" BACKREST_VERSION="2.08"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -28,7 +28,7 @@ RUN yum -y update && yum -y install epel-release \
     psmisc openssh-server openssh-clients \
  && yum -y install postgresql95-server postgresql95-contrib postgresql95 \
     pgaudit_95 \
-    pgbackrest \
+    pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/9.6/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.6/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm" BACKREST_VERSION="2.08"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -27,7 +27,7 @@ RUN yum -y update && yum -y install epel-release \
  && yum -y clean all
 
 RUN yum -y install postgresql96-server  \
- && yum -y install pgbackrest \
+ && yum -y install pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/9.6/Dockerfile.postgres-gis.centos7
+++ b/centos7/9.6/Dockerfile.postgres-gis.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres-gis" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm" BACKREST_VERSION="2.08"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -28,7 +28,7 @@ RUN yum -y update && yum -y install epel-release \
  && yum -y install postgresql96-server postgresql96-contrib postgresql96 \
     R-core libRmath plr96 \
     pgaudit_96 \
-    pgbackrest \
+    pgbackrest-"${BACKREST_VERSION}" \
     postgis23_96 postgis23_96-client \
  && yum -y clean all
 

--- a/centos7/9.6/Dockerfile.postgres.centos7
+++ b/centos7/9.6/Dockerfile.postgres.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm" BACKREST_VERSION="2.08"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -28,7 +28,7 @@ RUN yum -y update && yum -y install epel-release \
     psmisc openssh-server openssh-clients \
  && yum -y install postgresql96-server postgresql96-contrib postgresql96 \
     pgaudit_96 \
-    pgbackrest \
+    pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/examples/kube/backrest/async-archiving/backrest.json
+++ b/examples/kube/backrest/async-archiving/backrest.json
@@ -48,7 +48,7 @@
                 "containers": [
                     {
                         "name": "backrest",
-                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
                         "readinessProbe": {
                             "exec": {
                                 "command": [

--- a/examples/kube/backrest/backup/backrest.json
+++ b/examples/kube/backrest/backup/backrest.json
@@ -48,7 +48,7 @@
                 "containers": [
                     {
                         "name": "backrest",
-                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
                         "readinessProbe": {
                             "exec": {
                                 "command": [

--- a/examples/kube/backrest/delta/backrest-restored.json
+++ b/examples/kube/backrest/delta/backrest-restored.json
@@ -48,7 +48,7 @@
                 "containers": [
                     {
                         "name": "backrest",
-                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
                         "readinessProbe": {
                             "exec": {
                                 "command": [

--- a/examples/kube/backrest/full/backrest-restored.json
+++ b/examples/kube/backrest/full/backrest-restored.json
@@ -48,7 +48,7 @@
                 "containers": [
                     {
                         "name": "backrest",
-                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
                         "readinessProbe": {
                             "exec": {
                                 "command": [

--- a/examples/kube/backrest/pitr/backrest-restored.json
+++ b/examples/kube/backrest/pitr/backrest-restored.json
@@ -48,7 +48,7 @@
                 "containers": [
                     {
                         "name": "backrest",
-                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG",
+                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres$CCP_PG_IMAGE:$CCP_IMAGE_TAG",
                         "readinessProbe": {
                             "exec": {
                                 "command": [

--- a/rhel7/10/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/10/Dockerfile.backrest-restore.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/backrestrestore/help.1 /help.1
 COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="10"
+ENV PGVERSION="10" BACKREST_VERSION="2.08"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /
@@ -40,7 +40,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 
 # Doing these separately so postgres user exists when crunchy-backrest is installed.
 RUN yum -y install postgresql10-server  && \
-    yum -y install crunchy-backrest \
+    yum -y install crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/rhel7/10/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/10/Dockerfile.postgres-gis.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/postgres-gis/help.1 /help.1
 COPY conf/atomic/postgres-gis/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="10"
+ENV PGVERSION="10" BACKREST_VERSION="2.08"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf
@@ -45,7 +45,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y install postgresql10 postgresql10-contrib postgresql10-server \
     pgaudit10 pgaudit10_set_user \
     plr10 postgis24_10 postgis24_10-client pgrouting_10 \
- && yum -y install crunchy-backrest \
+ && yum -y install crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y --setopt=tsflags='' install pgaudit_analyze \
  && yum -y clean all
 

--- a/rhel7/10/Dockerfile.postgres.rhel7
+++ b/rhel7/10/Dockerfile.postgres.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/postgres/help.1 /help.1
 COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="10"
+ENV PGVERSION="10" BACKREST_VERSION="2.08"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf
@@ -43,7 +43,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y reinstall glibc-common \
  && yum -y install postgresql10 postgresql10-contrib postgresql10-server \
     pgaudit10 pgaudit10_set_user \
- && yum -y install crunchy-backrest \
+ && yum -y install crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y --setopt=tsflags='' install pgaudit_analyze \
  && yum -y clean all
 

--- a/rhel7/11/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/11/Dockerfile.backrest-restore.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/backrestrestore/help.1 /help.1
 COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="11"
+ENV PGVERSION="11" BACKREST_VERSION="2.08"
 
 # Crunchy Postgres repo
 ADD conf/RPM-GPG-KEY-crunchydata  /
@@ -39,7 +39,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y clean all
 
 RUN yum -y install postgresql11-server  \
- && yum -y install crunchy-backrest \
+ && yum -y install crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/rhel7/11/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/11/Dockerfile.postgres-gis.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/postgres-gis/help.1 /help.1
 COPY conf/atomic/postgres-gis/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="11"
+ENV PGVERSION="11" BACKREST_VERSION="2.08"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf
@@ -44,7 +44,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y reinstall glibc-common \
  && yum -y install postgresql11 postgresql11-contrib postgresql11-server \
     pgaudit11 pgaudit11_set_user \
-    crunchy-backrest plr11 \
+    crunchy-backrest-"${BACKREST_VERSION}" plr11 \
     postgis24_11 postgis24_11-client pgrouting_11 \
  && yum -y --setopt=tsflags='' install pgaudit_analyze \
  && yum -y clean all

--- a/rhel7/11/Dockerfile.postgres.rhel7
+++ b/rhel7/11/Dockerfile.postgres.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/postgres/help.1 /help.1
 COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="11"
+ENV PGVERSION="11" BACKREST_VERSION="2.08"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf
@@ -43,7 +43,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y reinstall glibc-common \
  && yum -y install postgresql11 postgresql11-contrib postgresql11-server \
     pgaudit11 pgaudit11_set_user \
- && yum -y install crunchy-backrest \
+ && yum -y install crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y --setopt=tsflags='' install pgaudit_analyze \
  && yum -y clean all
 

--- a/rhel7/9.5/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.5/Dockerfile.backrest-restore.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/backrestrestore/help.1 /help.1
 COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="9.5"
+ENV PGVERSION="9.5" BACKREST_VERSION="2.08"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /
@@ -39,7 +39,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y clean all
 
 RUN yum -y install postgresql95-server  \
- && yum -y install crunchy-backrest \
+ && yum -y install crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/rhel7/9.5/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres-gis.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/postgres-gis/help.1 /help.1
 COPY conf/atomic/postgres-gis/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="9.5"
+ENV PGVERSION="9.5" BACKREST_VERSION="2.08"
 
 # PGDG Postgres repo
 #RUN rpm -Uvh http://yum.postgresql.org/9.5/redhat/rhel-7-x86_64/pgdg-redhat95-9.5-3.noarch.rpm
@@ -47,7 +47,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y reinstall glibc-common \
  && yum -y install postgresql95 postgresql95-contrib postgresql95-server \
     pgaudit95 pgaudit95_set_user \
-    crunchy-backrest \
+    crunchy-backrest-"${BACKREST_VERSION}" \
     postgis22_95 postgis22_95-client pgrouting_95 plr95 \
  && yum -y --setopt=tsflags='' install pgaudit_analyze \
  && yum -y clean all

--- a/rhel7/9.5/Dockerfile.postgres.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/postgres/help.1 /help.1
 COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="9.5"
+ENV PGVERSION="9.5" BACKREST_VERSION="2.08"
 
 # PGDG Postgres repo
 #RUN rpm -Uvh http://yum.postgresql.org/9.5/redhat/rhel-7-x86_64/pgdg-redhat95-9.5-3.noarch.rpm
@@ -46,7 +46,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y reinstall glibc-common \
  && yum -y install postgresql95 postgresql95-contrib postgresql95-server \
     pgaudit95 pgaudit95_set_user \
-    crunchy-backrest \
+    crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y --setopt=tsflags='' install pgaudit_analyze \
  && yum -y clean all
 

--- a/rhel7/9.6/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.6/Dockerfile.backrest-restore.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/backrestrestore/help.1 /help.1
 COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="9.6"
+ENV PGVERSION="9.6" BACKREST_VERSION="2.08"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /
@@ -40,7 +40,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 
 # Doing these separately so postgres user exists when crunchy-backrest is installed.
 RUN yum -y install postgresql96-server &&  \
-    yum -y install crunchy-backrest \
+    yum -y install crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/rhel7/9.6/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres-gis.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/postgres-gis/help.1 /help.1
 COPY conf/atomic/postgres-gis/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="9.6"
+ENV PGVERSION="9.6" BACKREST_VERSION="2.08"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf
@@ -44,7 +44,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y reinstall glibc-common \
  && yum -y install postgresql96 postgresql96-contrib postgresql96-server \
     pgaudit96 pgaudit96_set_user \
-    crunchy-backrest \
+    crunchy-backrest-"${BACKREST_VERSION}" \
     postgis23_96 postgis23_96-client pgrouting_96 plr96 \
  && yum -y --setopt=tsflags='' install pgaudit_analyze \
  && yum -y clean all

--- a/rhel7/9.6/Dockerfile.postgres.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/postgres/help.1 /help.1
 COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="9.6"
+ENV PGVERSION="9.6" BACKREST_VERSION="2.08"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf
@@ -43,7 +43,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
  && yum -y reinstall glibc-common \
  && yum -y install postgresql96 postgresql96-contrib postgresql96-server \
     pgaudit96 pgaudit96_set_user \
- && yum -y install crunchy-backrest \
+ && yum -y install crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y --setopt=tsflags='' install pgaudit_analyze \
  && yum -y clean all
 


### PR DESCRIPTION
This PR locks the pgBackRest version number in at v2.08 across the Crunchy Container Suite.  This will ensure the version of pgBackRest utilized within the Crunchy Container Suite is compatible with the version of pgBackRest utilized by the Postgres Operator (which also uses v2.08).

Also, added the `$CCP_PG_IMAGE` environment variable back into the **backrest** container image names within the Kubernetes pgBackRest examples.  This re-enables support for the **crunchy-postgres-gis** container when running the backrest examples.


**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
A specific version of pgBackRest is not installed across the Crunchy Container Suite, which could lead to compatibility issues with the Postgres Operator in the event that they install different versions.

[ch2151]

The `$CCP_PG_IMAGE` environment is missing from the  **backrest** container image names in the Kubernetes pgBackRest examples, preventing the use of the **crunchy-postgres-gis** containers when running the pgBackRest examples.

[ch2182]

**What is the new behavior (if this is a feature change)?**
The version of pgBackRest is locked in at v2.08 across the Crunchy Container Suite.

The `$CCP_PG_IMAGE` environment is inlcuded in the  **backrest** container image names in the Kubernetes pgBackRest examples.

**Other information**:
N/A