### PR TITLE
Remove cluster role from cleanup function

### DIFF
--- a/examples/common.sh
+++ b/examples/common.sh
@@ -99,7 +99,7 @@ function cleanup() {
 
     CONFIG="configmap,secret"
     DEPLOY="deployment,daemonset,job,pod,replicaset,service,statefulset"
-    RBAC="clusterrolebinding,clusterrole,role,rolebinding,serviceaccount"
+    RBAC="role,rolebinding,serviceaccount"
     VOLUME="pvc,pv"
     OBJECTS="${CONFIG?},${DEPLOY?},${RBAC?},${VOLUME?}"
 

--- a/examples/kube/centralized-logging/efk/cleanup-rbac.sh
+++ b/examples/kube/centralized-logging/efk/cleanup-rbac.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Copyright 2016 - 2019 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,16 +14,16 @@
 # limitations under the License.
 
 source ${CCPROOT}/examples/common.sh
-echo_info "Cleaning up.."
+echo_info "Cleaning up RBAC.."
 
 ${CCP_CLI?} delete --namespace=kube-system \
-    service,statefulset,deployment,pod,daemonset,configmap,secret,serviceaccount,pvc \
+    clusterrolebinding,clusterrole \
     --selector=k8s-app=elasticsearch-logging
 
 ${CCP_CLI?} delete --namespace=kube-system \
-    service,statefulset,deployment,pod,daemonset,configmap,secret,serviceaccount,pvc \
+    clusterrolebinding,clusterrole \
     --selector=k8s-app=fluentd-es
 
 ${CCP_CLI?} delete --namespace=kube-system \
-    service,statefulset,deployment,pod,daemonset,configmap,secret,serviceaccount,pvc \
+    clusterrolebinding,clusterrole \
     --selector=k8s-app=kibana-logging

--- a/examples/kube/metrics/cleanup-rbac.sh
+++ b/examples/kube/metrics/cleanup-rbac.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Copyright 2016 - 2019 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,16 +14,6 @@
 # limitations under the License.
 
 source ${CCPROOT}/examples/common.sh
-echo_info "Cleaning up.."
+echo_info "Cleaning up RBAC.."
 
-${CCP_CLI?} delete --namespace=kube-system \
-    service,statefulset,deployment,pod,daemonset,configmap,secret,serviceaccount,pvc \
-    --selector=k8s-app=elasticsearch-logging
-
-${CCP_CLI?} delete --namespace=kube-system \
-    service,statefulset,deployment,pod,daemonset,configmap,secret,serviceaccount,pvc \
-    --selector=k8s-app=fluentd-es
-
-${CCP_CLI?} delete --namespace=kube-system \
-    service,statefulset,deployment,pod,daemonset,configmap,secret,serviceaccount,pvc \
-    --selector=k8s-app=kibana-logging
+${CCP_CLI?} delete --namespace=${CCP_NAMESPACE?} clusterrolebinding,clusterrole --selector="cleanup=${CCP_NAMESPACE?}-metrics"

--- a/hugo/content/examples/logging/centralized-logging.md
+++ b/hugo/content/examples/logging/centralized-logging.md
@@ -129,3 +129,15 @@ kubernetes.pod_name: "primary" AND log
 ```
 
 For more information about querying Kibana, see the official documentation: https://www.elastic.co/guide/en/beats/packetbeat/current/kibana-queries-filters.html
+
+To delete the centralized logging example run the following:
+
+```
+${CCP_ROOT?}/examples/kube/centralized-logging/efk/cleanup.sh
+```
+
+To delete the cluster roles required by the EFK stack, as an administrator, run the following:
+
+```
+${CCP_ROOT?}/examples/kube/centralized-logging/efk/cleanup-rbac.sh
+```

--- a/hugo/content/examples/metrics/metrics.md
+++ b/hugo/content/examples/metrics/metrics.md
@@ -57,6 +57,12 @@ To shutdown the instance and remove the container for each example, run the foll
 ./cleanup.sh
 ```
 
+To delete the cluster role required by the Prometheus, as an administrator, run the following:
+
+```
+./cleanup-rbac.sh
+```
+
 ### Docker
 
 To start this set of containers, run the following:


### PR DESCRIPTION
ClusterRole and ClusterRoleBinding were built into the cleanup function for examples but the crunchy test accounts do not have privileges to modify those objects.  I've removed them from the cleanup function to reduce noise and added `cleanup-rbac.sh` scripts to the examples that need them which can be run as an administrator.

[CH2267]