### PR TITLE
Allow Both Local and S3 Archiving to be Enabled in a PG Container

### DIFF
--- a/bin/postgres/start.sh
+++ b/bin/postgres/start.sh
@@ -359,7 +359,12 @@ configure_archiving() {
     then
         export ARCHIVE_MODE=on
         echo_info "Setting pgbackrest archive command.."
-        cat /opt/cpm/conf/backrest-archive-command >> /"${PGDATA?}"/postgresql.conf
+        if [[ "${BACKREST_LOCAL_AND_S3_STORAGE}" == "true" ]]
+        then
+            cat /opt/cpm/conf/backrest-archive-command-local-and-s3 >> /"${PGDATA?}"/postgresql.conf
+        else
+            cat /opt/cpm/conf/backrest-archive-command >> /"${PGDATA?}"/postgresql.conf
+        fi
     elif [[ "${ARCHIVE_MODE}" == "on" ]] && [[ ! "${PGBACKREST}" == "true" ]]
     then
         echo_info "Setting standard archive command.."

--- a/conf/postgres/backrest-archive-command-local-and-s3
+++ b/conf/postgres/backrest-archive-command-local-and-s3
@@ -1,0 +1,1 @@
+archive_command = 'pgbackrest archive-push %p && pgbackrest archive-push --repo-type=s3 %p'


### PR DESCRIPTION
This change allows a PG container to be configured to archive to both local storage and AWS S3 storage when using pgBackRest.  

This is accomplished by setting environment variable `BACKREST_LOCAL_AND_S3_STORAGE` to `true` when deploying a PG container.  When `BACKREST_LOCAL_AND_S3_STORAGE=true`, an archiving command will be added to **postgresql.conf** that will result in pgBackRest pushing archives to both local storage and a configured S3 storage bucket.

[ch2979]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
It is only possible to archive to either local storage or S3 storage when using pgBackRest in a PG container, not both.


**What is the new behavior (if this is a feature change)?**
It is possible to archive to both local storage and S3 storage when using pgBackRest in a PG container.


**Other information**:
N/A