### PR TITLE
allow non-ASCII psql restore

### DIFF
--- a/bin/pgrestore/start.sh
+++ b/bin/pgrestore/start.sh
@@ -72,7 +72,7 @@ echo_info "Restore will be attempted using backup ${BACKUP_FILE?}"
 # (tar, directory, custom) are restored via pg_restore
 BACKUP_TYPE=$(file ${BACKUP_FILE?})
 set +e
-if [[ ${BACKUP_TYPE?} = *"ASCII"* ]]
+if [[ ${BACKUP_TYPE?} = *"text"* ]]
 then
     echo_info "Restoring from SQL backup via psql.."
     ${PGROOT?}/bin/psql ${conn_opts?} -f ${BACKUP_FILE?}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
 The pgrestore helper script only accepts ASCII-encoded text files to be valid psql-importable files.


**What is the new behavior (if this is a feature change)?**
 Any file considered 'text' by the `file`-command can be a valid SQL file.


**Other information**:
