### PR TITLE
Add License & Atomic Help Files to pgbasebackup-restore RHEL Containers

### DIFF
--- a/conf/atomic/pgbasebackup_restore/help.1
+++ b/conf/atomic/pgbasebackup_restore/help.1
@@ -1,0 +1,40 @@
+.TH "pgbasebackup-restore" "1" " Container Image Pages" "Crunchy Data" "2019"
+.nh
+.ad l
+
+
+.SH NAME
+.PP
+Crunchy pgbasebackup\-restore \- provides the ability to restore a database using a pg_basebackup backup\&.
+
+
+.SH DESCRIPTION
+.PP
+The Crunchy pgbasebackup\-restore container restores a database into a specified PGDATA directory using a pg_basebackup 
+backup, while also preparing for a PITR if a recovery target is specified\&.
+
+.PP
+The container itself consists of:
+    \- RHEL7 base image
+    \- bash script that performs the container startup
+    \- rsync to restore the pg_basebackup backup
+
+.PP
+Files added to the container during docker build include: /help.1.
+
+
+.SH USAGE
+.PP
+See the crunchy docs.
+
+.PP
+\fB\fCVersion=\fR
+
+.PP
+The Red Hat Enterprise Linux version from which the container was built. For example, Version="7.6"
+
+.PP
+\fB\fCRelease=\fR
+
+.PP
+The specific release number of the container. For example, Release="2.4.0"

--- a/conf/atomic/pgbasebackup_restore/help.md
+++ b/conf/atomic/pgbasebackup_restore/help.md
@@ -1,0 +1,23 @@
+= pgbasebackup-restore (1)
+Crunchy Data
+2019
+== NAME
+Crunchy pgbasebackup-restore - provides the ability to restore a database using a pg_basebackup backup.
+
+== DESCRIPTION
+The Crunchy pgbasebackup-restore container restores a database into a specified PGDATA directory using a pg_basebackup 
+backup, while also preparing for a PITR if a recovery target is specified.
+
+The container itself consists of:
+    - RHEL7 base image
+    - bash script that performs the container startup
+    - rsync to restore the pg_basebackup backup
+
+== USAGE
+See the crunchy docs.
+
+The Red Hat Enterprise Linux version from which the container was built. For example, Version="7.6"
+
+`Release=`
+
+The specific release number of the container. For example, Release="2.4.0"

--- a/conf/atomic/pgbasebackup_restore/pgbasebackup_restore.1
+++ b/conf/atomic/pgbasebackup_restore/pgbasebackup_restore.1
@@ -1,0 +1,59 @@
+'\" t
+.\"     Title: Crunchy pgbasebackup-restore
+.\"    Author: Crunchy Data
+.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
+.\"      Date: 2019
+.\"    Manual: \ \&
+.\"    Source: \ \& 13
+.\"  Language: English
+.\"
+.TH "PGBASEBACKUP-RESTORE" "1" "2019" "\ \& 13" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+Crunchy pgbasebackup\-restore \- provides the ability to restore a database using a pg_basebackup backup\&.
+.SH "DESCRIPTION"
+.sp
+The Crunchy pgbasebackup\-restore container restores a database into a specified PGDATA directory using a pg_basebackup 
+backup, while also preparing for a PITR if a recovery target is specified\&.
+.sp
+The container itself consists of: \- RHEL7 base image \- bash script that performs the container startup \- rsync to restore the pg_basebackup backup
+.sp
+.sp
+Files added to the container during docker build include: /help\&.1\&.
+.SH "USAGE"
+.sp
+See the crunchy docs\&.
+.sp
+The registry location and name of the image\&. For example, Name="crunchydata/pgbasebackup\-restore"\&.
+.sp
+Version=
+.sp
+The Red Hat Enterprise Linux version from which the container was built\&. For example, Version="7.6"
+.sp
+Release=
+.sp
+The specific release number of the container\&. For example, Release="2.4.0"
+.SH "AUTHOR"
+.PP
+\fBCrunchy Data\fR
+.RS 4
+Author.
+.RE

--- a/rhel7/Dockerfile.pgbasebackup-restore.rhel7
+++ b/rhel7/Dockerfile.pgbasebackup-restore.rhel7
@@ -12,6 +12,10 @@ LABEL name="crunchydata/pgbasebackup-restore" \
         io.openshift.expose-services="" \
         io.openshift.tags="crunchy,database"
 
+COPY conf/atomic/pgbasebackup_restore/help.1 /help.1
+COPY conf/atomic/pgbasebackup_restore/help.md /help.md
+COPY conf/licenses /licenses
+
 RUN yum -y update \
  && yum -y install rsync  \
  && yum -y clean all


### PR DESCRIPTION
Added the license and atomic help files to the **pgbasebackup-restore** RHEL containers.

[ch4211]
