### PR TITLE
Remove unused configmap label in metrics

### DIFF
--- a/examples/kube/metrics/run.sh
+++ b/examples/kube/metrics/run.sh
@@ -26,9 +26,6 @@ then
     exit 1
 fi
 
-${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap \
-    metrics-pgconf cleanup=${CCP_NAMESPACE?}-metrics
-
 expenv -f $DIR/metrics.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 expenv -f $DIR/primary.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 expenv -f $DIR/replica.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -


### PR DESCRIPTION
Metrics example no longer uses a configmap so the label in the `run.sh` script should be removed.