### PR TITLE
Update pgMonitor dependencies [ch4549]

### DIFF
--- a/bin/install-deps.sh
+++ b/bin/install-deps.sh
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 # Dependency Versions
-PROMETHEUS_VERSION=2.7.1
-GRAFANA_VERSION=5.4.5
+PROMETHEUS_VERSION=2.9.2
+GRAFANA_VERSION=6.1.6
 POSTGRES_EXPORTER_VERSION=0.4.7
-NODE_EXPORTER_VERSION=0.16.0
-PGMONITOR_COMMIT='dffb2b5eb04ba13ee47ae81950410738d15e8c76'
+NODE_EXPORTER_VERSION=0.18.0
+PGMONITOR_COMMIT='v3.2'
 OPENSHIFT_CLIENT='https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz'
 CERTSTRAP_VERSION=1.1.1
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Uses a really old version of pgMonitor


**What is the new behavior (if this is a feature change)?**

This brings us up to pgMonitor 3.2. Follows the dependency chart listed here:

https://access.crunchydata.com/documentation/pgmonitor/3.2/changelog/

- Prometeheus: 2.9.2
- Grafana: 6.1.6
- node_exporter: 0.18.0

There are newer version of the postgres_exporter but pgMonitor does not use them yet.

I did not get to try a full build because my CentOS environment is borked, but I can work on doing that.