### PR TITLE
Updates to pgbadger Error Handling

### DIFF
--- a/badger/badgerserver.go
+++ b/badger/badgerserver.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -49,7 +50,9 @@ func BadgerGenerate(w http.ResponseWriter, r *http.Request) {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		log.Fatalf("Error running badger-generate: %s", err)
+		errorMsg := fmt.Sprintf("Error running badger-generate: %s\n%s", err, stderr.String())
+		log.Println(errorMsg)
+		http.Error(w, errorMsg, http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
Failed calls to **badger-generate.sh** no longer cause the badger server running within the **crunchy-pgbadger** container to exit, and a response with the error (and an HTTP status code) is now returned on a failed call to endpoint `/api/badgergenerate`.  All errors now also show any standard error output, including the error logged in the **crunchy-pgbadger** container logs and the error returned to the user.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Any standard error output is not displayed in the **crunchy-pgbadger** container logs on a failed call to **badger-generate.sh**.  Also, a failed call to **badger-generate.sh** results in an empty response to the user, and the server exits.

[ch3039]

**What is the new behavior (if this is a feature change)?**
Any standard error output is now displayed in the **crunchy-pgbadger** container output on a failed call to **badger-generate.sh**.  Also, a failed call to **badger-generate.sh** results in an error message (and the proper error code) returned to the user, and the server is no longer exits. 


**Other information**:
N/A