### PR TITLE
Updated pgbouncer, grafana & prometheus Container Folder Permissions 

### DIFF
--- a/centos7/10/Dockerfile.pgbouncer.centos7
+++ b/centos7/10/Dockerfile.pgbouncer.centos7
@@ -34,8 +34,8 @@ ADD bin/pgbouncer /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/pgbouncer /opt/cpm/conf
 
-RUN chgrp -R 0 /opt/cpm /pgconf && \
-        chmod -R g=u /opt/cpm /pgconf
+RUN chown -R 2:0 /opt/cpm /pgconf && \
+    chmod -R g=u /opt/cpm /pgconf
 
 EXPOSE 6432
 

--- a/centos7/11/Dockerfile.pgbouncer.centos7
+++ b/centos7/11/Dockerfile.pgbouncer.centos7
@@ -34,8 +34,8 @@ ADD bin/pgbouncer /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/pgbouncer /opt/cpm/conf
 
-RUN chgrp -R 0 /opt/cpm /pgconf && \
-        chmod -R g=u /opt/cpm /pgconf
+RUN chown -R 2:0 /opt/cpm /pgconf && \
+    chmod -R g=u /opt/cpm /pgconf
 
 EXPOSE 6432
 

--- a/centos7/9.5/Dockerfile.pgbouncer.centos7
+++ b/centos7/9.5/Dockerfile.pgbouncer.centos7
@@ -34,8 +34,8 @@ ADD bin/pgbouncer /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/pgbouncer /opt/cpm/conf
 
-RUN chgrp -R 0 /opt/cpm /pgconf && \
-        chmod -R g=u /opt/cpm /pgconf
+RUN chown -R 2:0 /opt/cpm /pgconf && \
+    chmod -R g=u /opt/cpm /pgconf
 
 EXPOSE 6432
 

--- a/centos7/9.6/Dockerfile.pgbouncer.centos7
+++ b/centos7/9.6/Dockerfile.pgbouncer.centos7
@@ -34,8 +34,8 @@ ADD bin/pgbouncer /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/pgbouncer /opt/cpm/conf
 
-RUN chgrp -R 0 /opt/cpm /pgconf && \
-        chmod -R g=u /opt/cpm /pgconf
+RUN chown -R 2:0 /opt/cpm /pgconf && \
+    chmod -R g=u /opt/cpm /pgconf
 
 EXPOSE 6432
 

--- a/centos7/Dockerfile.grafana.centos7
+++ b/centos7/Dockerfile.grafana.centos7
@@ -28,7 +28,7 @@ ADD bin/grafana /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/grafana /opt/cpm/conf
 
-RUN chgrp -R 0 /opt/cpm /data && \
+RUN chown -R 2:0 /opt/cpm /data && \
     chmod -R g=u /opt/cpm /data
 
 VOLUME ["/data", "/conf"]

--- a/centos7/Dockerfile.prometheus.centos7
+++ b/centos7/Dockerfile.prometheus.centos7
@@ -26,8 +26,8 @@ ADD bin/prometheus /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/prometheus /opt/cpm/conf
 
-RUN chgrp -R 0 /opt/cpm /data /conf && \
-    chmod -R g=u /opt/cpm /data 
+RUN chown -R 2:0 /opt/cpm /data /conf && \
+    chmod -R g=u /opt/cpm /data /conf
 
 EXPOSE 9090
 VOLUME ["/data", "/conf"]

--- a/rhel7/10/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/10/Dockerfile.pgbouncer.rhel7
@@ -48,8 +48,8 @@ ADD bin/pgbouncer /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/pgbouncer /opt/cpm/conf
 
-RUN chgrp -R 0 /opt/cpm /pgconf && \
-        chmod -R g=u /opt/cpm /pgconf
+RUN chown -R 2:0 /opt/cpm /pgconf && \
+    chmod -R g=u /opt/cpm /pgconf
 
 EXPOSE 6432
 

--- a/rhel7/11/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/11/Dockerfile.pgbouncer.rhel7
@@ -48,8 +48,8 @@ ADD bin/pgbouncer /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/pgbouncer /opt/cpm/conf
 
-RUN chgrp -R 0 /opt/cpm /pgconf && \
-        chmod -R g=u /opt/cpm /pgconf
+RUN chown -R 2:0 /opt/cpm /pgconf && \
+    chmod -R g=u /opt/cpm /pgconf
 
 EXPOSE 6432
 

--- a/rhel7/9.5/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbouncer.rhel7
@@ -48,8 +48,8 @@ ADD bin/pgbouncer /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/pgbouncer /opt/cpm/conf
 
-RUN chgrp -R 0 /opt/cpm /pgconf && \
-        chmod -R g=u /opt/cpm /pgconf
+RUN chown -R 2:0 /opt/cpm /pgconf && \
+    chmod -R g=u /opt/cpm /pgconf
 
 EXPOSE 6432
 

--- a/rhel7/9.6/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbouncer.rhel7
@@ -48,8 +48,8 @@ ADD bin/pgbouncer /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/pgbouncer /opt/cpm/conf
 
-RUN chgrp -R 0 /opt/cpm /pgconf && \
-        chmod -R g=u /opt/cpm /pgconf
+RUN chown -R 2:0 /opt/cpm /pgconf && \
+    chmod -R g=u /opt/cpm /pgconf
 
 EXPOSE 6432
 

--- a/rhel7/Dockerfile.grafana.rhel7
+++ b/rhel7/Dockerfile.grafana.rhel7
@@ -38,7 +38,7 @@ ADD bin/grafana /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/grafana /opt/cpm/conf
 
-RUN chgrp -R 0 /opt/cpm /data && \
+RUN chown -R 2:0 /opt/cpm /data && \
     chmod -R g=u /opt/cpm /data
 
 VOLUME ["/data", "/conf"]

--- a/rhel7/Dockerfile.prometheus.rhel7
+++ b/rhel7/Dockerfile.prometheus.rhel7
@@ -37,8 +37,8 @@ ADD bin/prometheus /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/prometheus /opt/cpm/conf
 
-RUN chgrp -R 0 /opt/cpm /data /conf && \
-    chmod -R g=u /opt/cpm /data 
+RUN chown -R 2:0 /opt/cpm /data && \
+    chmod -R g=u /opt/cpm /data
 
 EXPOSE 9090
 VOLUME ["/data", "/conf"]


### PR DESCRIPTION
Updated folder permissions in the crunchy-pgbouncer, crunchy-grafana and crunchy-prometheus containers so that they will run properly in a Docker environment.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The crunchy-pgbouncer, crunchy-grafana and crunchy-prometheus containers do not currently run in a Docker environment due to invalid directory permissions.

[ch2257]
[ch2254]


**What is the new behavior (if this is a feature change)?**
The crunchy-pgbouncer, crunchy-grafana and crunchy-prometheus containers now run properly in a Docker environment.


**Other information**:
N/A