### PR TITLE
Cleanup and Align Docker Examples

### DIFF
--- a/examples/docker/custom-config-ssl/run.sh
+++ b/examples/docker/custom-config-ssl/run.sh
@@ -50,6 +50,7 @@ docker run \
     --env=PG_USER=testuser \
     --env=PG_PASSWORD=password \
     --env=PG_ROOT_PASSWORD=password \
+    --env=PGHOST=/tmp \
     --env=XLOGDIR=true \
     --env=PGBACKREST=true \
     --detach ${CCP_IMAGE_PREFIX?}/crunchy-postgres:${CCP_IMAGE_TAG?}

--- a/examples/docker/custom-config/configs/pg_hba.conf
+++ b/examples/docker/custom-config/configs/pg_hba.conf
@@ -81,7 +81,7 @@
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 
 # "local" is for Unix domain socket connections only
-local   all             all                                     peer
+local   all             all                                     trust
 # IPv4 local connections:
 host    all             all             127.0.0.1/32            md5
 host    all             all             0.0.0.0/0               md5

--- a/examples/docker/custom-config/run.sh
+++ b/examples/docker/custom-config/run.sh
@@ -44,6 +44,7 @@ docker run \
     --env=PG_USER=testuser \
     --env=PG_PASSWORD=password \
     --env=PG_ROOT_PASSWORD=password \
+    --env=PGHOST=/tmp \
     --env=XLOGDIR=true \
     --env=PGBACKREST=true \
     --detach ${CCP_IMAGE_PREFIX?}/crunchy-postgres:${CCP_IMAGE_TAG?}

--- a/examples/docker/pgadmin4-http/run.sh
+++ b/examples/docker/pgadmin4-http/run.sh
@@ -29,7 +29,7 @@ docker run \
     --name=$CONTAINER_NAME \
     --hostname=$CONTAINER_NAME \
     -p 5050:5050 \
-    -v pgadmin:/var/lib/pgadmin:z\
+    -v ${CONTAINER_NAME}-data:/var/lib/pgadmin:z\
     -e PGADMIN_SETUP_EMAIL='admin@admin.com' \
     -e PGADMIN_SETUP_PASSWORD='password' \
     -e SERVER_PORT='5050' \

--- a/examples/docker/pgbasebackup/backup/run.sh
+++ b/examples/docker/pgbasebackup/backup/run.sh
@@ -22,7 +22,7 @@ CONTAINER_NAME=backup
 
 echo "Starting the ${CONTAINER_NAME} example..."
 
-VOLUME_NAME=$CONTAINER_NAME-pgdata
+VOLUME_NAME=backup-volume
 BACKUP_HOST=primary
 
 docker volume create --driver local --name=$VOLUME_NAME
@@ -35,7 +35,7 @@ docker run \
 	-e BACKUP_PASS=password \
 	-e BACKUP_PORT=5432 \
 	-e BACKUP_LABEL=mybackup \
-	--link $BACKUP_HOST:$BACKUP_HOST \
 	--name=$CONTAINER_NAME \
 	--hostname=$CONTAINER_NAME \
+	--network=pgnet \
 	-d $CCP_IMAGE_PREFIX/crunchy-backup:$CCP_IMAGE_TAG

--- a/examples/docker/pgbasebackup/pitr/cleanup.sh
+++ b/examples/docker/pgbasebackup/pitr/cleanup.sh
@@ -21,9 +21,14 @@ RESTORE_CONTAINER_NAME=restore-pitr
 
 docker stop $PITR_CONTAINER_NAME
 docker rm -v $PITR_CONTAINER_NAME
+docker volume rm pitr-pgdata
+docker volume rm pitr-wal
+docker network rm pitrnet
 
 docker stop $BACKUP_CONTAINER_NAME
 docker rm -v $BACKUP_CONTAINER_NAME
+docker volume rm pitr-backup-volume
 
 docker stop $RESTORE_CONTAINER_NAME
 docker rm -v $RESTORE_CONTAINER_NAME
+docker volume rm pitr-restore

--- a/examples/docker/pgbasebackup/pitr/run-backup-pitr.sh
+++ b/examples/docker/pgbasebackup/pitr/run-backup-pitr.sh
@@ -20,28 +20,18 @@ echo "Cleaning up..."
 
 docker stop ${CONTAINER_NAME}
 docker rm ${CONTAINER_NAME}
+docker volume rm pitr-backup-volume
 
 echo "Starting the ${CONTAINER_NAME} example..."
 
-BACKUP_HOST=pitr
-PGDATA=/tmp/backups
-
-if [ ! -d "$PGDATA" ]; then
-	echo "Creating pgdata directory..."
-	mkdir -p $PGDATA
-fi
-
-sudo chown postgres:postgres $PGDATA
-sudo chcon -Rt svirt_sandbox_file_t $PGDATA
-
 docker run \
-	-v $PGDATA:/pgdata \
-	-e BACKUP_HOST=$BACKUP_HOST \
+	-v pitr-backup-volume:/pgdata \
+	-e BACKUP_HOST=pitr \
 	-e BACKUP_USER=primaryuser \
 	-e BACKUP_PASS=password \
 	-e BACKUP_PORT=5432 \
 	-e BACKUP_LABEL=mybackup1 \
-	--link $BACKUP_HOST:$BACKUP_HOST \
 	--name=${CONTAINER_NAME} \
 	--hostname=${CONTAINER_NAME} \
+	--network=pitrnet \
 	-d $CCP_IMAGE_PREFIX/crunchy-backup:$CCP_IMAGE_TAG

--- a/examples/docker/pgbasebackup/pitr/run-pitr.sh
+++ b/examples/docker/pgbasebackup/pitr/run-pitr.sh
@@ -19,33 +19,18 @@ echo "Cleaning up..."
 
 sudo docker stop ${CONTAINER_NAME}
 sudo docker rm ${CONTAINER_NAME}
+docker volume rm pitr-pgdata
+docker volume rm pitr-wal
+docker network rm pitrnet
 
 echo "Starting the ${CONTAINER_NAME} example..."
 
-# uncomment these lines to override the pg config files with
-# your own versions of pg_hba.conf and postgresql.conf
-#PGCONF=$HOME/openshift-dedicated-container/pgconf
-#sudo chown postgres:postgres $PGCONF
-#sudo chmod 0700 $PGCONF
-#sudo chcon -Rt svirt_sandbox_file_t $PGCONF
-# add this next line to the docker run to override pg config files
-
-DATA_DIR=/tmp/${CONTAINER_NAME}
-sudo rm -rf $DATA_DIR
-sudo mkdir -p $DATA_DIR
-sudo chown postgres:postgres $DATA_DIR
-sudo chcon -Rt svirt_sandbox_file_t $DATA_DIR
-
-WAL_DIR=/tmp/${CONTAINER_NAME}-wal
-sudo rm -rf $WAL_DIR
-sudo mkdir -p $WAL_DIR
-sudo chown postgres:postgres $WAL_DIR
-sudo chcon -Rt svirt_sandbox_file_t $WAL_DIR
+docker network create --driver bridge pitrnet
 
 sudo docker run \
 	-p 12000:5432 \
-	-v $DATA_DIR:/pgdata \
-	-v $WAL_DIR:/pgwal \
+	-v pitr-pgdata:/pgdata \
+	-v pitr-wal:/pgwal \
 	-e TEMP_BUFFERS=9MB \
 	-e PGHOST=/tmp \
 	-e MAX_CONNECTIONS=101 \
@@ -64,4 +49,5 @@ sudo docker run \
 	-e ARCHIVE_TIMEOUT=60 \
 	--name=${CONTAINER_NAME} \
 	--hostname=${CONTAINER_NAME} \
+	--network=pitrnet \
 	-d $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG

--- a/examples/docker/pgbasebackup/pitr/run-restore-pitr.sh
+++ b/examples/docker/pgbasebackup/pitr/run-restore-pitr.sh
@@ -19,45 +19,18 @@ echo "Cleaning up..."
 
 sudo docker stop ${CONTAINER_NAME}
 sudo docker rm ${CONTAINER_NAME}
+docker volume rm pitr-restore
 
 echo "Starting the ${CONTAINER_NAME} example..."
 
-# uncomment these lines to override the pg config files with
-# your own versions of pg_hba.conf and postgresql.conf
-#PGCONF=$HOME/openshift-dedicated-container/pgconf
-#sudo chown postgres:postgres $PGCONF
-#sudo chmod 0700 $PGCONF
-#sudo chcon -Rt svirt_sandbox_file_t $PGCONF
-# add this next line to the docker run to override pg config files
-
-# the following path is where the base backup files
-# are located for doing the database restore
-BACKUP=/tmp/backups/pitr-backups/2018-04-05-18-39-54
-
-# WAL_DIR contains the WAL files generated from
-# this database after recovery and ongoing afterwards
-WAL_DIR=/tmp/${CONTAINER_NAME}-wal
-
-# RECOVER_DIR contains the WAL files from where we
-# want to recover from
-RECOVER_DIR=/tmp/pitr/pitr/pg_wal
-
-DATA_DIR=/tmp/${CONTAINER_NAME}
-sudo rm -rf $DATA_DIR $WAL_DIR
-sudo mkdir -p $DATA_DIR $WAL_DIR
-sudo chown postgres:postgres $DATA_DIR $WAL_DIR
-sudo chcon -Rt svirt_sandbox_file_t $DATA_DIR $WAL_DIR
-#	-e RECOVERY_TARGET_NAME=beforechanges \
-#	-e RECOVERY_TARGET_NAME=afterchanges \
-#	-e RECOVERY_TARGET_TIME='2016-09-21 16:05:00' \
+docker volume create --driver local --name=pitr-restore
 
 sudo docker run \
 	-e RECOVERY_TARGET_NAME=beforechanges \
 	-p 12001:5432 \
-	-v $DATA_DIR:/pgdata \
-	-v $WAL_DIR:/pgwal \
-	-v "$BACKUP":/backup \
-	-v $RECOVER_DIR:/recover \
+	-v pitr-restore:/pgdata \
+	-v pitr-backup-volume:/backup \
+	-v pitr-wal:/recover \
 	-e ARCHIVE_MODE=on \
 	-e ARCHIVE_TIMEOUT=60 \
 	-e TEMP_BUFFERS=9MB \
@@ -73,6 +46,8 @@ sudo docker run \
 	-e PG_ROOT_PASSWORD=password \
 	-e PG_PASSWORD=password \
 	-e PG_DATABASE=userdb \
+	-e WAL_DIR=pitr-wal \
+	-e BACKUP_PATH=pitr-backups/2019-03-08-15-04-02 \
 	--name=${CONTAINER_NAME} \
 	--hostname=${CONTAINER_NAME} \
 	-d $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG

--- a/examples/docker/postgres-gis/run.sh
+++ b/examples/docker/postgres-gis/run.sh
@@ -22,22 +22,6 @@ CONTAINER_NAME=postgres-gis
 
 echo "Starting the ${CONTAINER_NAME} example..."
 
-# if you want to use local host directories for persistence
-# then uncomment out these lines below and use them instead
-# of the docker volume as used in this example
-
-#PGCONF=$HOME/openshift-dedicated-container/pgconf
-#sudo chown postgres:postgres $PGCONF
-#sudo chmod 0700 $PGCONF
-#sudo chcon -Rt svirt_sandbox_file_t $PGCONF
-#	-v $PGCONF:/pgconf \
-
-#DATA_DIR=/tmp/crunchy-pg-data
-#sudo rm -rf $DATA_DIR
-#sudo mkdir -p $DATA_DIR
-#sudo chown postgres:postgres $DATA_DIR
-#sudo chcon -Rt svirt_sandbox_file_t $DATA_DIR
-
 VOLUME_NAME=${CONTAINER_NAME}-pgdata
 
 docker volume create --driver local --name=$VOLUME_NAME

--- a/examples/docker/primary-replica/run.sh
+++ b/examples/docker/primary-replica/run.sh
@@ -23,24 +23,6 @@ PRIMARY_CONTAINER_NAME=primary
 
 echo "Starting the ${PRIMARY_CONTAINER_NAME} container..."
 
-# uncomment these lines to override the pg config files with
-# your own versions of pg_hba.conf and postgresql.conf
-#PGCONF=$HOME/openshift-dedicated-container/pgconf
-#sudo chown postgres:postgres $PGCONF
-#sudo chmod 0700 $PGCONF
-#sudo chcon -Rt svirt_sandbox_file_t $PGCONF
-# add this next line to the docker run to override pg config files
-#DATA_DIR=/tmp/primary-data
-#sudo rm -rf $DATA_DIR
-#sudo mkdir -p $DATA_DIR
-#sudo chown postgres:postgres $DATA_DIR
-#sudo chcon -Rt svirt_sandbox_file_t $DATA_DIR
-#DATA_DIR=/tmp/pg-replica-data
-#sudo rm -rf $DATA_DIR
-#sudo mkdir -p $DATA_DIR
-#sudo chown postgres:postgres $DATA_DIR
-#sudo chcon -Rt svirt_sandbox_file_t $DATA_DIR
-
 PRIMARY_VOLUME_NAME=${PRIMARY_CONTAINER_NAME}-pgdata
 docker volume create --driver local --name=${PRIMARY_VOLUME_NAME}
 

--- a/examples/docker/primary/run.sh
+++ b/examples/docker/primary/run.sh
@@ -32,6 +32,7 @@ docker run \
     -e PG_PRIMARY_PORT=5432 \
     -e PG_PRIMARY_PASSWORD=password \
     -e PG_ROOT_PASSWORD=password \
+    -e PGHOST=/tmp \
     --name=primary \
     --hostname=primary \
     --network=pgnet \

--- a/examples/docker/sync/run.sh
+++ b/examples/docker/sync/run.sh
@@ -21,26 +21,13 @@ ASYNC_CONTAINER_NAME=replicaasync
 
 echo "Starting the ${PRIMARY_CONTAINER_NAME} container..."
 
-# uncomment these lines to override the pg config files with
-# your own versions of pg_hba.conf and postgresql.conf
-#PGCONF=$HOME/openshift-dedicated-container/pgconf
-#sudo chown postgres:postgres $PGCONF
-#sudo chmod 0700 $PGCONF
-#sudo chcon -Rt svirt_sandbox_file_t $PGCONF
-# add this next line to the docker run to override pg config files
-
-DATA_DIR=/tmp/${PRIMARY_CONTAINER_NAME}-data
-sudo rm -rf $DATA_DIR
-sudo mkdir -p $DATA_DIR
-sudo chown postgres:postgres $DATA_DIR
-sudo chcon -Rt svirt_sandbox_file_t $DATA_DIR
-
 sudo docker stop ${PRIMARY_CONTAINER_NAME}
 sudo docker rm ${PRIMARY_CONTAINER_NAME}
+docker volume rm ${PRIMARY_CONTAINER_NAME}-pgdata
 
 sudo docker run \
 	-p 12010:5432 \
-	-v $DATA_DIR:/pgdata \
+	-v ${PRIMARY_CONTAINER_NAME}-pgdata:/pgdata \
 	-e PGHOST=/tmp \
 	-e TEMP_BUFFERS=9MB \
 	-e MAX_CONNECTIONS=101 \
@@ -65,18 +52,13 @@ sleep 20
 
 echo "Starting the ${SYNC_CONTAINER_NAME} container..."
 
-DATA_DIR=/tmp/${SYNC_CONTAINER_NAME}
-sudo rm -rf $DATA_DIR
-sudo mkdir -p $DATA_DIR
-sudo chown postgres:postgres $DATA_DIR
-sudo chcon -Rt svirt_sandbox_file_t $DATA_DIR
-
 sudo docker stop ${SYNC_CONTAINER_NAME}
 sudo docker rm ${SYNC_CONTAINER_NAME}
+docker volume rm ${SYNC_CONTAINER_NAME}-pgdata
 
 sudo docker run \
 	-p 12011:5432 \
-	-v $DATA_DIR:/pgdata \
+	-v ${SYNC_CONTAINER_NAME}-pgdata:/pgdata \
 	-e PGHOST=/tmp \
 	-e TEMP_BUFFERS=9MB \
 	-e MAX_CONNECTIONS=101 \
@@ -100,18 +82,13 @@ sudo docker run \
 
 echo "Starting the ${ASYNC_CONTAINER_NAME} container..."
 
-DATA_DIR=/tmp/${ASYNC_CONTAINER_NAME}
-sudo rm -rf $DATA_DIR
-sudo mkdir -p $DATA_DIR
-sudo chown postgres:postgres $DATA_DIR
-sudo chcon -Rt svirt_sandbox_file_t $DATA_DIR
-
 sudo docker stop ${ASYNC_CONTAINER_NAME}
 sudo docker rm ${ASYNC_CONTAINER_NAME}
+docker volume rm ${ASYNC_CONTAINER_NAME}-pgdata
 
 sudo docker run \
 	-p 12012:5432 \
-	-v $DATA_DIR:/pgdata \
+	-v ${ASYNC_CONTAINER_NAME}-pgdata:/pgdata \
 	-e PGHOST=/tmp \
 	-e TEMP_BUFFERS=9MB \
 	-e MAX_CONNECTIONS=101 \

--- a/hugo/content/examples/metrics/pgbadger.md
+++ b/hugo/content/examples/metrics/pgbadger.md
@@ -36,7 +36,7 @@ After execution, the container will run and provide a simple HTTP
 command you can browse to view the report.  As you run queries against
 the database, you can invoke this URL to generate updated reports:
 ```
-curl -L http://127.0.0.1:14000/api/badgergenerate
+curl -L http://127.0.0.1:10000/api/badgergenerate
 ```
 
 ### Kubernetes and OpenShift


### PR DESCRIPTION
Cleaned up Docker examples.  This includes adding missing environment variables to various `run.sh` scripts, standardizing on named volumes for volume creation, updating network and PG configuration, and general cleanup, defect corrections and documentation updates.

Additionally, defects with the pg_basebackup Docker example have fixed (with documentation updated accordingly), and the example now works according to the documentation.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Various issues exist in the containers Docker examples and/or require cleanup to align with latest standards for containers Docker examples:

[ch2207]
[ch2208]
[ch2234]
[ch2244]
[ch2241]
[ch2245]
[ch2251]
[ch2193]

**What is the new behavior (if this is a feature change)?**
Various issues have been addressed in the Docker examples, which now better align with the latest standards for all containers Docker examples.


**Other information**:
N/A
