### PR TITLE
Update pgBackRest Stanza Creation Due to pgBackRest v2.10 Error Message Changes

### DIFF
--- a/bin/postgres/pgbackrest.sh
+++ b/bin/postgres/pgbackrest.sh
@@ -112,21 +112,14 @@ fi
 if [[ "${BACKREST_SKIP_CREATE_STANZA}" == "true" ]]
 then
     echo_info "pgBackRest: BACKREST_SKIP_CREATE_STANZA is 'true'.  Skipping stanza creation.." 
-elif pgbackrest info | grep -q 'missing stanza path'
-then
+else
     echo_info "pgBackRest: The following pgbackrest env vars have been set:"
     ( set -o posix ; set | grep -oP "^PGBACKREST.*" )
 
-    echo_info "pgBackRest: Creating stanza '${PGBACKREST_STANZA}'.."
-    pgbackrest stanza-create --no-online \
-        > /tmp/pgbackrest.stdout 2> /tmp/pgbackrest.stderr
+    echo_info "pgBackRest: Executing 'stanza-create' to create stanza '${PGBACKREST_STANZA}'.."
+    pgbackrest stanza-create --no-online --log-level-console=info \
+        2> /tmp/pgbackrest.stderr
     err=$?
     err_check ${err} "pgBackRest Stanza Creation" \
         "Could not create a pgBackRest stanza: \n$(cat /tmp/pgbackrest.stderr)"
-    if [[ ${err} == 0 ]]
-    then
-        echo_info "pgBackRest: Stanza '${PGBACKREST_STANZA}'' created"
-    fi
-else
-    echo_info "pgBackRest: Stanza '${PGBACKREST_STANZA}' already exists.."
 fi


### PR DESCRIPTION
Unless **BACKREST_SKIP_CREATE_STANZA** is set to **true**, `pgbackrest stanza-create` is now always run during initialization of pgBackRest on a crunchy postgres or postgis container.  This effectively removes the logic previously used to determine if a stanza exists prior to running `pgbackrest stanza-create`.  Now the command is executed regardless, and if the stanza already exists, pgBackRest simply prints a message to stdout such as the following stating that the stanza has already been created, and then exits (with exit code 0):

```bash
$ pgbackrest stanza-create --log-level-console=info
2019-02-09 10:37:58.932 P00   INFO: stanza-create command begin 2.10: --log-level-console=info --log-path=/tmp --pg1-path=/pgdata/custom-config --repo1-path=/backrestrepo/custom-config-backups --stanza=db
2019-02-09 10:37:59.441 P00   INFO: stanza-create was already performed
2019-02-09 10:37:59.442 P00   INFO: stanza-create command end: completed successfully (511ms)
```

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The pgBackRest stanza is not created upon initialization of a crunchy postgres or postgis container that has pgBackRest enabled.

[ch2205]

**What is the new behavior (if this is a feature change)?**
The pgBackRest stanza is now properly created upon initialization of a crunchy postgres or postgis container that has pgBackRest enabled.


**Other information**:
N/A
