### PR TITLE
Drop pgbadger port from prometheus

### DIFF
--- a/conf/prometheus/prometheus-kube.yml
+++ b/conf/prometheus/prometheus-kube.yml
@@ -16,6 +16,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_container_port_number]
     action: drop
     regex: 5432
+  - source_labels: [__meta_kubernetes_pod_container_port_number]
+    action: drop
+    regex: 10000
   - source_labels: [__meta_kubernetes_namespace]
     action: replace
     target_label: kubernetes_namespace


### PR DESCRIPTION
Prometheus queries Kube to find all pods with the `crunchy_collect=true` label. It then finds all the ports exposed on that pod and scrapes them (except PG because we told it to drop 5432).

So if collect and badger are deployed together, this will cause prom to trigger badger to generate a report every 5 seconds indefinitely.

[CH3394]