### PR TITLE
update to the latest pgbackrest version

### DIFF
--- a/centos7/10/Dockerfile.backrest-restore.centos7
+++ b/centos7/10/Dockerfile.backrest-restore.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg96,pgdg95,pgdg94" \
-    BACKREST_VERSION="2.15.1"
+    BACKREST_VERSION="2.16"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.postgres.centos7
+++ b/centos7/10/Dockerfile.postgres.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg96,pgdg95,pgdg94" \
-    BACKREST_VERSION="2.15.1"
+    BACKREST_VERSION="2.16"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.backrest-restore.centos7
+++ b/centos7/11/Dockerfile.backrest-restore.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg10,pgdg96,pgdg95,pgdg94" \
-    BACKREST_VERSION="2.15.1"
+    BACKREST_VERSION="2.16"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.postgres.centos7
+++ b/centos7/11/Dockerfile.postgres.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg10,pgdg96,pgdg95,pgdg94" \
-    BACKREST_VERSION="2.15.1"
+    BACKREST_VERSION="2.16"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.5/Dockerfile.backrest-restore.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg96,pgdg94" \
-    BACKREST_VERSION="2.15.1"
+    BACKREST_VERSION="2.16"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.postgres.centos7
+++ b/centos7/9.5/Dockerfile.postgres.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg96,pgdg94" \
-    BACKREST_VERSION="2.15.1"
+    BACKREST_VERSION="2.16"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.6/Dockerfile.backrest-restore.centos7
@@ -16,8 +16,8 @@ LABEL name="crunchydata/postgres" \
 
 COPY licenses /licenses
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg95,pgdg94" \ 
-    BACKREST_VERSION="2.15.1"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg95,pgdg94" \
+    BACKREST_VERSION="2.16"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.postgres.centos7
+++ b/centos7/9.6/Dockerfile.postgres.centos7
@@ -16,8 +16,8 @@ LABEL name="crunchydata/postgres" \
 
 COPY licenses /licenses
 
-ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg95,pgdg94" \ 
-    BACKREST_VERSION="2.15.1"
+ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg11,pgdg10,pgdg95,pgdg94" \
+    BACKREST_VERSION="2.16"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/hugo/content/container-specifications/crunchy-backrest-restore.md
+++ b/hugo/content/container-specifications/crunchy-backrest-restore.md
@@ -19,7 +19,7 @@ The following features are supported and required by the crunchy-backrest-restor
 The crunchy-backrest-restore Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
 * PostgreSQL (11.5, 10.10, 9.6.15 and 9.5.19)
-* [pgBackRest](https://pgbackrest.org/) (2.15.1)
+* [pgBackRest](https://pgbackrest.org/) (2.16)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-postgres-gis.md
+++ b/hugo/content/container-specifications/crunchy-postgres-gis.md
@@ -23,7 +23,7 @@ The following features are supported by the `crunchy-postgres-gis` container:
 The crunchy-postgres-gis Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
 * PostgreSQL (11.5, 10.10, 9.6.15 and 9.5.19)
-* [pgBackRest](https://pgbackrest.org/) (2.15.1)
+* [pgBackRest](https://pgbackrest.org/) (2.16)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-postgres.md
+++ b/hugo/content/container-specifications/crunchy-postgres.md
@@ -21,7 +21,7 @@ The following features are supported by the `crunchy-postgres` container:
 The crunchy-postgres Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
 * PostgreSQL (11.5, 10.10, 9.6.15 and 9.5.19)
-* [pgBackRest](https://pgbackrest.org/) (2.15.1)
+* [pgBackRest](https://pgbackrest.org/) (2.16)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/overview/overview.md
+++ b/hugo/content/overview/overview.md
@@ -73,7 +73,7 @@ Crunchy Container Suite provides two types of backup images:
 
 *Physical* backup and restoration tools included in the Crunchy Container suite are:
 
-* [pgBackRest](2.15.1)
+* [pgBackRest](2.16)
   PostgreSQL images
 * [pg_basebackup](https://www.postgresql.org/docs/current/app-pgbasebackup.html) -
   provided by the Crunchy Backup image

--- a/rhel7/10/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/10/Dockerfile.backrest-restore.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="10" BACKREST_VERSION="2.15.1"
+ENV PGVERSION="10" BACKREST_VERSION="2.16"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /

--- a/rhel7/10/Dockerfile.postgres.rhel7
+++ b/rhel7/10/Dockerfile.postgres.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="10" BACKREST_VERSION="2.15.1"
+ENV PGVERSION="10" BACKREST_VERSION="2.16"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf

--- a/rhel7/11/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/11/Dockerfile.backrest-restore.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="11" BACKREST_VERSION="2.15.1"
+ENV PGVERSION="11" BACKREST_VERSION="2.16"
 
 # Crunchy Postgres repo
 ADD conf/RPM-GPG-KEY-crunchydata  /

--- a/rhel7/11/Dockerfile.postgres.rhel7
+++ b/rhel7/11/Dockerfile.postgres.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="11" BACKREST_VERSION="2.15.1"
+ENV PGVERSION="11" BACKREST_VERSION="2.16"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf

--- a/rhel7/9.5/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.5/Dockerfile.backrest-restore.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="9.5" BACKREST_VERSION="2.15.1"
+ENV PGVERSION="9.5" BACKREST_VERSION="2.16"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /

--- a/rhel7/9.5/Dockerfile.postgres.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="9.5" BACKREST_VERSION="2.15.1"
+ENV PGVERSION="9.5" BACKREST_VERSION="2.16"
 
 # PGDG Postgres repo
 #RUN rpm -Uvh http://yum.postgresql.org/9.5/redhat/rhel-7-x86_64/pgdg-redhat95-9.5-3.noarch.rpm

--- a/rhel7/9.6/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.6/Dockerfile.backrest-restore.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="9.6" BACKREST_VERSION="2.15.1"
+ENV PGVERSION="9.6" BACKREST_VERSION="2.16"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /

--- a/rhel7/9.6/Dockerfile.postgres.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="9.6" BACKREST_VERSION="2.15.1"
+ENV PGVERSION="9.6" BACKREST_VERSION="2.16"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf

--- a/ubi7/11/Dockerfile.backrest-restore.ubi7
+++ b/ubi7/11/Dockerfile.backrest-restore.ubi7
@@ -24,7 +24,7 @@ COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="11" BACKREST_VERSION="2.15.1"
+ENV PGVERSION="11" BACKREST_VERSION="2.16"
 
 # Crunchy Postgres repo
 ADD conf/RPM-GPG-KEY-crunchydata  /

--- a/ubi7/11/Dockerfile.postgres.ubi7
+++ b/ubi7/11/Dockerfile.postgres.ubi7
@@ -24,7 +24,7 @@ COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="11" BACKREST_VERSION="2.15.1"
+ENV PGVERSION="11" BACKREST_VERSION="2.16"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf
@@ -34,7 +34,7 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm 
+RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 # && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
 RUN yum -y update && yum -y install bind-utils \
     epel-release \


### PR DESCRIPTION
2.16 version has crucial fixes related to S3 backups
https://pgbackrest.org/release.html
* Retry S3 RequestTimeTooSkewed errors instead of immediately terminating


**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
S3 backup fails to often due to S3 reply-response time being to big. which led to zombifying pgbackrest. which required backrest-repo pod restart

**What is the new behavior (if this is a feature change)?**
New exception can be handled right way with retry


**Other information**:
Contributing guide is hidden on access.crunchydata.com which needs registration, right?