### PR TITLE
Moved VOLUME Instructions After all RUN Instructions in all Dockerfiles

### DIFF
--- a/centos7/10/Dockerfile.backup.centos7
+++ b/centos7/10/Dockerfile.backup.centos7
@@ -36,10 +36,10 @@ ADD conf/backup/ /opt/cpm/conf
 RUN chown -R postgres:postgres  /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/10/Dockerfile.collect.centos7
+++ b/centos7/10/Dockerfile.collect.centos7
@@ -39,12 +39,12 @@ ADD conf/collect /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm/bin /opt/cpm/conf && \
     chmod -R g=u /opt/cpm/bin/ opt/cpm/conf
 
-VOLUME ["/conf"]
-
 # postgres_exporter
 EXPOSE 9187
 
 RUN chmod g=u /etc/passwd
+
+VOLUME ["/conf"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_daemon.sh"]
 

--- a/centos7/10/Dockerfile.pgadmin4.centos7
+++ b/centos7/10/Dockerfile.pgadmin4.centos7
@@ -50,9 +50,10 @@ RUN ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python2.7/site-packages/pga
 
 EXPOSE 5050
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/var/lib/pgadmin", "/certs", "/run/httpd"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/centos7/10/Dockerfile.pgbadger.centos7
+++ b/centos7/10/Dockerfile.pgbadger.centos7
@@ -40,10 +40,10 @@ RUN chown -R postgres:postgres /opt/cpm /report /bin && \
 # pgbadger port
 EXPOSE 10000
 
-VOLUME ["/pgdata", "/report"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata", "/report"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/10/Dockerfile.pgbouncer.centos7
+++ b/centos7/10/Dockerfile.pgbouncer.centos7
@@ -39,9 +39,10 @@ RUN chown -R 2:0 /opt/cpm /pgconf && \
 
 EXPOSE 6432
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/centos7/10/Dockerfile.pgdump.centos7
+++ b/centos7/10/Dockerfile.pgdump.centos7
@@ -36,10 +36,10 @@ ADD conf/pgdump/ /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm /pgdata && \
     chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/10/Dockerfile.pgpool.centos7
+++ b/centos7/10/Dockerfile.pgpool.centos7
@@ -46,10 +46,11 @@ RUN chgrp -R 0 /opt/cpm && \
 # open up the postgres port
 EXPOSE 5432
 
+RUN chmod g=u /etc/passwd
+
 # add volumes to allow override of pgpool config files
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/centos7/10/Dockerfile.pgrestore.centos7
+++ b/centos7/10/Dockerfile.pgrestore.centos7
@@ -37,10 +37,10 @@ ADD conf/pgrestore/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/10/Dockerfile.postgres.centos7
+++ b/centos7/10/Dockerfile.postgres.centos7
@@ -53,14 +53,6 @@ RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
     chmod -R g=u /opt/cpm /var/lib/pgsql \
     /pgdata /pgwal /pgconf /recover /backrestrepo
 
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
-
 # open up the postgres port
 EXPOSE 5432
 
@@ -73,6 +65,14 @@ RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+
+# add volumes to allow override of pg_hba.conf and postgresql.conf
+# add volumes to offer a restore feature
+# add volumes to allow storage of postgres WAL segment files
+# add volumes to locate WAL files to recover with
+# add volumes for pgbackrest to write to
+
+VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/10/Dockerfile.upgrade.centos7
+++ b/centos7/10/Dockerfile.upgrade.centos7
@@ -39,10 +39,10 @@ ADD conf/upgrade/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
         chmod -R g=u /opt/cpm /pgolddata /pgnewdata
 
-VOLUME /pgolddata /pgnewdata
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME /pgolddata /pgnewdata
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/11/Dockerfile.backup.centos7
+++ b/centos7/11/Dockerfile.backup.centos7
@@ -36,11 +36,11 @@ ADD conf/backup/ /opt/cpm/conf
 RUN chown -R postgres:postgres  /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 	
+VOLUME ["/pgdata"]
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 USER 26

--- a/centos7/11/Dockerfile.collect.centos7
+++ b/centos7/11/Dockerfile.collect.centos7
@@ -39,12 +39,12 @@ ADD conf/collect /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm/bin /opt/cpm/conf && \
     chmod -R g=u /opt/cpm/bin/ opt/cpm/conf
 
-VOLUME ["/conf"]
-
 # postgres_exporter
 EXPOSE 9187
 
 RUN chmod g=u /etc/passwd
+
+VOLUME ["/conf"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_daemon.sh"]
 

--- a/centos7/11/Dockerfile.pgadmin4.centos7
+++ b/centos7/11/Dockerfile.pgadmin4.centos7
@@ -50,9 +50,10 @@ RUN ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python2.7/site-packages/pga
 
 EXPOSE 5050
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/var/lib/pgadmin", "/certs", "/run/httpd"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/centos7/11/Dockerfile.pgbadger.centos7
+++ b/centos7/11/Dockerfile.pgbadger.centos7
@@ -40,10 +40,10 @@ RUN chown -R postgres:postgres /opt/cpm /report /bin && \
 # pgbadger port
 EXPOSE 10000
 
-VOLUME ["/pgdata", "/report"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata", "/report"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/11/Dockerfile.pgbouncer.centos7
+++ b/centos7/11/Dockerfile.pgbouncer.centos7
@@ -39,9 +39,10 @@ RUN chown -R 2:0 /opt/cpm /pgconf && \
 
 EXPOSE 6432
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/centos7/11/Dockerfile.pgdump.centos7
+++ b/centos7/11/Dockerfile.pgdump.centos7
@@ -36,9 +36,10 @@ ADD conf/pgdump/ /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm /pgdata && \
     chmod -R g=u /opt/cpm /pgdata 
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/pgdata"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 USER 26

--- a/centos7/11/Dockerfile.pgpool.centos7
+++ b/centos7/11/Dockerfile.pgpool.centos7
@@ -46,10 +46,11 @@ RUN chgrp -R 0 /opt/cpm && \
 # open up the postgres port
 EXPOSE 5432
 
+RUN chmod g=u /etc/passwd
+
 # add volumes to allow override of pgpool config files
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/centos7/11/Dockerfile.pgrestore.centos7
+++ b/centos7/11/Dockerfile.pgrestore.centos7
@@ -37,10 +37,10 @@ ADD conf/pgrestore/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/11/Dockerfile.postgres-appdev.centos7
+++ b/centos7/11/Dockerfile.postgres-appdev.centos7
@@ -51,9 +51,6 @@ RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
     chmod -R g=u /opt/cpm /var/lib/pgsql \
     /pgdata /pgconf
 
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-VOLUME ["/pgconf", "/pgdata"]
-
 # open up the postgres port
 EXPOSE 5432
 
@@ -71,6 +68,9 @@ RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+
+# add volumes to allow override of pg_hba.conf and postgresql.conf
+VOLUME ["/pgconf", "/pgdata"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/11/Dockerfile.postgres.centos7
+++ b/centos7/11/Dockerfile.postgres.centos7
@@ -53,14 +53,6 @@ RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
     chmod -R g=u /opt/cpm /var/lib/pgsql \
     /pgdata /pgwal /pgconf /recover /backrestrepo
 
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
-
 # open up the postgres port
 EXPOSE 5432
 
@@ -73,6 +65,14 @@ RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+
+# add volumes to allow override of pg_hba.conf and postgresql.conf
+# add volumes to offer a restore feature
+# add volumes to allow storage of postgres WAL segment files
+# add volumes to locate WAL files to recover with
+# add volumes for pgbackrest to write to
+
+VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/11/Dockerfile.upgrade.centos7
+++ b/centos7/11/Dockerfile.upgrade.centos7
@@ -40,10 +40,10 @@ ADD conf/upgrade/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
         chmod -R g=u /opt/cpm /pgolddata /pgnewdata
 
-VOLUME /pgolddata /pgnewdata
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME /pgolddata /pgnewdata
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/9.5/Dockerfile.backup.centos7
+++ b/centos7/9.5/Dockerfile.backup.centos7
@@ -28,11 +28,11 @@ ADD conf/backup/ /opt/cpm/conf
 RUN chown -R postgres:postgres  /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 	
+VOLUME ["/pgdata"]
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 USER 26

--- a/centos7/9.5/Dockerfile.collect.centos7
+++ b/centos7/9.5/Dockerfile.collect.centos7
@@ -39,12 +39,12 @@ ADD conf/collect /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm/bin /opt/cpm/conf && \
     chmod -R g=u /opt/cpm/bin/ opt/cpm/conf
 
-VOLUME ["/conf"]
-
 # postgres_exporter
 EXPOSE 9187
 
 RUN chmod g=u /etc/passwd
+
+VOLUME ["/conf"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_daemon.sh"]
 

--- a/centos7/9.5/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.5/Dockerfile.pgadmin4.centos7
@@ -50,9 +50,10 @@ RUN ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python2.7/site-packages/pga
 
 EXPOSE 5050
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/var/lib/pgadmin", "/certs", "/run/httpd"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/centos7/9.5/Dockerfile.pgbadger.centos7
+++ b/centos7/9.5/Dockerfile.pgbadger.centos7
@@ -40,11 +40,11 @@ RUN chown -R postgres:postgres /opt/cpm /report /bin && \
 # pgbadger port
 EXPOSE 10000
 
-VOLUME ["/pgdata", "/report"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
-	
+
+VOLUME ["/pgdata", "/report"]
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 

--- a/centos7/9.5/Dockerfile.pgbouncer.centos7
+++ b/centos7/9.5/Dockerfile.pgbouncer.centos7
@@ -39,9 +39,10 @@ RUN chown -R 2:0 /opt/cpm /pgconf && \
 
 EXPOSE 6432
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/centos7/9.5/Dockerfile.pgdump.centos7
+++ b/centos7/9.5/Dockerfile.pgdump.centos7
@@ -36,10 +36,10 @@ ADD conf/pgdump/ /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm /pgdata && \
     chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/9.5/Dockerfile.pgpool.centos7
+++ b/centos7/9.5/Dockerfile.pgpool.centos7
@@ -46,10 +46,11 @@ RUN chgrp -R 0 /opt/cpm && \
 # open up the postgres port
 EXPOSE 5432
 
+RUN chmod g=u /etc/passwd
+
 # add volumes to allow override of pgpool config files
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/centos7/9.5/Dockerfile.pgrestore.centos7
+++ b/centos7/9.5/Dockerfile.pgrestore.centos7
@@ -37,10 +37,10 @@ ADD conf/pgrestore/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/9.5/Dockerfile.postgres.centos7
+++ b/centos7/9.5/Dockerfile.postgres.centos7
@@ -53,14 +53,6 @@ RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
     chmod -R g=u /opt/cpm /var/lib/pgsql \
     /pgdata /pgwal /pgconf /recover /backrestrepo
 
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
-
 # open up the postgres port
 EXPOSE 5432
 
@@ -73,6 +65,14 @@ RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+
+# add volumes to allow override of pg_hba.conf and postgresql.conf
+# add volumes to offer a restore feature
+# add volumes to allow storage of postgres WAL segment files
+# add volumes to locate WAL files to recover with
+# add volumes for pgbackrest to write to
+
+VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/9.6/Dockerfile.backup.centos7
+++ b/centos7/9.6/Dockerfile.backup.centos7
@@ -37,11 +37,11 @@ ADD conf/backup/ /opt/cpm/conf
 RUN chown -R postgres:postgres  /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 	
+VOLUME ["/pgdata"]
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 USER 26

--- a/centos7/9.6/Dockerfile.collect.centos7
+++ b/centos7/9.6/Dockerfile.collect.centos7
@@ -39,12 +39,12 @@ ADD conf/collect /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm/bin /opt/cpm/conf && \
     chmod -R g=u /opt/cpm/bin/ opt/cpm/conf
 
-VOLUME ["/conf"]
-
 # postgres_exporter
 EXPOSE 9187
 
 RUN chmod g=u /etc/passwd
+
+VOLUME ["/conf"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_daemon.sh"]
 

--- a/centos7/9.6/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.6/Dockerfile.pgadmin4.centos7
@@ -50,9 +50,10 @@ RUN ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python2.7/site-packages/pga
 
 EXPOSE 5050
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/var/lib/pgadmin", "/certs", "/run/httpd"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/centos7/9.6/Dockerfile.pgbadger.centos7
+++ b/centos7/9.6/Dockerfile.pgbadger.centos7
@@ -40,11 +40,11 @@ RUN chown -R postgres:postgres /opt/cpm /report /bin && \
 # pgbadger port
 EXPOSE 10000
 
-VOLUME ["/pgdata", "/report"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 	
+VOLUME ["/pgdata", "/report"]
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 

--- a/centos7/9.6/Dockerfile.pgbouncer.centos7
+++ b/centos7/9.6/Dockerfile.pgbouncer.centos7
@@ -39,9 +39,10 @@ RUN chown -R 2:0 /opt/cpm /pgconf && \
 
 EXPOSE 6432
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/centos7/9.6/Dockerfile.pgdump.centos7
+++ b/centos7/9.6/Dockerfile.pgdump.centos7
@@ -36,11 +36,11 @@ ADD conf/pgdump/ /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm /pgdata && \
     chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 	
+VOLUME ["/pgdata"]
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 USER 26

--- a/centos7/9.6/Dockerfile.pgpool.centos7
+++ b/centos7/9.6/Dockerfile.pgpool.centos7
@@ -46,10 +46,11 @@ RUN chgrp -R 0 /opt/cpm && \
 # open up the postgres port
 EXPOSE 5432
 
+RUN chmod g=u /etc/passwd
+
 # add volumes to allow override of pgpool config files
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/centos7/9.6/Dockerfile.pgrestore.centos7
+++ b/centos7/9.6/Dockerfile.pgrestore.centos7
@@ -38,10 +38,10 @@ ADD conf/pgrestore/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/9.6/Dockerfile.postgres.centos7
+++ b/centos7/9.6/Dockerfile.postgres.centos7
@@ -52,14 +52,6 @@ RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
     chmod -R g=u /opt/cpm /var/lib/pgsql \
     /pgdata /pgwal /pgconf /recover /backrestrepo
 
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
-
 # open up the postgres port
 EXPOSE 5432
 
@@ -72,6 +64,14 @@ RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+
+# add volumes to allow override of pg_hba.conf and postgresql.conf
+# add volumes to offer a restore feature
+# add volumes to allow storage of postgres WAL segment files
+# add volumes to locate WAL files to recover with
+# add volumes for pgbackrest to write to
+
+VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/9.6/Dockerfile.upgrade.centos7
+++ b/centos7/9.6/Dockerfile.upgrade.centos7
@@ -38,10 +38,10 @@ ADD conf/upgrade/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
         chmod -R g=u /opt/cpm /pgolddata /pgnewdata
 
-VOLUME /pgolddata /pgnewdata
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME /pgolddata /pgnewdata
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/Dockerfile.grafana.centos7
+++ b/centos7/Dockerfile.grafana.centos7
@@ -31,10 +31,12 @@ ADD conf/grafana /opt/cpm/conf
 RUN chown -R 2:0 /opt/cpm /data && \
     chmod -R g=u /opt/cpm /data
 
-VOLUME ["/data", "/conf"]
 EXPOSE 3000
 
 RUN chmod g=u /etc/passwd
+
+VOLUME ["/data", "/conf"]
+
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/centos7/Dockerfile.pgbasebackup-restore.centos7
+++ b/centos7/Dockerfile.pgbasebackup-restore.centos7
@@ -23,14 +23,14 @@ RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata
 
 RUN chown -R postgres:postgres /opt/cpm /pgdata
 
-VOLUME ["/backup","/pgdata"]
-
 ADD bin/pgbasebackup_restore /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/pgbasebackup_restore /opt/cpm/conf
 
 RUN chmod g=u /etc/passwd \
  && chmod g=u /etc/group
+
+VOLUME ["/backup","/pgdata"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/Dockerfile.prometheus.centos7
+++ b/centos7/Dockerfile.prometheus.centos7
@@ -30,9 +30,11 @@ RUN chown -R 2:0 /opt/cpm /data /conf && \
     chmod -R g=u /opt/cpm /data /conf
 
 EXPOSE 9090
-VOLUME ["/data", "/conf"]
 
 RUN chmod g=u /etc/passwd
+
+VOLUME ["/data", "/conf"]
+
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/rhel7/10/Dockerfile.backup.rhel7
+++ b/rhel7/10/Dockerfile.backup.rhel7
@@ -48,10 +48,10 @@ ADD conf/backup/ /opt/cpm/conf
 RUN chown -R postgres:postgres  /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/10/Dockerfile.collect.rhel7
+++ b/rhel7/10/Dockerfile.collect.rhel7
@@ -53,12 +53,12 @@ ADD conf/collect /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm/bin /opt/cpm/conf && \
     chmod -R g=u /opt/cpm/bin/ opt/cpm/conf
 
-VOLUME ["/conf"]
-
 # postgres_exporter
 EXPOSE 9187
 
 RUN chmod g=u /etc/passwd
+
+VOLUME ["/conf"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_daemon.sh"]
 

--- a/rhel7/10/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/10/Dockerfile.pgadmin4.rhel7
@@ -67,9 +67,10 @@ RUN ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python2.7/site-packages/pga
 
 EXPOSE 5050
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/var/lib/pgadmin", "/certs", "/run/httpd"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/rhel7/10/Dockerfile.pgbadger.rhel7
+++ b/rhel7/10/Dockerfile.pgbadger.rhel7
@@ -54,10 +54,10 @@ RUN chown -R postgres:postgres /opt/cpm /report /bin && \
 # pgbadger port
 EXPOSE 10000
 
-VOLUME ["/pgdata", "/report"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata", "/report"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/10/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/10/Dockerfile.pgbouncer.rhel7
@@ -53,9 +53,10 @@ RUN chown -R 2:0 /opt/cpm /pgconf && \
 
 EXPOSE 6432
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/rhel7/10/Dockerfile.pgdump.rhel7
+++ b/rhel7/10/Dockerfile.pgdump.rhel7
@@ -48,10 +48,10 @@ ADD conf/pgdump/ /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm /pgdata && \
     chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/10/Dockerfile.pgpool.rhel7
+++ b/rhel7/10/Dockerfile.pgpool.rhel7
@@ -60,10 +60,11 @@ RUN chgrp -R 0 /opt/cpm && \
 # open up the postgres port
 EXPOSE 5432
 
+RUN chmod g=u /etc/passwd
+
 # add volumes to allow override of pgpool config files
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/rhel7/10/Dockerfile.pgrestore.rhel7
+++ b/rhel7/10/Dockerfile.pgrestore.rhel7
@@ -49,10 +49,10 @@ ADD conf/pgrestore/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/10/Dockerfile.postgres.rhel7
+++ b/rhel7/10/Dockerfile.postgres.rhel7
@@ -67,14 +67,6 @@ RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
     chmod -R g=u /opt/cpm /var/lib/pgsql \
     /pgdata /pgwal /pgconf /recover /backrestrepo
 
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
-
 # open up the postgres port
 EXPOSE 5432
 
@@ -87,6 +79,14 @@ RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+
+# add volumes to allow override of pg_hba.conf and postgresql.conf
+# add volumes to offer a restore feature
+# add volumes to allow storage of postgres WAL segment files
+# add volumes to locate WAL files to recover with
+# add volumes for pgbackrest to write to
+
+VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/10/Dockerfile.upgrade.rhel7
+++ b/rhel7/10/Dockerfile.upgrade.rhel7
@@ -54,10 +54,10 @@ ADD conf/upgrade/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
         chmod -R g=u /opt/cpm /pgolddata /pgnewdata
 
-VOLUME /pgolddata /pgnewdata
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME /pgolddata /pgnewdata
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/11/Dockerfile.backup.rhel7
+++ b/rhel7/11/Dockerfile.backup.rhel7
@@ -48,10 +48,10 @@ ADD conf/backup/ /opt/cpm/conf
 RUN chown -R postgres:postgres  /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/11/Dockerfile.collect.rhel7
+++ b/rhel7/11/Dockerfile.collect.rhel7
@@ -53,12 +53,12 @@ ADD conf/collect /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm/bin /opt/cpm/conf && \
     chmod -R g=u /opt/cpm/bin/ opt/cpm/conf
 
-VOLUME ["/conf"]
-
 # postgres_exporter
 EXPOSE 9187
 
 RUN chmod g=u /etc/passwd
+
+VOLUME ["/conf"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_daemon.sh"]
 

--- a/rhel7/11/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/11/Dockerfile.pgadmin4.rhel7
@@ -67,9 +67,10 @@ RUN ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python2.7/site-packages/pga
 
 EXPOSE 5050
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/var/lib/pgadmin", "/certs", "/run/httpd"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/rhel7/11/Dockerfile.pgbadger.rhel7
+++ b/rhel7/11/Dockerfile.pgbadger.rhel7
@@ -54,10 +54,10 @@ RUN chown -R postgres:postgres /opt/cpm /report /bin && \
 # pgbadger port
 EXPOSE 10000
 
-VOLUME ["/pgdata", "/report"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata", "/report"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/11/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/11/Dockerfile.pgbouncer.rhel7
@@ -53,9 +53,10 @@ RUN chown -R 2:0 /opt/cpm /pgconf && \
 
 EXPOSE 6432
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/rhel7/11/Dockerfile.pgdump.rhel7
+++ b/rhel7/11/Dockerfile.pgdump.rhel7
@@ -48,10 +48,10 @@ ADD conf/pgdump/ /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm /pgdata && \
     chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/11/Dockerfile.pgpool.rhel7
+++ b/rhel7/11/Dockerfile.pgpool.rhel7
@@ -60,10 +60,11 @@ RUN chgrp -R 0 /opt/cpm && \
 # open up the postgres port
 EXPOSE 5432
 
+RUN chmod g=u /etc/passwd
+
 # add volumes to allow override of pgpool config files
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/rhel7/11/Dockerfile.pgrestore.rhel7
+++ b/rhel7/11/Dockerfile.pgrestore.rhel7
@@ -49,10 +49,10 @@ ADD conf/pgrestore/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/11/Dockerfile.postgres.rhel7
+++ b/rhel7/11/Dockerfile.postgres.rhel7
@@ -67,14 +67,6 @@ RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
     chmod -R g=u /opt/cpm /var/lib/pgsql \
     /pgdata /pgwal /pgconf /recover /backrestrepo
 
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
-
 # open up the postgres port
 EXPOSE 5432
 
@@ -87,6 +79,14 @@ RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+
+# add volumes to allow override of pg_hba.conf and postgresql.conf
+# add volumes to offer a restore feature
+# add volumes to allow storage of postgres WAL segment files
+# add volumes to locate WAL files to recover with
+# add volumes for pgbackrest to write to
+
+VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/11/Dockerfile.upgrade.rhel7
+++ b/rhel7/11/Dockerfile.upgrade.rhel7
@@ -58,10 +58,10 @@ ADD conf/upgrade/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
         chmod -R g=u /opt/cpm /pgolddata /pgnewdata
 
-VOLUME /pgolddata /pgnewdata
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME /pgolddata /pgnewdata
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/9.5/Dockerfile.backup.rhel7
+++ b/rhel7/9.5/Dockerfile.backup.rhel7
@@ -51,10 +51,10 @@ ADD conf/backup/ /opt/cpm/conf
 RUN chown -R postgres:postgres  /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/9.5/Dockerfile.collect.rhel7
+++ b/rhel7/9.5/Dockerfile.collect.rhel7
@@ -53,12 +53,12 @@ ADD conf/collect /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm/bin /opt/cpm/conf && \
     chmod -R g=u /opt/cpm/bin/ opt/cpm/conf
 
-VOLUME ["/conf"]
-
 # postgres_exporter
 EXPOSE 9187
 
 RUN chmod g=u /etc/passwd
+
+VOLUME ["/conf"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_daemon.sh"]
 

--- a/rhel7/9.5/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/9.5/Dockerfile.pgadmin4.rhel7
@@ -67,9 +67,10 @@ RUN ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python2.7/site-packages/pga
 
 EXPOSE 5050
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/var/lib/pgadmin", "/certs", "/run/httpd"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/rhel7/9.5/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbadger.rhel7
@@ -57,10 +57,10 @@ RUN chown -R postgres:postgres /opt/cpm /report /bin && \
 # pgbadger port
 EXPOSE 10000
 
-VOLUME ["/pgdata", "/report"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata", "/report"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/9.5/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbouncer.rhel7
@@ -53,9 +53,10 @@ RUN chown -R 2:0 /opt/cpm /pgconf && \
 
 EXPOSE 6432
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/rhel7/9.5/Dockerfile.pgdump.rhel7
+++ b/rhel7/9.5/Dockerfile.pgdump.rhel7
@@ -51,10 +51,10 @@ ADD conf/pgdump/ /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm /pgdata && \
     chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/9.5/Dockerfile.pgpool.rhel7
+++ b/rhel7/9.5/Dockerfile.pgpool.rhel7
@@ -63,10 +63,11 @@ RUN chgrp -R 0 /opt/cpm && \
 # open up the postgres port
 EXPOSE 5432
 
+RUN chmod g=u /etc/passwd
+
 # add volumes to allow override of pgpool config files
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/rhel7/9.5/Dockerfile.pgrestore.rhel7
+++ b/rhel7/9.5/Dockerfile.pgrestore.rhel7
@@ -49,10 +49,10 @@ ADD conf/pgrestore/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/9.5/Dockerfile.postgres.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres.rhel7
@@ -68,14 +68,6 @@ RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
     chmod -R g=u /opt/cpm /var/lib/pgsql \
     /pgdata /pgwal /pgconf /recover /backrestrepo
 
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
-
 # open up the postgres port
 EXPOSE 5432
 
@@ -88,6 +80,14 @@ RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+
+# add volumes to allow override of pg_hba.conf and postgresql.conf
+# add volumes to offer a restore feature
+# add volumes to allow storage of postgres WAL segment files
+# add volumes to locate WAL files to recover with
+# add volumes for pgbackrest to write to
+
+VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/9.6/Dockerfile.backup.rhel7
+++ b/rhel7/9.6/Dockerfile.backup.rhel7
@@ -48,10 +48,10 @@ ADD conf/backup/ /opt/cpm/conf
 RUN chown -R postgres:postgres  /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/9.6/Dockerfile.collect.rhel7
+++ b/rhel7/9.6/Dockerfile.collect.rhel7
@@ -53,12 +53,12 @@ ADD conf/collect /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm/bin /opt/cpm/conf && \
     chmod -R g=u /opt/cpm/bin/ opt/cpm/conf
 
-VOLUME ["/conf"]
-
 # postgres_exporter
 EXPOSE 9187
 
 RUN chmod g=u /etc/passwd
+
+VOLUME ["/conf"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_daemon.sh"]
 

--- a/rhel7/9.6/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/9.6/Dockerfile.pgadmin4.rhel7
@@ -67,9 +67,10 @@ RUN ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python2.7/site-packages/pga
 
 EXPOSE 5050
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/var/lib/pgadmin", "/certs", "/run/httpd"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/rhel7/9.6/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbadger.rhel7
@@ -54,10 +54,10 @@ RUN chown -R postgres:postgres /opt/cpm /report /bin && \
 # pgbadger port
 EXPOSE 10000
 
-VOLUME ["/pgdata", "/report"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata", "/report"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/9.6/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbouncer.rhel7
@@ -53,9 +53,10 @@ RUN chown -R 2:0 /opt/cpm /pgconf && \
 
 EXPOSE 6432
 
+RUN chmod g=u /etc/passwd
+
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/rhel7/9.6/Dockerfile.pgdump.rhel7
+++ b/rhel7/9.6/Dockerfile.pgdump.rhel7
@@ -48,10 +48,10 @@ ADD conf/pgdump/ /opt/cpm/conf
 RUN chgrp -R 0 /opt/cpm /pgdata && \
     chmod -R g=u /opt/cpm /pgdata 
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/9.6/Dockerfile.pgpool.rhel7
+++ b/rhel7/9.6/Dockerfile.pgpool.rhel7
@@ -60,10 +60,11 @@ RUN chgrp -R 0 /opt/cpm && \
 # open up the postgres port
 EXPOSE 5432
 
+RUN chmod g=u /etc/passwd
+
 # add volumes to allow override of pgpool config files
 VOLUME ["/pgconf"]
 
-RUN chmod g=u /etc/passwd
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/rhel7/9.6/Dockerfile.pgrestore.rhel7
+++ b/rhel7/9.6/Dockerfile.pgrestore.rhel7
@@ -49,10 +49,10 @@ ADD conf/pgrestore/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgdata && \
         chmod -R g=u /opt/cpm /pgdata
 
-VOLUME ["/pgdata"]
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME ["/pgdata"]
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/9.6/Dockerfile.postgres.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres.rhel7
@@ -67,14 +67,6 @@ RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
     chmod -R g=u /opt/cpm /var/lib/pgsql \
     /pgdata /pgwal /pgconf /recover /backrestrepo
 
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
-
 # open up the postgres port
 EXPOSE 5432
 
@@ -87,6 +79,14 @@ RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+
+# add volumes to allow override of pg_hba.conf and postgresql.conf
+# add volumes to offer a restore feature
+# add volumes to allow storage of postgres WAL segment files
+# add volumes to locate WAL files to recover with
+# add volumes for pgbackrest to write to
+
+VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/9.6/Dockerfile.upgrade.rhel7
+++ b/rhel7/9.6/Dockerfile.upgrade.rhel7
@@ -52,10 +52,10 @@ ADD conf/upgrade/ /opt/cpm/conf
 RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
         chmod -R g=u /opt/cpm /pgolddata /pgnewdata
 
-VOLUME /pgolddata /pgnewdata
-
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
+
+VOLUME /pgolddata /pgnewdata
 	
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/Dockerfile.grafana.rhel7
+++ b/rhel7/Dockerfile.grafana.rhel7
@@ -41,10 +41,12 @@ ADD conf/grafana /opt/cpm/conf
 RUN chown -R 2:0 /opt/cpm /data && \
     chmod -R g=u /opt/cpm /data
 
-VOLUME ["/data", "/conf"]
 EXPOSE 3000
 
 RUN chmod g=u /etc/passwd
+
+VOLUME ["/data", "/conf"]
+
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2

--- a/rhel7/Dockerfile.pgbasebackup-restore.rhel7
+++ b/rhel7/Dockerfile.pgbasebackup-restore.rhel7
@@ -27,14 +27,14 @@ RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata
 
 RUN chown -R postgres:postgres /opt/cpm /pgdata
 
-VOLUME ["/backup","/pgdata"]
-
 ADD bin/pgbasebackup_restore /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 ADD conf/pgbasebackup_restore /opt/cpm/conf
 
 RUN chmod g=u /etc/passwd \
  && chmod g=u /etc/group
+
+VOLUME ["/backup","/pgdata"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/Dockerfile.prometheus.rhel7
+++ b/rhel7/Dockerfile.prometheus.rhel7
@@ -41,9 +41,11 @@ RUN chown -R 2:0 /opt/cpm /data && \
     chmod -R g=u /opt/cpm /data
 
 EXPOSE 9090
-VOLUME ["/data", "/conf"]
 
 RUN chmod g=u /etc/passwd
+
+VOLUME ["/data", "/conf"]
+
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
 
 USER 2


### PR DESCRIPTION
Moved **VOLUME** instructions after all **RUN** instructions in all Dockerfiles.  This is to address invalid permissions for the various directories specified in the **VOLUME** instruction when building using `buildah bud`.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The directories specified in the **VOLUME** instruction have invalid permissions if the instruction is defined prior to the last **RUN** instruction.

[ch4775]

**What is the new behavior (if this is a feature change)?**
The VOLUME instruction now occurs after all RUN instructions in all Dockerfiles.


**Other information**:
N/A