### PR TITLE
Removing the ability to install from any repo besides UBI and EPEL

### DIFF
--- a/ubi7/11/Dockerfile.backrest-restore.ubi7
+++ b/ubi7/11/Dockerfile.backrest-restore.ubi7
@@ -33,15 +33,16 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm  \
 # && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
-RUN yum -y update && yum -y install  \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager \
 	hostname \
 	gettext \
 	nss_wrapper \
  	procps-ng  \
  && yum -y clean all
 
-RUN yum -y install postgresql11-server  \
- && yum -y install crunchy-backrest-"${BACKREST_VERSION}" \
+RUN yum -y install --disableplugin=subscription-manager postgresql11-server  \
+ && yum -y install --disableplugin=subscription-manager crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/ubi7/11/Dockerfile.backup.ubi7
+++ b/ubi7/11/Dockerfile.backup.ubi7
@@ -33,12 +33,13 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
 # && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
-RUn yum -y update && yum install -y bind-utils \
+RUn yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager bind-utils \
 	gettext \
 	hostname \
 	procps-ng \
 	unzip \
- && yum -y install postgresql11 postgresql11-server \
+ && yum -y install --disableplugin=subscription-manager postgresql11 postgresql11-server \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata

--- a/ubi7/11/Dockerfile.collect.ubi7
+++ b/ubi7/11/Dockerfile.collect.ubi7
@@ -36,7 +36,8 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 # Install postgres client tools and libraries
 #RUN yum install -y epel-release \
 #  && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
-RUN yum -y update  && yum -y install \
+RUN yum -y update --disableplugin=subscription-manager \
+  && yum -y install --disableplugin=subscription-manager \
     gettext \
     postgresql11 \
     postgresql11-libs \

--- a/ubi7/11/Dockerfile.pgadmin4.ubi7
+++ b/ubi7/11/Dockerfile.pgadmin4.ubi7
@@ -35,8 +35,8 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 
 #RUN yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
 #RUN yum -y update && yum -y install epel-release \
-RUN yum -y update \
- && yum -y install \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager \
     glibc-common \
     gcc \
     gettext \
@@ -45,8 +45,8 @@ RUN yum -y update \
     procps-ng \
     mod_wsgi mod_ssl \
 # && yum --enablerepo rhel-7-server-extras-rpms -y install pgadmin4-web \
- && yum -y install pgadmin4-web \
- && yum -y install postgresql11-devel postgresql11-server \
+ && yum -y install --disableplugin=subscription-manager pgadmin4-web \
+ && yum -y install --disableplugin=subscription-manager postgresql11-devel postgresql11-server \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/ubi7/11/Dockerfile.pgbadger.ubi7
+++ b/ubi7/11/Dockerfile.pgbadger.ubi7
@@ -36,7 +36,8 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 #RUN yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
 # && yum -y install epel-release \
 #RUN yum -y update && yum -y install --enablerepo="rhel-7-server-optional-rpms" \
-RUN yum -y update && yum -y install  \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager \
       gettext \
       hostname \
       pgbadger \

--- a/ubi7/11/Dockerfile.pgbench.ubi7
+++ b/ubi7/11/Dockerfile.pgbench.ubi7
@@ -34,13 +34,15 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
 # && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
-RUN yum -y update && yum -y install bind-utils \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager \
+    bind-utils \
     gettext \
     hostname \
     procps-ng \
     rsync \
- && yum -y reinstall glibc-common \
- && yum -y install postgresql11 \
+ && yum -y reinstall --disableplugin=subscription-manager glibc-common \
+ && yum -y install --disableplugin=subscription-manager postgresql11 \
  && yum -y clean all
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf

--- a/ubi7/11/Dockerfile.pgbouncer.ubi7
+++ b/ubi7/11/Dockerfile.pgbouncer.ubi7
@@ -35,8 +35,8 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 
 #RUN yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
 #RUN yum -y update && yum -y install epel-release \
-RUN yum -y update \
- && yum -y install \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager \
       gettext \
       hostname  \
       pgbouncer \

--- a/ubi7/11/Dockerfile.pgdump.ubi7
+++ b/ubi7/11/Dockerfile.pgdump.ubi7
@@ -33,12 +33,14 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
 # && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
-RUN yum -y update && yum install -y bind-utils \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager \
+        bind-utils \
 	gettext \
 	hostname \
 	procps-ng \
 	unzip \
- && yum -y install postgresql11 postgresql11-server \
+ && yum -y install --disableplugin=subscription-manager postgresql11 postgresql11-server \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata

--- a/ubi7/11/Dockerfile.pgpool.ubi7
+++ b/ubi7/11/Dockerfile.pgpool.ubi7
@@ -35,12 +35,12 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 
 #RUN yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
 #RUN yum -y update && yum -y install epel-release \
-RUN yum -y update  \
- && yum -y install \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager \
       gettext \
       hostname \
       procps-ng \
- && yum -y install \
+ && yum -y install --disableplugin=subscription-manager \
       postgresql11 \
       pgpool-II-11 \
       pgpool-II-11-extensions \

--- a/ubi7/11/Dockerfile.pgrestore.ubi7
+++ b/ubi7/11/Dockerfile.pgrestore.ubi7
@@ -33,13 +33,15 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
 # && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
-RUN yum -y update && yum install -y bind-utils \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager \
+        bind-utils \
 	gettext \
 	hostname \
 	procps-ng \
 	unzip \
 	file \
- && yum -y install postgresql11 postgresql11-server \
+ && yum -y install --disableplugin=subscription-manager postgresql11 postgresql11-server \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata

--- a/ubi7/11/Dockerfile.postgres-gis.ubi7
+++ b/ubi7/11/Dockerfile.postgres-gis.ubi7
@@ -22,7 +22,7 @@ LABEL name="crunchydata/postgres-gis" \
 USER 0
 
 #RUN yum -y install --enablerepo=rhel-7-server-optional-rpms \
-RUN yum -y install  \
+RUN yum -y install --disableplugin=subscription-manager \
     R-core libRmath texinfo-tex texlive-epsf \
     postgis24_11 postgis24_11-client pgrouting_11 plr11 \
  && yum -y clean all

--- a/ubi7/11/Dockerfile.postgres.ubi7
+++ b/ubi7/11/Dockerfile.postgres.ubi7
@@ -36,18 +36,21 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm 
 # && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
-RUN yum -y update && yum -y install bind-utils \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager \
+    bind-utils \
     epel-release \
     gettext \
     hostname \
     procps-ng \
     rsync \
     psmisc openssh-server openssh-clients \
- && yum -y reinstall glibc-common \
- && yum -y install postgresql11 postgresql11-contrib postgresql11-server \
+ && yum -y reinstall --disableplugin=subscription-manager glibc-common \
+ && yum -y install --disableplugin=subscription-manager \
+    postgresql11 postgresql11-contrib postgresql11-server \
     pgaudit11 pgaudit11_set_user postgresql11-plpython \
- && yum -y install crunchy-backrest-"${BACKREST_VERSION}" \
- && yum -y --setopt=tsflags='' install pgaudit_analyze \
+ && yum -y install --disableplugin=subscription-manager crunchy-backrest-"${BACKREST_VERSION}" \
+ && yum -y --setopt=tsflags='' install --disableplugin=subscription-manager pgaudit_analyze \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/ubi7/11/Dockerfile.upgrade.ubi7
+++ b/ubi7/11/Dockerfile.upgrade.ubi7
@@ -38,13 +38,14 @@ ADD conf/crunchypg11.repo /etc/yum.repos.d/
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
 # && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
-RUN yum -y update && yum -y update glibc-common \
- && yum install -y bind-utils \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y update --disableplugin=subscription-manager glibc-common \
+ && yum -y install --disableplugin=subscription-manager bind-utils \
 	gettext \
 	hostname \
 	procps-ng \
 	unzip \
- && yum -y install \
+ && yum -y install --disableplugin=subscription-manager \
  postgresql95 postgresql95-server postgresql95-contrib pgaudit95 \
  postgresql96 postgresql96-server postgresql96-contrib pgaudit96 \
  postgresql10 postgresql10-server postgresql10-contrib pgaudit10 \

--- a/ubi7/Dockerfile.grafana.ubi7
+++ b/ubi7/Dockerfile.grafana.ubi7
@@ -24,7 +24,8 @@ COPY licenses /licenses
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
 #  && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms update \
-RUN yum -y update  && yum -y install \
+RUN yum -y update  --disableplugin=subscription-manager \
+  && yum -y install --disableplugin=subscription-manager \
     bind-utils \
     gettext \
     hostname \

--- a/ubi7/Dockerfile.node-exporter.ubi7
+++ b/ubi7/Dockerfile.node-exporter.ubi7
@@ -24,7 +24,8 @@ COPY licenses /licenses
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
 #  && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms update \
-RUN yum -y update  && yum -y install \
+RUN yum -y update --disableplugin=subscription-manager \
+  && yum -y install --disableplugin=subscription-manager \
     bind-utils \
     gettext \
     hostname \

--- a/ubi7/Dockerfile.pgbasebackup-restore.ubi7
+++ b/ubi7/Dockerfile.pgbasebackup-restore.ubi7
@@ -17,8 +17,8 @@ COPY conf/atomic/pgbasebackup_restore/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-RUN yum -y update \
- && yum -y install rsync  \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager rsync  \
  && yum -y clean all
 
 RUN groupadd postgres -g 26 \

--- a/ubi7/Dockerfile.prometheus.ubi7
+++ b/ubi7/Dockerfile.prometheus.ubi7
@@ -24,7 +24,8 @@ COPY licenses /licenses
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
 #  && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms update \
-RUN yum -y update  && yum -y install \
+RUN yum -y update --disableplugin=subscription-manager \
+  && yum -y install --disableplugin=subscription-manager \
     bind-utils \
     gettext \
     hostname \

--- a/ubi7/Dockerfile.scheduler.ubi7
+++ b/ubi7/Dockerfile.scheduler.ubi7
@@ -21,7 +21,8 @@ COPY licenses /licenses
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
  # && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms update \
-RUN yum -y update  && yum -y install \
+RUN yum -y update --disableplugin=subscription-manager \
+  && yum -y install --disableplugin=subscription-manager \
     bind-utils \
     gettext \
     hostname \


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently in a UBI build if you are using a RHEL VM that is registered with RH then when you build the containers they pull in packages from the rhel server rpms repo instead of from the UBI repo.

**What is the new behavior (if this is a feature change)?**
Pulls in the packages only from UBI repos and if necessary EPEL.  This will cause some of the containers to fail to build due to UBI not having all the necessary dependencies.

**Other information**:
