### PR TITLE
Fix pgadmin4 permissions

### DIFF
--- a/centos7/10/Dockerfile.pgadmin4.centos7
+++ b/centos7/10/Dockerfile.pgadmin4.centos7
@@ -40,8 +40,7 @@ ADD conf/pgadmin4/ /opt/cpm/conf
 RUN cp /opt/cpm/conf/httpd.conf /etc/httpd/conf/httpd.conf \
   && rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/ssl.conf
 
-
-RUN chgrp -R 0 /usr/lib/python2.7/site-packages/pgadmin4-web \
+RUN chown -R 2:0 /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd && \
     chmod -R g=u /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd

--- a/centos7/11/Dockerfile.pgadmin4.centos7
+++ b/centos7/11/Dockerfile.pgadmin4.centos7
@@ -40,8 +40,7 @@ ADD conf/pgadmin4/ /opt/cpm/conf
 RUN cp /opt/cpm/conf/httpd.conf /etc/httpd/conf/httpd.conf \
   && rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/ssl.conf
 
-
-RUN chgrp -R 0 /usr/lib/python2.7/site-packages/pgadmin4-web \
+RUN chown -R 2:0 /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd && \
     chmod -R g=u /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd

--- a/centos7/9.5/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.5/Dockerfile.pgadmin4.centos7
@@ -40,8 +40,7 @@ ADD conf/pgadmin4/ /opt/cpm/conf
 RUN cp /opt/cpm/conf/httpd.conf /etc/httpd/conf/httpd.conf \
   && rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/ssl.conf
 
-
-RUN chgrp -R 0 /usr/lib/python2.7/site-packages/pgadmin4-web \
+RUN chown -R 2:0 /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd && \
     chmod -R g=u /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd

--- a/centos7/9.6/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.6/Dockerfile.pgadmin4.centos7
@@ -40,8 +40,7 @@ ADD conf/pgadmin4/ /opt/cpm/conf
 RUN cp /opt/cpm/conf/httpd.conf /etc/httpd/conf/httpd.conf \
   && rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/ssl.conf
 
-
-RUN chgrp -R 0 /usr/lib/python2.7/site-packages/pgadmin4-web \
+RUN chown -R 2:0 /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd && \
     chmod -R g=u /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd

--- a/rhel7/10/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/10/Dockerfile.pgadmin4.rhel7
@@ -57,8 +57,7 @@ ADD conf/pgadmin4/ /opt/cpm/conf
 RUN cp /opt/cpm/conf/httpd.conf /etc/httpd/conf/httpd.conf \
   && rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/ssl.conf
 
-
-RUN chgrp -R 0 /usr/lib/python2.7/site-packages/pgadmin4-web \
+RUN chown -R 2:0 /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd && \
     chmod -R g=u /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd

--- a/rhel7/11/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/11/Dockerfile.pgadmin4.rhel7
@@ -57,8 +57,7 @@ ADD conf/pgadmin4/ /opt/cpm/conf
 RUN cp /opt/cpm/conf/httpd.conf /etc/httpd/conf/httpd.conf \
   && rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/ssl.conf
 
-
-RUN chgrp -R 0 /usr/lib/python2.7/site-packages/pgadmin4-web \
+RUN chown -R 2:0 /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd && \
     chmod -R g=u /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd

--- a/rhel7/9.5/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/9.5/Dockerfile.pgadmin4.rhel7
@@ -57,8 +57,7 @@ ADD conf/pgadmin4/ /opt/cpm/conf
 RUN cp /opt/cpm/conf/httpd.conf /etc/httpd/conf/httpd.conf \
   && rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/ssl.conf
 
-
-RUN chgrp -R 0 /usr/lib/python2.7/site-packages/pgadmin4-web \
+RUN chown -R 2:0 /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd && \
     chmod -R g=u /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd

--- a/rhel7/9.6/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/9.6/Dockerfile.pgadmin4.rhel7
@@ -57,8 +57,7 @@ ADD conf/pgadmin4/ /opt/cpm/conf
 RUN cp /opt/cpm/conf/httpd.conf /etc/httpd/conf/httpd.conf \
   && rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/ssl.conf
 
-
-RUN chgrp -R 0 /usr/lib/python2.7/site-packages/pgadmin4-web \
+RUN chown -R 2:0 /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd && \
     chmod -R g=u /usr/lib/python2.7/site-packages/pgadmin4-web \
    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd


### PR DESCRIPTION
pgAdmin4 could not write to volume directories due to `/var/lib/pgadmin` being owned by `0:0` when running on standalone Docker.  Adjusted the bits on the directories we need to support Docker deployments.

[CH2172]