### PR TITLE
Use the crunchy-postgres Image as the Base Image for the crunchy-postgres-gis Container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,10 @@ postgres: versiontest commands
 
 postgres-gis: versiontest commands
 	cp $(GOBIN)/pgc bin/postgres
-	docker build -t crunchy-postgres-gis -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres-gis.$(CCP_BASEOS) .
+	expenv -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres-gis.$(CCP_BASEOS) > $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres-gis.$(CCP_BASEOS).tmp
+	docker build -t crunchy-postgres-gis -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres-gis.$(CCP_BASEOS).tmp .
 	docker tag crunchy-postgres-gis $(CCP_IMAGE_PREFIX)/crunchy-postgres-gis:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
+	rm -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres-gis.$(CCP_BASEOS).tmp
 
 prometheus:	versiontest
 	docker build -t crunchy-prometheus -f $(CCP_BASEOS)/Dockerfile.prometheus.$(CCP_BASEOS) .

--- a/centos7/10/Dockerfile.postgres-gis.centos7
+++ b/centos7/10/Dockerfile.postgres-gis.centos7
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
@@ -14,67 +14,20 @@ LABEL name="crunchydata/postgres-gis" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm" BACKREST_VERSION="2.10"
+USER 0
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
-
-RUN yum -y update && yum -y install epel-release \
- && yum -y update glibc-common \
- && yum -y install bind-utils \
-    gettext \
-    hostname \
-    procps-ng  \
-    rsync \
- && yum -y install postgresql10-server postgresql10-contrib postgresql10 \
+RUN yum -y update \
+ && yum -y install \
     R-core libRmath plr10 \
-    pgaudit12_10 \
-    pgbackrest-"${BACKREST_VERSION}" \
     postgis24_10 postgis24_10-client \
  && yum -y clean all
-
-ENV PGROOT="/usr/pgsql-${PGVERSION}"
-
-# add path settings for postgres user
-# bash_profile is loaded in login, but not with exec
-# bashrc to set permissions in OCP when using exec
-# HOME is / in OCP
-ADD conf/.bash_profile /var/lib/pgsql/
-ADD conf/.bashrc /var/lib/pgsql
-ADD conf/.bash_profile /
-ADD conf/.bashrc /
-
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo &&  \
-    chmod -R g=u /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to allow backup of postgres files
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/pgconf", "/pgdata", "/pgwal", "/backup", "/recover", "/backrestrepo"]
 
 # open up the postgres port
 EXPOSE 5432
 
-ADD bin/postgres /opt/cpm/bin
 ADD bin/postgres-gis /opt/cpm/bin
-ADD bin/common /opt/cpm/bin
-ADD conf/postgres /opt/cpm/conf
-ADD tools/pgmonitor/exporter/postgres /opt/cpm/bin/modules
-
-RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-
-RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
-
 
 USER 26
 

--- a/centos7/11/Dockerfile.postgres-gis.centos7
+++ b/centos7/11/Dockerfile.postgres-gis.centos7
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
@@ -14,67 +14,20 @@ LABEL name="crunchydata/postgres-gis" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.10"
+USER 0
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
-
-RUN yum -y update && yum -y install epel-release \
- && yum -y update glibc-common \
- && yum -y install bind-utils \
-    gettext \
-    hostname \
-    procps-ng  \
-    rsync \
- && yum -y install postgresql11-server postgresql11-contrib postgresql11 \
+RUN yum -y update \
+ && yum -y install \
     R-core libRmath plr11 \
-    pgaudit13_11 \
-    pgbackrest-"${BACKREST_VERSION}" \
     postgis24_11 postgis24_11-client \
  && yum -y clean all
-
-ENV PGROOT="/usr/pgsql-${PGVERSION}"
-
-# add path settings for postgres user
-# bash_profile is loaded in login, but not with exec
-# bashrc to set permissions in OCP when using exec
-# HOME is / in OCP
-ADD conf/.bash_profile /var/lib/pgsql/
-ADD conf/.bashrc /var/lib/pgsql
-ADD conf/.bash_profile /
-ADD conf/.bashrc /
-
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo && \
-    chmod -R g=u /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to allow backup of postgres files
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/pgconf", "/pgdata", "/pgwal", "/backup", "/recover", "/backrestrepo"]
 
 # open up the postgres port
 EXPOSE 5432
 
-ADD bin/postgres /opt/cpm/bin
 ADD bin/postgres-gis /opt/cpm/bin
-ADD bin/common /opt/cpm/bin
-ADD conf/postgres /opt/cpm/conf
-ADD tools/pgmonitor/exporter/postgres /opt/cpm/bin/modules
-
-RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-
-RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
-
 
 USER 26
 

--- a/centos7/9.5/Dockerfile.postgres-gis.centos7
+++ b/centos7/9.5/Dockerfile.postgres-gis.centos7
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
@@ -14,68 +14,20 @@ LABEL name="crunchydata/postgres-gis" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm" BACKREST_VERSION="2.10"
+USER 0
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
-
-RUN yum -y update && yum -y install epel-release \
- && yum -y update glibc-common \
- && yum -y install bind-utils \
-    gettext \
-    hostname \
-    procps-ng  \
-    rsync \
- && yum -y install postgresql95-server postgresql95-contrib postgresql95 \
+RUN yum -y update \
+ && yum -y install \
     R-core libRmath plr95 \
-    pgaudit_95 \
-    pgbackrest-"${BACKREST_VERSION}" \
-    postgis22_95 postgis22_95-client  \
+    postgis22_95 postgis22_95-client \
  && yum -y clean all
-
-ENV	PGROOT="/usr/pgsql-${PGVERSION}"
-
-# add path settings for postgres user
-# bash_profile is loaded in login, but not with exec
-# bashrc to set permissions in OCP when using exec
-# HOME is / in OCP
-ADD conf/.bash_profile /var/lib/pgsql/
-ADD conf/.bashrc /var/lib/pgsql
-ADD conf/.bash_profile /
-ADD conf/.bashrc /
-
-# set up cpm directory
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo &&  \
-    chmod -R g=u /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to allow backup of postgres files
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/pgconf", "/pgdata", "/pgwal", "/backup", "/recover", "/backrestrepo"]
 
 # open up the postgres port
 EXPOSE 5432
 
-ADD bin/postgres /opt/cpm/bin
 ADD bin/postgres-gis /opt/cpm/bin
-ADD bin/common /opt/cpm/bin
-ADD conf/postgres /opt/cpm/conf
-ADD tools/pgmonitor/exporter/postgres /opt/cpm/bin/modules
-
-RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-
-RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
-
 
 USER 26
 

--- a/centos7/9.6/Dockerfile.postgres-gis.centos7
+++ b/centos7/9.6/Dockerfile.postgres-gis.centos7
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
@@ -14,67 +14,20 @@ LABEL name="crunchydata/postgres-gis" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm" BACKREST_VERSION="2.10"
+USER 0
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
-
-RUN yum -y update && yum -y install epel-release \
- && yum -y update glibc-common \
- && yum -y install bind-utils \
-    gettext \
-    hostname \
-    procps-ng  \
-    rsync \
- && yum -y install postgresql96-server postgresql96-contrib postgresql96 \
+RUN yum -y update \
+ && yum -y install \
     R-core libRmath plr96 \
-    pgaudit_96 \
-    pgbackrest-"${BACKREST_VERSION}" \
     postgis23_96 postgis23_96-client \
  && yum -y clean all
-
-ENV PGROOT="/usr/pgsql-${PGVERSION}"
-
-# add path settings for postgres user
-# bash_profile is loaded in login, but not with exec
-# bashrc to set permissions in OCP when using exec
-# HOME is / in OCP
-ADD conf/.bash_profile /var/lib/pgsql/
-ADD conf/.bashrc /var/lib/pgsql
-ADD conf/.bash_profile /
-ADD conf/.bashrc /
-
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo &&  \
-    chmod -R g=u /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to allow backup of postgres files
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/pgconf", "/pgdata", "/pgwal", "/backup", "/recover", "/backrestrepo"]
 
 # open up the postgres port
 EXPOSE 5432
 
-ADD bin/postgres /opt/cpm/bin
 ADD bin/postgres-gis /opt/cpm/bin
-ADD bin/common /opt/cpm/bin
-ADD conf/postgres /opt/cpm/conf
-ADD tools/pgmonitor/exporter/postgres /opt/cpm/bin/modules
-
-RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-
-RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
-
 
 USER 26
 

--- a/rhel7/10/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/10/Dockerfile.postgres-gis.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7
+FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
@@ -19,80 +19,23 @@ LABEL name="crunchydata/postgres-gis" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
+USER 0
+
 COPY conf/atomic/postgres-gis/help.1 /help.1
 COPY conf/atomic/postgres-gis/help.md /help.md
-COPY conf/licenses /licenses
 
-ENV PGVERSION="10" BACKREST_VERSION="2.10"
-
-# if you ever need to install package docs inside the container, uncomment
-#RUN sed -i '/nodocs/d' /etc/yum.conf
-
-# Crunchy Postgres repo
-ADD conf/CRUNCHY-GPG-KEY.public  /
-ADD conf/crunchypg10.repo /etc/yum.repos.d/
-RUN rpm --import CRUNCHY-GPG-KEY.public
-
-RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
- && yum -y update && yum --enablerepo=epel --enablerepo="rhel-7-server-optional-rpms" -y install bind-utils \
-    gettext \
-    hostname \
+RUN yum -y update \
+ && yum -y install --enablerepo=rhel-7-server-optional-rpms \
     R-core libRmath texinfo-tex texlive-epsf \
-    procps-ng \
-    rsync \
-    psmisc openssh-server openssh-clients \
- && yum -y reinstall glibc-common \
- && yum -y install postgresql10 postgresql10-contrib postgresql10-server \
-    pgaudit10 pgaudit10_set_user \
-    plr10 postgis24_10 postgis24_10-client pgrouting_10 \
- && yum -y install crunchy-backrest-"${BACKREST_VERSION}" \
- && yum -y --setopt=tsflags='' install pgaudit_analyze \
+    postgis24_10 postgis24_10-client pgrouting_10 plr10 \
  && yum -y clean all
-
-ENV PGROOT="/usr/pgsql-${PGVERSION}"
-
-# add path settings for postgres user
-# bash_profile is loaded in login, but not with exec
-# bashrc to set permissions in OCP when using exec
-# HOME is / in OCP
-ADD conf/.bash_profile /var/lib/pgsql/
-ADD conf/.bashrc /var/lib/pgsql
-ADD conf/.bash_profile /
-ADD conf/.bashrc /
-
-# set up cpm directory
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo &&  \
-    chmod -R g=u /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to allow backup of postgres files
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/backup", "/recover", "/backrestrepo"]
 
 # open up the postgres port
 EXPOSE 5432
 
-ADD bin/postgres /opt/cpm/bin
 ADD bin/postgres-gis /opt/cpm/bin
-ADD bin/common /opt/cpm/bin
-ADD conf/postgres /opt/cpm/conf
-ADD tools/pgmonitor/exporter/postgres /opt/cpm/bin/modules
-
-RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-
-RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
-
 
 USER 26
 

--- a/rhel7/11/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/11/Dockerfile.postgres-gis.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7
+FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
@@ -19,80 +19,23 @@ LABEL name="crunchydata/postgres-gis" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
+USER 0
+
 COPY conf/atomic/postgres-gis/help.1 /help.1
 COPY conf/atomic/postgres-gis/help.md /help.md
-COPY conf/licenses /licenses
 
-ENV PGVERSION="11" BACKREST_VERSION="2.10"
-
-# if you ever need to install package docs inside the container, uncomment
-#RUN sed -i '/nodocs/d' /etc/yum.conf
-
-# Crunchy Postgres repo
-ADD conf/RPM-GPG-KEY-crunchydata  /
-ADD conf/crunchypg11.repo /etc/yum.repos.d/
-RUN rpm --import RPM-GPG-KEY-crunchydata
-
-RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
- && yum -y update && yum --enablerepo=epel --enablerepo="rhel-7-server-optional-rpms" -y install bind-utils \
-    gettext \
-    hostname \
+RUN yum -y update \
+ && yum -y install --enablerepo=rhel-7-server-optional-rpms \
     R-core libRmath texinfo-tex texlive-epsf \
-    procps-ng \
-    rsync \
-    psmisc openssh-server openssh-clients \
- && yum -y reinstall glibc-common \
- && yum -y install postgresql11 postgresql11-contrib postgresql11-server \
-    pgaudit11 pgaudit11_set_user \
-    crunchy-backrest-"${BACKREST_VERSION}" plr11 \
-    postgis24_11 postgis24_11-client pgrouting_11 \
- && yum -y --setopt=tsflags='' install pgaudit_analyze \
+    postgis24_11 postgis24_11-client pgrouting_11 plr11 \
  && yum -y clean all
-
-ENV PGROOT="/usr/pgsql-${PGVERSION}"
-
-# add path settings for postgres user
-# bash_profile is loaded in login, but not with exec
-# bashrc to set permissions in OCP when using exec
-# HOME is / in OCP
-ADD conf/.bash_profile /var/lib/pgsql/
-ADD conf/.bashrc /var/lib/pgsql
-ADD conf/.bash_profile /
-ADD conf/.bashrc /
-
-# set up cpm directory
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo &&  \
-    chmod -R g=u /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to allow backup of postgres files
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/backup", "/recover", "/backrestrepo"]
 
 # open up the postgres port
 EXPOSE 5432
 
-ADD bin/postgres /opt/cpm/bin
 ADD bin/postgres-gis /opt/cpm/bin
-ADD bin/common /opt/cpm/bin
-ADD conf/postgres /opt/cpm/conf
-ADD tools/pgmonitor/exporter/postgres /opt/cpm/bin/modules
-
-RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-
-RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
-
 
 USER 26
 

--- a/rhel7/9.5/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres-gis.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7
+FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
@@ -19,81 +19,23 @@ LABEL name="crunchydata/postgres-gis" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
+USER 0
+
 COPY conf/atomic/postgres-gis/help.1 /help.1
 COPY conf/atomic/postgres-gis/help.md /help.md
-COPY conf/licenses /licenses
 
-ENV PGVERSION="9.5" BACKREST_VERSION="2.10"
-
-# PGDG Postgres repo
-#RUN rpm -Uvh http://yum.postgresql.org/9.5/redhat/rhel-7-x86_64/pgdg-redhat95-9.5-3.noarch.rpm
-
-# if you ever need to install package docs inside the container, uncomment
-#RUN sed -i '/nodocs/d' /etc/yum.conf
-
-# Crunchy Postgres repo
-ADD conf/CRUNCHY-GPG-KEY.public  /
-ADD conf/crunchypg95.repo /etc/yum.repos.d/
-RUN rpm --import CRUNCHY-GPG-KEY.public
-
-RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
- && yum -y update && yum --enablerepo=epel --enablerepo="rhel-7-server-optional-rpms" -y install bind-utils \
+RUN yum -y update \
+ && yum -y install --enablerepo=rhel-7-server-optional-rpms \
     R-core libRmath texinfo-tex texlive-epsf \
-    gettext \
-    hostname \
-    procps-ng \
-    rsync \
-    psmisc openssh-server openssh-clients \
- && yum -y reinstall glibc-common \
- && yum -y install postgresql95 postgresql95-contrib postgresql95-server \
-    pgaudit95 pgaudit95_set_user \
-    crunchy-backrest-"${BACKREST_VERSION}" \
     postgis22_95 postgis22_95-client pgrouting_95 plr95 \
- && yum -y --setopt=tsflags='' install pgaudit_analyze \
  && yum -y clean all
-
-# add path settings for postgres user
-# bash_profile is loaded in login, but not with exec
-# bashrc to set permissions in OCP when using exec
-# HOME is / in OCP
-ADD conf/.bash_profile /var/lib/pgsql/
-ADD conf/.bashrc /var/lib/pgsql
-ADD conf/.bash_profile /
-ADD conf/.bashrc /
-
-# set up cpm directory
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo &&  \
-    chmod -R g=u /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to allow backup of postgres files
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/backup", "/recover", "/backrestrepo"]
 
 # open up the postgres port
 EXPOSE 5432
 
-ADD bin/postgres /opt/cpm/bin
 ADD bin/postgres-gis /opt/cpm/bin
-ADD bin/common /opt/cpm/bin
-ADD conf/postgres /opt/cpm/conf
-ADD tools/pgmonitor/exporter/postgres /opt/cpm/bin/modules
-
-RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-
-RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
-
 
 USER 26
 

--- a/rhel7/9.6/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres-gis.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7
+FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
@@ -19,80 +19,23 @@ LABEL name="crunchydata/postgres-gis" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
+USER 0
+
 COPY conf/atomic/postgres-gis/help.1 /help.1
 COPY conf/atomic/postgres-gis/help.md /help.md
-COPY conf/licenses /licenses
 
-ENV PGVERSION="9.6" BACKREST_VERSION="2.10"
-
-# if you ever need to install package docs inside the container, uncomment
-#RUN sed -i '/nodocs/d' /etc/yum.conf
-
-# Crunchy Postgres repo
-ADD conf/CRUNCHY-GPG-KEY.public  /
-ADD conf/crunchypg96.repo /etc/yum.repos.d/
-RUN rpm --import CRUNCHY-GPG-KEY.public
-
-RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
- && yum -y update && yum --enablerepo=epel --enablerepo="rhel-7-server-optional-rpms" -y install bind-utils \
-    gettext \
-    hostname \
+RUN yum -y update \
+ && yum -y install --enablerepo=rhel-7-server-optional-rpms \
     R-core libRmath texinfo-tex texlive-epsf \
-    procps-ng \
-    rsync \
-    psmisc openssh-server openssh-clients \
- && yum -y reinstall glibc-common \
- && yum -y install postgresql96 postgresql96-contrib postgresql96-server \
-    pgaudit96 pgaudit96_set_user \
-    crunchy-backrest-"${BACKREST_VERSION}" \
     postgis23_96 postgis23_96-client pgrouting_96 plr96 \
- && yum -y --setopt=tsflags='' install pgaudit_analyze \
  && yum -y clean all
-
-ENV PGROOT="/usr/pgsql-${PGVERSION}"
-
-# add path settings for postgres user
-# bash_profile is loaded in login, but not with exec
-# bashrc to set permissions in OCP when using exec
-# HOME is / in OCP
-ADD conf/.bash_profile /var/lib/pgsql/
-ADD conf/.bashrc /var/lib/pgsql
-ADD conf/.bash_profile /
-ADD conf/.bashrc /
-
-# set up cpm directory
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo &&  \
-    chmod -R g=u /opt/cpm /var/lib/pgsql \
-    /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to allow backup of postgres files
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/backup", "/recover", "/backrestrepo"]
 
 # open up the postgres port
 EXPOSE 5432
 
-ADD bin/postgres /opt/cpm/bin
 ADD bin/postgres-gis /opt/cpm/bin
-ADD bin/common /opt/cpm/bin
-ADD conf/postgres /opt/cpm/conf
-ADD tools/pgmonitor/exporter/postgres /opt/cpm/bin/modules
-
-RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-
-RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
-
 
 USER 26
 


### PR DESCRIPTION
The **crunchy-postgres-gis** container now uses the **crunchy-postgres** as its base image.  This reduces build times for the **crunchy-postgres-gis** container by leveraging the core PostgeSQL packages already installed on the **crunchy-postgres** container (i.e. now the **crunchy-postgres-gis** container simply adds packages and configuration needed for PostGIS and PL/R on top of the **crunchy-postgres**  container).

This also simplifies the Dockerfile for the **crunchy-postgres-gis** image, while also reducing duplication across the **crunchy-postgres** and **crunchy-postgres-gis** Dockerfiles.

[ch2176]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The **crunchy-postgres-gis** container is built off of the base CentOS or RHEL image, and not the **crunchy-postgres** container.


**What is the new behavior (if this is a feature change)?**
The **crunchy-postgres-gis** container is built off of the **crunchy-postgres** container, i.e. it uses the **crunchy-postgres** container as its base image. 


**Other information**:
N/A