### PR TITLE
Update pgdg Repos in CentOS7 Containers & Update pgBackRest Version in all Containers

### DIFF
--- a/centos7/10/Dockerfile.backrest-restore.centos7
+++ b/centos7/10/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.backrest-restore.centos7
+++ b/centos7/10/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,8 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg96,pgdg95,pgdg94" \
+    BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -27,7 +28,7 @@ RUN yum -y update && yum -y install epel-release \
  && yum -y clean all
 
 RUN yum -y install postgresql10-server  \
- && yum -y install pgbackrest-"${BACKREST_VERSION}" \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/10/Dockerfile.backrest-restore.centos7
+++ b/centos7/10/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.backup.centos7
+++ b/centos7/10/Dockerfile.backup.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/backup" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.collect.centos7
+++ b/centos7/10/Dockerfile.collect.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/collect" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 # Install the PGDG yum repo
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}

--- a/centos7/10/Dockerfile.pgadmin4.centos7
+++ b/centos7/10/Dockerfile.pgadmin4.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgadmin4" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.pgadmin4.centos7
+++ b/centos7/10/Dockerfile.pgadmin4.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgadmin4" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg96,pgdg95,pgdg94"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -26,7 +26,7 @@ RUN yum -y update && yum -y install epel-release \
     openssl \
     procps-ng \
     mod_wsgi mod_ssl \
- && yum -y install postgresql10-devel postgresql10-server pgadmin4-web \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" postgresql10-devel postgresql10-server pgadmin4-web \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/10/Dockerfile.pgbadger.centos7
+++ b/centos7/10/Dockerfile.pgbadger.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgbadger" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.pgbadger.centos7
+++ b/centos7/10/Dockerfile.pgbadger.centos7
@@ -14,13 +14,13 @@ LABEL name="crunchydata/pgbadger" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg96,pgdg95,pgdg94"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update \
  && yum -y install epel-release \
- && yum -y install \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
       gettext \
       hostname \
       pgbadger \

--- a/centos7/10/Dockerfile.pgbench.centos7
+++ b/centos7/10/Dockerfile.pgbench.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgbench" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.pgbouncer.centos7
+++ b/centos7/10/Dockerfile.pgbouncer.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgbouncer" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.pgbouncer.centos7
+++ b/centos7/10/Dockerfile.pgbouncer.centos7
@@ -14,13 +14,13 @@ LABEL name="crunchydata/pgbouncer" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg96,pgdg95,pgdg94"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update \
  && yum -y install epel-release \
- && yum -y install \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
       gettext \
       hostname  \
       pgbouncer \

--- a/centos7/10/Dockerfile.pgdump.centos7
+++ b/centos7/10/Dockerfile.pgdump.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgdump" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.pgpool.centos7
+++ b/centos7/10/Dockerfile.pgpool.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgpool" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.pgrestore.centos7
+++ b/centos7/10/Dockerfile.pgrestore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/restore" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.postgres.centos7
+++ b/centos7/10/Dockerfile.postgres.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.postgres.centos7
+++ b/centos7/10/Dockerfile.postgres.centos7
@@ -14,7 +14,8 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg96,pgdg95,pgdg94" \
+    BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -27,7 +28,8 @@ RUN yum -y update \
     procps-ng  \
     rsync \
     psmisc openssh-server openssh-clients \
- && yum -y install postgresql10-server postgresql10-contrib postgresql10 \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
+    postgresql10-server postgresql10-contrib postgresql10 \
     pgaudit12_10 \
     pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all

--- a/centos7/10/Dockerfile.postgres.centos7
+++ b/centos7/10/Dockerfile.postgres.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.upgrade.centos7
+++ b/centos7/10/Dockerfile.upgrade.centos7
@@ -14,12 +14,8 @@ LABEL name="crunchydata/upgrade" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGDG_95_REPO="pgdg-centos95-9.5-3.noarch.rpm" \
-    PGDG_96_REPO="pgdg-centos96-9.6-3.noarch.rpm" \
-    PGDG_10_REPO="pgdg-centos10-10-2.noarch.rpm"
+ENV PGDG_10_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/${PGDG_95_REPO}
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/${PGDG_96_REPO}
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/${PGDG_10_REPO}
 
 RUN yum -y update && yum install -y epel-release \

--- a/centos7/11/Dockerfile.backrest-restore.centos7
+++ b/centos7/11/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.backrest-restore.centos7
+++ b/centos7/11/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.backrest-restore.centos7
+++ b/centos7/11/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,8 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg10,pgdg96,pgdg95,pgdg94" \
+    BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -27,7 +28,7 @@ RUN yum -y update && yum -y install epel-release \
  && yum -y clean all
 
 RUN yum -y install postgresql11-server  \
- && yum -y install pgbackrest-"${BACKREST_VERSION}" \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/11/Dockerfile.backup.centos7
+++ b/centos7/11/Dockerfile.backup.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/backup" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.collect.centos7
+++ b/centos7/11/Dockerfile.collect.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/collect" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 # Install the PGDG yum repo
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}

--- a/centos7/11/Dockerfile.pgadmin4.centos7
+++ b/centos7/11/Dockerfile.pgadmin4.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgadmin4" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.pgadmin4.centos7
+++ b/centos7/11/Dockerfile.pgadmin4.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgadmin4" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg10,pgdg96,pgdg95,pgdg94"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -26,7 +26,7 @@ RUN yum -y update && yum -y install epel-release \
     openssl \
     procps-ng \
     mod_wsgi mod_ssl \
- && yum -y install postgresql11-devel postgresql11-server pgadmin4-web \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" postgresql11-devel postgresql11-server pgadmin4-web \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/11/Dockerfile.pgbadger.centos7
+++ b/centos7/11/Dockerfile.pgbadger.centos7
@@ -14,13 +14,13 @@ LABEL name="crunchydata/pgbadger" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg10,pgdg96,pgdg95,pgdg94"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update \
  && yum -y install epel-release \
- && yum -y install \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
       gettext \
       hostname \
       pgbadger \

--- a/centos7/11/Dockerfile.pgbadger.centos7
+++ b/centos7/11/Dockerfile.pgbadger.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgbadger" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.pgbench.centos7
+++ b/centos7/11/Dockerfile.pgbench.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgbench" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.pgbouncer.centos7
+++ b/centos7/11/Dockerfile.pgbouncer.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgbouncer" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.pgbouncer.centos7
+++ b/centos7/11/Dockerfile.pgbouncer.centos7
@@ -14,13 +14,13 @@ LABEL name="crunchydata/pgbouncer" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg10,pgdg96,pgdg95,pgdg94"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update \
  && yum -y install epel-release \
- && yum -y install \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
       gettext \
       hostname  \
       pgbouncer \

--- a/centos7/11/Dockerfile.pgdump.centos7
+++ b/centos7/11/Dockerfile.pgdump.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgdump" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.pgpool.centos7
+++ b/centos7/11/Dockerfile.pgpool.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgpool" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.pgrestore.centos7
+++ b/centos7/11/Dockerfile.pgrestore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/restore" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.postgres.centos7
+++ b/centos7/11/Dockerfile.postgres.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.postgres.centos7
+++ b/centos7/11/Dockerfile.postgres.centos7
@@ -14,7 +14,8 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg10,pgdg96,pgdg95,pgdg94" \
+    BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -27,7 +28,8 @@ RUN yum -y update \
     procps-ng  \
     rsync \
     psmisc openssh-server openssh-clients \
- && yum -y install postgresql11-server postgresql11-contrib postgresql11 \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
+    postgresql11-server postgresql11-contrib postgresql11 \
     pgaudit13_11 \
     pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all

--- a/centos7/11/Dockerfile.postgres.centos7
+++ b/centos7/11/Dockerfile.postgres.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.upgrade.centos7
+++ b/centos7/11/Dockerfile.upgrade.centos7
@@ -14,14 +14,8 @@ LABEL name="crunchydata/upgrade" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGDG_95_REPO="pgdg-centos95-9.5-3.noarch.rpm" \
-    PGDG_96_REPO="pgdg-centos96-9.6-3.noarch.rpm" \
-    PGDG_10_REPO="pgdg-centos10-10-2.noarch.rpm"  \
-    PGDG_11_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGDG_11_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/${PGDG_95_REPO}
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/${PGDG_96_REPO}
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/${PGDG_10_REPO}
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-7-x86_64/${PGDG_11_REPO}
 
 RUN yum -y update && yum install -y epel-release \

--- a/centos7/9.5/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.5/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.5/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,8 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg96,pgdg94" \
+    BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -27,7 +28,7 @@ RUN yum -y update && yum -y install epel-release \
  && yum -y clean all
 
 RUN yum -y install postgresql95-server \
- && yum -y install pgbackrest-"${BACKREST_VERSION}" \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/9.5/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.5/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.backup.centos7
+++ b/centos7/9.5/Dockerfile.backup.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/backup" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.collect.centos7
+++ b/centos7/9.5/Dockerfile.collect.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/collect" \
   io.openshift.expose-services="" \
   io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 # Install the PGDG yum repo
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}

--- a/centos7/9.5/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.5/Dockerfile.pgadmin4.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgadmin4" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.5/Dockerfile.pgadmin4.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgadmin4" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg96,pgdg94"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -26,7 +26,7 @@ RUN yum -y update && yum -y install epel-release \
         openssl \
         procps-ng \
         mod_wsgi mod_ssl \
- && yum -y install postgresql95-devel postgresql95-server pgadmin4-web \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" postgresql95-devel postgresql95-server pgadmin4-web \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/9.5/Dockerfile.pgbadger.centos7
+++ b/centos7/9.5/Dockerfile.pgbadger.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgbadger" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.pgbadger.centos7
+++ b/centos7/9.5/Dockerfile.pgbadger.centos7
@@ -14,13 +14,13 @@ LABEL name="crunchydata/pgbadger" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg96,pgdg94"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update \
  && yum -y install epel-release \
- && yum -y install \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
       gettext \
       hostname \
       pgbadger \

--- a/centos7/9.5/Dockerfile.pgbench.centos7
+++ b/centos7/9.5/Dockerfile.pgbench.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgbench" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.pgbouncer.centos7
+++ b/centos7/9.5/Dockerfile.pgbouncer.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgbouncer" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.pgbouncer.centos7
+++ b/centos7/9.5/Dockerfile.pgbouncer.centos7
@@ -14,13 +14,13 @@ LABEL name="crunchydata/pgbouncer" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg96,pgdg94"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update \
  && yum -y install epel-release \
- && yum -y install \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
       gettext \
       hostname  \
       pgbouncer \

--- a/centos7/9.5/Dockerfile.pgdump.centos7
+++ b/centos7/9.5/Dockerfile.pgdump.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgdump" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.pgpool.centos7
+++ b/centos7/9.5/Dockerfile.pgpool.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgpool" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.pgrestore.centos7
+++ b/centos7/9.5/Dockerfile.pgrestore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/restore" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.postgres.centos7
+++ b/centos7/9.5/Dockerfile.postgres.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-centos95-9.5-3.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.postgres.centos7
+++ b/centos7/9.5/Dockerfile.postgres.centos7
@@ -14,7 +14,8 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg96,pgdg94" \
+    BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -26,7 +27,8 @@ RUN yum -y update && yum -y install epel-release \
     procps-ng  \
     rsync \
     psmisc openssh-server openssh-clients \
- && yum -y install postgresql95-server postgresql95-contrib postgresql95 \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
+    postgresql95-server postgresql95-contrib postgresql95 \
     pgaudit_95 \
     pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all

--- a/centos7/9.5/Dockerfile.postgres.centos7
+++ b/centos7/9.5/Dockerfile.postgres.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.6/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.6/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.6/Dockerfile.backrest-restore.centos7
@@ -14,7 +14,8 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg95,pgdg94" \ 
+    BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -27,7 +28,7 @@ RUN yum -y update && yum -y install epel-release \
  && yum -y clean all
 
 RUN yum -y install postgresql96-server  \
- && yum -y install pgbackrest-"${BACKREST_VERSION}" \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/9.6/Dockerfile.backup.centos7
+++ b/centos7/9.6/Dockerfile.backup.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/backup" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 # PGDG Postgres repo
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}

--- a/centos7/9.6/Dockerfile.collect.centos7
+++ b/centos7/9.6/Dockerfile.collect.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/collect" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 # Install the PGDG yum repo
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}

--- a/centos7/9.6/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.6/Dockerfile.pgadmin4.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgadmin4" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.6/Dockerfile.pgadmin4.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgadmin4" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg95,pgdg94"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -26,7 +26,7 @@ RUN yum -y update && yum -y install epel-release \
         openssl \
         procps-ng \
         mod_wsgi mod_ssl \
- && yum -y install postgresql96-devel postgresql96-server pgadmin4-web \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" postgresql96-devel postgresql96-server pgadmin4-web \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/centos7/9.6/Dockerfile.pgbadger.centos7
+++ b/centos7/9.6/Dockerfile.pgbadger.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgbadger" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.pgbadger.centos7
+++ b/centos7/9.6/Dockerfile.pgbadger.centos7
@@ -14,13 +14,13 @@ LABEL name="crunchydata/pgbadger" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg95,pgdg94"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update \
  && yum -y install epel-release \
- && yum -y install \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
       gettext \
       hostname \
       pgbadger \

--- a/centos7/9.6/Dockerfile.pgbench.centos7
+++ b/centos7/9.6/Dockerfile.pgbench.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgbench" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.pgbouncer.centos7
+++ b/centos7/9.6/Dockerfile.pgbouncer.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgbouncer" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.pgbouncer.centos7
+++ b/centos7/9.6/Dockerfile.pgbouncer.centos7
@@ -14,13 +14,13 @@ LABEL name="crunchydata/pgbouncer" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg95,pgdg94"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
 RUN yum -y update \
  && yum -y install epel-release \
- && yum -y install \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
       gettext \
       hostname  \
       pgbouncer \

--- a/centos7/9.6/Dockerfile.pgdump.centos7
+++ b/centos7/9.6/Dockerfile.pgdump.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgdump" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.pgpool.centos7
+++ b/centos7/9.6/Dockerfile.pgpool.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgpool" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.pgrestore.centos7
+++ b/centos7/9.6/Dockerfile.pgrestore.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/restore" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 # PGDG Postgres repo
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}

--- a/centos7/9.6/Dockerfile.postgres.centos7
+++ b/centos7/9.6/Dockerfile.postgres.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-centos96-9.6-3.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.postgres.centos7
+++ b/centos7/9.6/Dockerfile.postgres.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.postgres.centos7
+++ b/centos7/9.6/Dockerfile.postgres.centos7
@@ -14,7 +14,8 @@ LABEL name="crunchydata/postgres" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg95,pgdg94" \ 
+    BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
@@ -26,7 +27,8 @@ RUN yum -y update && yum -y install epel-release \
     procps-ng  \
     rsync \
     psmisc openssh-server openssh-clients \
- && yum -y install postgresql96-server postgresql96-contrib postgresql96 \
+ && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
+    postgresql96-server postgresql96-contrib postgresql96 \
     pgaudit_96 \
     pgbackrest-"${BACKREST_VERSION}" \
  && yum -y clean all

--- a/centos7/9.6/Dockerfile.upgrade.centos7
+++ b/centos7/9.6/Dockerfile.upgrade.centos7
@@ -14,10 +14,8 @@ LABEL name="crunchydata/upgrade" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
-ENV PGDG_95_REPO="pgdg-centos95-9.5-3.noarch.rpm" \
-    PGDG_96_REPO="pgdg-centos96-9.6-3.noarch.rpm"
+ENV PGDG_96_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/${PGDG_95_REPO}
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/${PGDG_96_REPO}
 
 RUN yum -y update && yum install -y epel-release \

--- a/centos7/Dockerfile.sample-app.centos7
+++ b/centos7/Dockerfile.sample-app.centos7
@@ -12,7 +12,7 @@ LABEL name="crunchydata/sample-app" \
 	io.openshift.expose-services="" \
 	io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/rhel7/10/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/10/Dockerfile.backrest-restore.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/backrestrestore/help.1 /help.1
 COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="10" BACKREST_VERSION="2.10"
+ENV PGVERSION="10" BACKREST_VERSION="2.12"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /

--- a/rhel7/10/Dockerfile.postgres.rhel7
+++ b/rhel7/10/Dockerfile.postgres.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/postgres/help.1 /help.1
 COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="10" BACKREST_VERSION="2.10"
+ENV PGVERSION="10" BACKREST_VERSION="2.12"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf

--- a/rhel7/11/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/11/Dockerfile.backrest-restore.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/backrestrestore/help.1 /help.1
 COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="11" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" BACKREST_VERSION="2.12"
 
 # Crunchy Postgres repo
 ADD conf/RPM-GPG-KEY-crunchydata  /

--- a/rhel7/11/Dockerfile.postgres.rhel7
+++ b/rhel7/11/Dockerfile.postgres.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/postgres/help.1 /help.1
 COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="11" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" BACKREST_VERSION="2.12"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf

--- a/rhel7/9.5/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.5/Dockerfile.backrest-restore.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/backrestrestore/help.1 /help.1
 COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="9.5" BACKREST_VERSION="2.10"
+ENV PGVERSION="9.5" BACKREST_VERSION="2.12"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /

--- a/rhel7/9.5/Dockerfile.postgres.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/postgres/help.1 /help.1
 COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="9.5" BACKREST_VERSION="2.10"
+ENV PGVERSION="9.5" BACKREST_VERSION="2.12"
 
 # PGDG Postgres repo
 #RUN rpm -Uvh http://yum.postgresql.org/9.5/redhat/rhel-7-x86_64/pgdg-redhat95-9.5-3.noarch.rpm

--- a/rhel7/9.6/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.6/Dockerfile.backrest-restore.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/backrestrestore/help.1 /help.1
 COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="9.6" BACKREST_VERSION="2.10"
+ENV PGVERSION="9.6" BACKREST_VERSION="2.12"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /

--- a/rhel7/9.6/Dockerfile.postgres.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres.rhel7
@@ -23,7 +23,7 @@ COPY conf/atomic/postgres/help.1 /help.1
 COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 
-ENV PGVERSION="9.6" BACKREST_VERSION="2.10"
+ENV PGVERSION="9.6" BACKREST_VERSION="2.12"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf


### PR DESCRIPTION
Updated the rpm used to install the pgdg repos in all CentOS7 Dockerfiles, and then updated those Dockerfiles as needed to properly install all required packages from the pgdg repos.  This includes disabling certain repos when installing packages that exist in all pgdg repos (pgBackRest, pgbadger, pgbouncer and pgadmin4) to ensure the package is obtained from the proper repository according to the GPG installed when installing the pgdg repo rpm.

Also updated the version of pgBackRest across all CentOS7 and RHEL7 containers to v2.12.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Containers builds are failing due to a new pdgd repository architecture and installation process.

[ch3383]

**What is the new behavior (if this is a feature change)?**
Containers builds now succeed.


**Other information**:
N/A