### PR TITLE
Remove 'yum update' Command from crunchy-postgres-gis Dockerfiles

### DIFF
--- a/centos7/10/Dockerfile.postgres-gis.centos7
+++ b/centos7/10/Dockerfile.postgres-gis.centos7
@@ -16,8 +16,7 @@ LABEL name="crunchydata/postgres-gis" \
 
 USER 0
 
-RUN yum -y update \
- && yum -y install \
+RUN yum -y install \
     R-core libRmath plr10 \
     postgis24_10 postgis24_10-client \
  && yum -y clean all

--- a/centos7/11/Dockerfile.postgres-gis.centos7
+++ b/centos7/11/Dockerfile.postgres-gis.centos7
@@ -16,8 +16,7 @@ LABEL name="crunchydata/postgres-gis" \
 
 USER 0
 
-RUN yum -y update \
- && yum -y install \
+RUN yum -y install \
     R-core libRmath plr11 \
     postgis24_11 postgis24_11-client \
  && yum -y clean all

--- a/centos7/9.5/Dockerfile.postgres-gis.centos7
+++ b/centos7/9.5/Dockerfile.postgres-gis.centos7
@@ -16,8 +16,7 @@ LABEL name="crunchydata/postgres-gis" \
 
 USER 0
 
-RUN yum -y update \
- && yum -y install \
+RUN yum -y install \
     R-core libRmath plr95 \
     postgis22_95 postgis22_95-client \
  && yum -y clean all

--- a/centos7/9.6/Dockerfile.postgres-gis.centos7
+++ b/centos7/9.6/Dockerfile.postgres-gis.centos7
@@ -16,8 +16,7 @@ LABEL name="crunchydata/postgres-gis" \
 
 USER 0
 
-RUN yum -y update \
- && yum -y install \
+RUN yum -y install \
     R-core libRmath plr96 \
     postgis23_96 postgis23_96-client \
  && yum -y clean all

--- a/rhel7/10/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/10/Dockerfile.postgres-gis.rhel7
@@ -24,8 +24,7 @@ USER 0
 COPY conf/atomic/postgres-gis/help.1 /help.1
 COPY conf/atomic/postgres-gis/help.md /help.md
 
-RUN yum -y update \
- && yum -y install --enablerepo=rhel-7-server-optional-rpms \
+RUN yum -y install --enablerepo=rhel-7-server-optional-rpms \
     R-core libRmath texinfo-tex texlive-epsf \
     postgis24_10 postgis24_10-client pgrouting_10 plr10 \
  && yum -y clean all

--- a/rhel7/11/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/11/Dockerfile.postgres-gis.rhel7
@@ -24,8 +24,7 @@ USER 0
 COPY conf/atomic/postgres-gis/help.1 /help.1
 COPY conf/atomic/postgres-gis/help.md /help.md
 
-RUN yum -y update \
- && yum -y install --enablerepo=rhel-7-server-optional-rpms \
+RUN yum -y install --enablerepo=rhel-7-server-optional-rpms \
     R-core libRmath texinfo-tex texlive-epsf \
     postgis24_11 postgis24_11-client pgrouting_11 plr11 \
  && yum -y clean all

--- a/rhel7/9.5/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres-gis.rhel7
@@ -24,8 +24,7 @@ USER 0
 COPY conf/atomic/postgres-gis/help.1 /help.1
 COPY conf/atomic/postgres-gis/help.md /help.md
 
-RUN yum -y update \
- && yum -y install --enablerepo=rhel-7-server-optional-rpms \
+RUN yum -y install --enablerepo=rhel-7-server-optional-rpms \
     R-core libRmath texinfo-tex texlive-epsf \
     postgis22_95 postgis22_95-client pgrouting_95 plr95 \
  && yum -y clean all

--- a/rhel7/9.6/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres-gis.rhel7
@@ -24,8 +24,7 @@ USER 0
 COPY conf/atomic/postgres-gis/help.1 /help.1
 COPY conf/atomic/postgres-gis/help.md /help.md
 
-RUN yum -y update \
- && yum -y install --enablerepo=rhel-7-server-optional-rpms \
+RUN yum -y install --enablerepo=rhel-7-server-optional-rpms \
     R-core libRmath texinfo-tex texlive-epsf \
     postgis23_96 postgis23_96-client pgrouting_96 plr96 \
  && yum -y clean all


### PR DESCRIPTION
Removed the `yum update` command from all **crunchy-postgres-gis** Dockerfiles.  This will ensure the version of pgBackRest installed on the **crunchy-postgres** base image is maintained in the **crunchy-postgres-gis** container, preventing the potential for version mismatch errors when used with PGO.

[ch3109]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The pgBackRest version could be updated while building a **crunchy-postgres-gis** container, which can subsequently result in pgBackRest version mismatch errors with PGO.


**What is the new behavior (if this is a feature change)?**
A `yum update` command is no longer run when building a **crunchy-postgres-gis** container, preventing pgBackRest from upgrading to a version that is incompatible with PGO.


**Other information**:
