### PR TITLE
General Dockerfile cleanup, add flag to force yum

### DIFF
--- a/ubi7/11/Dockerfile.backrest-restore.ubi7
+++ b/ubi7/11/Dockerfile.backrest-restore.ubi7
@@ -3,21 +3,21 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/crunchy-backrest-restore" \
-        vendor="crunchy data" \
-	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="Executes the pgbackrest utility, allowing FULL & DELTA restore capability." \
-        description="Executes pgbackrest utility, allowing FULL, DELTA & PITR restore capability. Capable of mounting the /backrestrepo for access to pgbackrest archives, while allowing for the configuration of pgbackrest using applicable pgbackrest environment variables." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="backrest restore container" \
-        io.k8s.display-name="Crunchy backrest restore container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      PostgresVersion="11" \
+      PostgresFullVersion="11.5" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Executes the pgbackrest utility, allowing FULL & DELTA restore capability." \
+      description="Executes pgbackrest utility, allowing FULL, DELTA & PITR restore capability. Capable of mounting the /backrestrepo for access to pgbackrest archives, while allowing for the configuration of pgbackrest using applicable pgbackrest environment variables." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="backrest restore container" \
+      io.k8s.display-name="Crunchy backrest restore container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/backrestrestore/help.1 /help.1
 COPY conf/atomic/backrestrestore/help.md /help.md
@@ -34,35 +34,35 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
-	hostname \
-	gettext \
-	nss_wrapper \
- 	procps-ng  \
+    hostname \
+    gettext \
+    nss_wrapper \
+    procps-ng  \
  && yum -y clean all
 
 RUN yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql11-server  \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
-ENV	PGROOT="/usr/pgsql-${PGVERSION}"
+ENV PGROOT="/usr/pgsql-${PGVERSION}"
 
 # add path settings for postgres user
 ADD conf/.bash_profile /var/lib/pgsql/
 
 # set up cpm directory
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /backrestrepo \
-	/var/lib/pgsql /var/log/pgbackrest
+    /var/lib/pgsql /var/log/pgbackrest
 
 RUN chown -R postgres:postgres /opt/cpm  \
-	/pgdata /backrestrepo  \
-	/var/lib/pgsql /var/log/pgbackrest
+    /pgdata /backrestrepo \
+    /var/lib/pgsql /var/log/pgbackrest
 
 #RUN chgrp -R 0 /opt/cpm  \
-#	/pgdata /backrestrepo  \
-#	/var/lib/pgsql /var/log/pgbackrest && \
-#    chmod -R g=u /opt/cpm  \
-#	/pgdata /backrestrepo  \
-#	/var/lib/pgsql /var/log/pgbackrest
+#  /pgdata /backrestrepo  \
+#  /var/lib/pgsql /var/log/pgbackrest && \
+#  chmod -R g=u /opt/cpm  \
+#  /pgdata /backrestrepo  \
+#  /var/lib/pgsql /var/log/pgbackrest
 
 # volume backrestrepo for pgbackrest to restore from and log
 VOLUME /pgdata /backrestrepo
@@ -77,10 +77,9 @@ ADD conf/backrest_restore /opt/cpm/conf
 
 # Removed to rely on nss_wrapper for now
 #RUN chmod g=u /etc/passwd && \
-#	chmod g=u /etc/group
+#  chmod g=u /etc/group
 #
 #ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
-
 
 USER 26
 CMD ["/opt/cpm/bin/start.sh"]

--- a/ubi7/11/Dockerfile.backrest-restore.ubi7
+++ b/ubi7/11/Dockerfile.backrest-restore.ubi7
@@ -31,18 +31,17 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm  \
-# && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
+#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
 	hostname \
 	gettext \
 	nss_wrapper \
  	procps-ng  \
  && yum -y clean all
 
-RUN yum -y install --disableplugin=subscription-manager postgresql11-server  \
- && yum -y install --disableplugin=subscription-manager crunchy-backrest-"${BACKREST_VERSION}" \
+RUN yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql11-server  \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 ENV	PGROOT="/usr/pgsql-${PGVERSION}"

--- a/ubi7/11/Dockerfile.backup.ubi7
+++ b/ubi7/11/Dockerfile.backup.ubi7
@@ -3,21 +3,21 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/backup" \
-        vendor="crunchy data" \
-	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="Performs a pg_basebackup full database backup on a database container" \
-        description="Meant to be executed upon demand, this container will run pg_basebackup against a running database container and write the backup files to a mounted directory." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="backup container" \
-        io.k8s.display-name="Crunchy backup container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      PostgresVersion="11" \
+      PostgresFullVersion="11.5" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Performs a pg_basebackup full database backup on a database container" \
+      description="Meant to be executed upon demand, this container will run pg_basebackup against a running database container and write the backup files to a mounted directory." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="backup container" \
+      io.k8s.display-name="Crunchy backup container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/backup/help.1 /help.1
 COPY conf/atomic/backup/help.md /help.md
@@ -34,10 +34,10 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False bind-utils \
-	gettext \
-	hostname \
-	procps-ng \
-	unzip \
+    gettext \
+    hostname \
+    procps-ng \
+    unzip \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql11 postgresql11-server \
  && yum clean all -y
 
@@ -47,13 +47,13 @@ ADD bin/common /opt/cpm/bin
 ADD conf/backup/ /opt/cpm/conf
 
 RUN chown -R postgres:postgres  /opt/cpm /pgdata && \
-        chmod -R g=u /opt/cpm /pgdata 
+    chmod -R g=u /opt/cpm /pgdata 
 
 VOLUME ["/pgdata"]
 
 RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-	
+    chmod g=u /etc/group
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 USER 26

--- a/ubi7/11/Dockerfile.backup.ubi7
+++ b/ubi7/11/Dockerfile.backup.ubi7
@@ -31,15 +31,14 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-# && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
-RUn yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager bind-utils \
+#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False bind-utils \
 	gettext \
 	hostname \
 	procps-ng \
 	unzip \
- && yum -y install --disableplugin=subscription-manager postgresql11 postgresql11-server \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql11 postgresql11-server \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata

--- a/ubi7/11/Dockerfile.collect.ubi7
+++ b/ubi7/11/Dockerfile.collect.ubi7
@@ -31,13 +31,10 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-
 # Install postgres client tools and libraries
-#RUN yum install -y epel-release \
-#  && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
+RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
-  && yum -y install --disableplugin=subscription-manager \
+  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     gettext \
     postgresql11 \
     postgresql11-libs \

--- a/ubi7/11/Dockerfile.collect.ubi7
+++ b/ubi7/11/Dockerfile.collect.ubi7
@@ -3,21 +3,21 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/collect" \
-        vendor="crunchy data" \
-	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="Provides metrics for crunchy-postgres" \
-        description="Run with crunchy-postgres, crunchy-collect reads the Postgres data directory and has a SQL interface to a database to allow for metrics collection. Used in conjunction with crunchy-prometheus and crunchy-grafana." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="collect container" \
-        io.k8s.display-name="Crunchy collect container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      PostgresVersion="11" \
+      PostgresFullVersion="11.5" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Provides metrics for crunchy-postgres" \
+      description="Run with crunchy-postgres, crunchy-collect reads the Postgres data directory and has a SQL interface to a database to allow for metrics collection. Used in conjunction with crunchy-prometheus and crunchy-grafana." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="collect container" \
+      io.k8s.display-name="Crunchy collect container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/collect/help.1 /help.1
 COPY conf/atomic/collect/help.md /help.md
@@ -34,12 +34,12 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 # Install postgres client tools and libraries
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
-  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     gettext \
     postgresql11 \
     postgresql11-libs \
     hostname \
-  && yum -y clean all
+ && yum -y clean all
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf
 

--- a/ubi7/11/Dockerfile.pgadmin4.ubi7
+++ b/ubi7/11/Dockerfile.pgadmin4.ubi7
@@ -32,11 +32,8 @@ ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-
-#RUN yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
-#RUN yum -y update && yum -y install epel-release \
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     glibc-common \
     gcc \
     gettext \
@@ -45,8 +42,8 @@ RUN yum -y update --disableplugin=subscription-manager \
     procps-ng \
     mod_wsgi mod_ssl \
 # && yum --enablerepo rhel-7-server-extras-rpms -y install pgadmin4-web \
- && yum -y install --disableplugin=subscription-manager pgadmin4-web \
- && yum -y install --disableplugin=subscription-manager postgresql11-devel postgresql11-server \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False pgadmin4-web \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql11-devel postgresql11-server \
  && yum -y clean all
 
 ENV PGROOT="/usr/pgsql-${PGVERSION}"

--- a/ubi7/11/Dockerfile.pgadmin4.ubi7
+++ b/ubi7/11/Dockerfile.pgadmin4.ubi7
@@ -3,21 +3,21 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/pgadmin4" \
-        vendor="crunchy data" \
-	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="Crunchy Data pgAdmin4 GUI utility" \
-        description="Provides GUI for the pgAdmin utility." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="pgadmin4 container" \
-        io.k8s.display-name="Crunchy pgadmin4 container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      PostgresVersion="11" \
+      PostgresFullVersion="11.5" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Crunchy Data pgAdmin4 GUI utility" \
+      description="Provides GUI for the pgAdmin utility." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="pgadmin4 container" \
+      io.k8s.display-name="Crunchy pgadmin4 container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/pgadmin4/help.1 /help.1
 COPY conf/atomic/pgadmin4/help.md /help.md
@@ -41,7 +41,6 @@ RUN yum -y update --disableplugin=subscription-manager \
     openssl \
     procps-ng \
     mod_wsgi mod_ssl \
-# && yum --enablerepo rhel-7-server-extras-rpms -y install pgadmin4-web \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False pgadmin4-web \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql11-devel postgresql11-server \
  && yum -y clean all
@@ -55,15 +54,15 @@ ADD bin/common /opt/cpm/bin
 ADD conf/pgadmin4/ /opt/cpm/conf
 
 RUN cp /opt/cpm/conf/httpd.conf /etc/httpd/conf/httpd.conf \
-  && rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/ssl.conf
+ && rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/ssl.conf
 
 RUN chown -R 2:0 /usr/lib/python2.7/site-packages/pgadmin4-web \
-   /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd && \
+    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd && \
     chmod -R g=u /usr/lib/python2.7/site-packages/pgadmin4-web \
-   /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd
+    /var/lib/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd
 
 RUN ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python2.7/site-packages/pgadmin4-web/config_local.py \
-  && ln -sf /var/lib/pgadmin/pgadmin.conf /etc/httpd/conf.d/pgadmin.conf
+ && ln -sf /var/lib/pgadmin/pgadmin.conf /etc/httpd/conf.d/pgadmin.conf
 
 EXPOSE 5050
 

--- a/ubi7/11/Dockerfile.pgadmin4.ubi7
+++ b/ubi7/11/Dockerfile.pgadmin4.ubi7
@@ -31,7 +31,7 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     glibc-common \

--- a/ubi7/11/Dockerfile.pgbadger.ubi7
+++ b/ubi7/11/Dockerfile.pgbadger.ubi7
@@ -3,21 +3,21 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/pgbadger" \
-        vendor="crunchy data" \
-	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="HTTP wrapper around the PGBadger PostgreSQL utility" \
-        description="Has an HTTP REST interface. You GET http://host:10000/api/badgergenerate, and it will generate a pgbadger report on a database container's log files." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="pgbadger container" \
-        io.k8s.display-name="Crunchy pgbadger container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      PostgresVersion="11" \
+      PostgresFullVersion="11.5" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="HTTP wrapper around the PGBadger PostgreSQL utility" \
+      description="Has an HTTP REST interface. You GET http://host:10000/api/badgergenerate, and it will generate a pgbadger report on a database container's log files." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="pgbadger container" \
+      io.k8s.display-name="Crunchy pgbadger container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/pgbadger/help.1 /help.1
 COPY conf/atomic/pgbadger/help.md /help.md
@@ -34,9 +34,9 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
-      gettext \
-      hostname \
-      pgbadger \
+    gettext \
+    hostname \
+    pgbadger \
  && yum clean all -y
 
 RUN groupadd -g 26 postgres && useradd -g 26 -u 26 postgres
@@ -48,7 +48,7 @@ ADD bin/common /opt/cpm/bin
 ADD bin/pgbadger /opt/cpm/bin
 
 RUN chown -R postgres:postgres /opt/cpm /report /bin && \
-        chmod -R g=u /opt/cpm /report /bin
+    chmod -R g=u /opt/cpm /report /bin
 
 # pgbadger port
 EXPOSE 10000
@@ -56,10 +56,9 @@ EXPOSE 10000
 VOLUME ["/pgdata", "/report"]
 
 RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
+    chmod g=u /etc/group
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
-
 
 USER 26
 

--- a/ubi7/11/Dockerfile.pgbadger.ubi7
+++ b/ubi7/11/Dockerfile.pgbadger.ubi7
@@ -32,12 +32,8 @@ ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-
-#RUN yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
-# && yum -y install epel-release \
-#RUN yum -y update && yum -y install --enablerepo="rhel-7-server-optional-rpms" \
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
       gettext \
       hostname \
       pgbadger \

--- a/ubi7/11/Dockerfile.pgbench.ubi7
+++ b/ubi7/11/Dockerfile.pgbench.ubi7
@@ -32,17 +32,16 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-# && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
+#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     bind-utils \
     gettext \
     hostname \
     procps-ng \
     rsync \
  && yum -y reinstall --disableplugin=subscription-manager glibc-common \
- && yum -y install --disableplugin=subscription-manager postgresql11 \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql11 \
  && yum -y clean all
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf

--- a/ubi7/11/Dockerfile.pgbench.ubi7
+++ b/ubi7/11/Dockerfile.pgbench.ubi7
@@ -3,21 +3,21 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/pgbench" \
-        vendor="crunchy data" \
-	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-    	summary="pgBench 11.2 (PGDG) on a RHEL7 base image" \
-        description="pgbench is a simple program for running benchmark tests on PostgreSQL. It runs the same sequence of SQL commands over and over, possibly in multiple concurrent database sessions, and then calculates the average transaction rate (transactions per second)." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="pgbench container" \
-        io.k8s.display-name="Crunchy pgbench container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      PostgresVersion="11" \
+      PostgresFullVersion="11.5" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="pgBench 11.2 (PGDG) on a RHEL7 base image" \
+      description="pgbench is a simple program for running benchmark tests on PostgreSQL. It runs the same sequence of SQL commands over and over, possibly in multiple concurrent database sessions, and then calculates the average transaction rate (transactions per second)." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="pgbench container" \
+      io.k8s.display-name="Crunchy pgbench container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/pgbench/help.1 /help.1
 COPY conf/atomic/pgbench/help.md /help.md
@@ -54,7 +54,7 @@ ADD bin/common /opt/cpm/bin
 ADD conf/pgbench /opt/cpm/conf
 
 RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
+    chmod g=u /etc/group
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/ubi7/11/Dockerfile.pgbouncer.ubi7
+++ b/ubi7/11/Dockerfile.pgbouncer.ubi7
@@ -32,11 +32,8 @@ ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-
-#RUN yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
-#RUN yum -y update && yum -y install epel-release \
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
       gettext \
       hostname  \
       pgbouncer \

--- a/ubi7/11/Dockerfile.pgbouncer.ubi7
+++ b/ubi7/11/Dockerfile.pgbouncer.ubi7
@@ -3,21 +3,21 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/pgbouncer" \
-	vendor="crunchy data" \
-	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="Lightweight connection pooler for crunchy-postgres" \
-        description="The aim of crunchy-pgbouncer is to lower the performance impact of opening new connections to PostgreSQL; clients connect through this service. It offers session, transaction and statement pooling." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="pgbouncer container" \
-        io.k8s.display-name="Crunchy pgbouncer container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      PostgresVersion="11" \
+      PostgresFullVersion="11.5" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Lightweight connection pooler for crunchy-postgres" \
+      description="The aim of crunchy-pgbouncer is to lower the performance impact of opening new connections to PostgreSQL; clients connect through this service. It offers session, transaction and statement pooling." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="pgbouncer container" \
+      io.k8s.display-name="Crunchy pgbouncer container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/pgbouncer/help.1 /help.1
 COPY conf/atomic/pgbouncer/help.md /help.md
@@ -34,11 +34,11 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
-      gettext \
-      hostname  \
-      pgbouncer \
-      postgresql11 \
-      procps-ng \
+    gettext \
+    hostname  \
+    pgbouncer \
+    postgresql11 \
+    procps-ng \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgconf

--- a/ubi7/11/Dockerfile.pgdump.ubi7
+++ b/ubi7/11/Dockerfile.pgdump.ubi7
@@ -3,21 +3,21 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/pgdump" \
-        vendor="crunchy data" \
-	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="Performs a pg_dump on a database container" \
-        description="Meant to be executed upon demand, this container will run pg_dump against a running database container and write the backup files to a mounted directory." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="pgdump container" \
-        io.k8s.display-name="Crunchy pgdump container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      PostgresVersion="11" \
+      PostgresFullVersion="11.5" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Performs a pg_dump on a database container" \
+      description="Meant to be executed upon demand, this container will run pg_dump against a running database container and write the backup files to a mounted directory." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="pgdump container" \
+      io.k8s.display-name="Crunchy pgdump container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/pgdump/help.1 /help.1
 COPY conf/atomic/pgdump/help.md /help.md
@@ -34,11 +34,11 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
-        bind-utils \
-	gettext \
-	hostname \
-	procps-ng \
-	unzip \
+    bind-utils \
+    gettext \
+    hostname \
+    procps-ng \
+    unzip \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql11 postgresql11-server \
  && yum clean all -y
 
@@ -53,8 +53,8 @@ RUN chgrp -R 0 /opt/cpm /pgdata && \
 VOLUME ["/pgdata"]
 
 RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-	
+    chmod g=u /etc/group
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 USER 26

--- a/ubi7/11/Dockerfile.pgdump.ubi7
+++ b/ubi7/11/Dockerfile.pgdump.ubi7
@@ -31,16 +31,15 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-# && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
+#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
         bind-utils \
 	gettext \
 	hostname \
 	procps-ng \
 	unzip \
- && yum -y install --disableplugin=subscription-manager postgresql11 postgresql11-server \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql11 postgresql11-server \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata

--- a/ubi7/11/Dockerfile.pgpool.ubi7
+++ b/ubi7/11/Dockerfile.pgpool.ubi7
@@ -32,15 +32,12 @@ ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-
-#RUN yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
-#RUN yum -y update && yum -y install epel-release \
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
       gettext \
       hostname \
       procps-ng \
- && yum -y install --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
       postgresql11 \
       pgpool-II-11 \
       pgpool-II-11-extensions \

--- a/ubi7/11/Dockerfile.pgpool.ubi7
+++ b/ubi7/11/Dockerfile.pgpool.ubi7
@@ -3,21 +3,21 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/pgpool" \
-	vendor="crunchy data" \
-	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
-	Version="7.7" \
-	Release="2.4.2" \
-  url="https://crunchydata.com" \
-  summary="Contains the pgpool utility as a PostgreSQL-aware load balancer" \
-  description="Offers a smart load balancer in front of a Postgres cluster, sending writes only to the primary and reads to the replica(s). This allows an application to only have a single connection point when interacting with a Postgres cluster." \
-  run="" \
-  start="" \
-  stop="" \
-  io.k8s.description="pgpool container" \
-  io.k8s.display-name="Crunchy pgpool container" \
-  io.openshift.expose-services="" \
-  io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      PostgresVersion="11" \
+      PostgresFullVersion="11.5" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Contains the pgpool utility as a PostgreSQL-aware load balancer" \
+      description="Offers a smart load balancer in front of a Postgres cluster, sending writes only to the primary and reads to the replica(s). This allows an application to only have a single connection point when interacting with a Postgres cluster." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="pgpool container" \
+      io.k8s.display-name="Crunchy pgpool container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/pgpool/help.1 /help.1
 COPY conf/atomic/pgpool/help.md /help.md
@@ -34,13 +34,13 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
-      gettext \
-      hostname \
-      procps-ng \
+    gettext \
+    hostname \
+    procps-ng \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
-      postgresql11 \
-      pgpool-II-11 \
-      pgpool-II-11-extensions \
+    postgresql11 \
+    pgpool-II-11 \
+    pgpool-II-11-extensions \
  && yum -y clean all
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf
@@ -50,11 +50,10 @@ ADD bin/common /opt/cpm/bin
 ADD conf/pgpool /opt/cpm/conf
 
 RUN ln -sf /opt/cpm/conf/pool_hba.conf /etc/pgpool-II-11/pool_hba.conf \
-  && ln -sf /opt/cpm/conf/pgpool/pool_passwd /etc/pgpool-II-11/pool_passwd
+ && ln -sf /opt/cpm/conf/pgpool/pool_passwd /etc/pgpool-II-11/pool_passwd
 
 RUN chgrp -R 0 /opt/cpm && \
     chmod -R g=u /opt/cpm
-
 
 # open up the postgres port
 EXPOSE 5432

--- a/ubi7/11/Dockerfile.pgrestore.ubi7
+++ b/ubi7/11/Dockerfile.pgrestore.ubi7
@@ -31,17 +31,16 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-# && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
+#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
         bind-utils \
 	gettext \
 	hostname \
 	procps-ng \
 	unzip \
 	file \
- && yum -y install --disableplugin=subscription-manager postgresql11 postgresql11-server \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql11 postgresql11-server \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata

--- a/ubi7/11/Dockerfile.pgrestore.ubi7
+++ b/ubi7/11/Dockerfile.pgrestore.ubi7
@@ -3,21 +3,21 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/restore" \
-        vendor="crunchy data" \
-	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="Performs a pg_restore on a database container" \
-        description="Meant to be executed upon demand, this container will run pg_restore against a running database container and write the backup files to a mounted directory." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="pgrestore container" \
-        io.k8s.display-name="Crunchy pgrestore container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      PostgresVersion="11" \
+      PostgresFullVersion="11.5" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Performs a pg_restore on a database container" \
+      description="Meant to be executed upon demand, this container will run pg_restore against a running database container and write the backup files to a mounted directory." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="pgrestore container" \
+      io.k8s.display-name="Crunchy pgrestore container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/pgrestore/help.1 /help.1
 COPY conf/atomic/pgrestore/help.md /help.md
@@ -34,12 +34,12 @@ RUN rpm --import RPM-GPG-KEY-crunchydata
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
-        bind-utils \
-	gettext \
-	hostname \
-	procps-ng \
-	unzip \
-	file \
+    bind-utils \
+    gettext \
+    hostname \
+    procps-ng \
+    unzip \
+    file \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql11 postgresql11-server \
  && yum clean all -y
 
@@ -49,13 +49,13 @@ ADD bin/common /opt/cpm/bin
 ADD conf/pgrestore/ /opt/cpm/conf
 
 RUN chown -R postgres:postgres /opt/cpm /pgdata && \
-        chmod -R g=u /opt/cpm /pgdata
+    chmod -R g=u /opt/cpm /pgdata
 
 VOLUME ["/pgdata"]
 
 RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-	
+    chmod g=u /etc/group
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 USER 26

--- a/ubi7/11/Dockerfile.postgres-appdev.ubi7
+++ b/ubi7/11/Dockerfile.postgres-appdev.ubi7
@@ -1,18 +1,18 @@
 FROM ubi7
 
 LABEL name="crunchydata/postgres-appdev" \
-        vendor="crunchydata" \
-	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="A PostgreSQL image that makes life easier for application developers. NOT FOR PRODUCTION USE" \
-        description="A container image that contains all the extensions application developers probably want with extra ease of use" \
-        io.k8s.description="postgres-appdev container" \
-        io.k8s.display-name="Crunchy Data postgres-appdev container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchydata,database"
+      vendor="crunchydata" \
+      PostgresVersion="11" \
+      PostgresFullVersion="11.5" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="A PostgreSQL image that makes life easier for application developers. NOT FOR PRODUCTION USE" \
+      description="A container image that contains all the extensions application developers probably want with extra ease of use" \
+      io.k8s.description="postgres-appdev container" \
+      io.k8s.display-name="Crunchy Data postgres-appdev container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchydata,database"
 
 COPY conf/atomic/pgdump/help.1 /help.1
 COPY conf/atomic/pgdump/help.md /help.md
@@ -73,7 +73,7 @@ ADD conf/postgres /opt/cpm/conf
 ADD tools/pgmonitor/exporter/postgres /opt/cpm/bin/modules
 
 RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
+    chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 

--- a/ubi7/11/Dockerfile.postgres-gis.ubi7
+++ b/ubi7/11/Dockerfile.postgres-gis.ubi7
@@ -3,21 +3,21 @@ FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/postgres-gis" \
-        vendor="crunchy data" \
-	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="Includes PostGIS extensions on top of crunchy-postgres" \
-        description="An identical image of crunchy-postgres with the extra PostGIS and pgrouting packages added for users that require PostGIS." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="postgres-gis container" \
-        io.k8s.display-name="Crunchy postgres-gis container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      PostgresVersion="11" \
+      PostgresFullVersion="11.5" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Includes PostGIS extensions on top of crunchy-postgres" \
+      description="An identical image of crunchy-postgres with the extra PostGIS and pgrouting packages added for users that require PostGIS." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="postgres-gis container" \
+      io.k8s.display-name="Crunchy postgres-gis container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 USER 0
 

--- a/ubi7/11/Dockerfile.postgres-gis.ubi7
+++ b/ubi7/11/Dockerfile.postgres-gis.ubi7
@@ -21,8 +21,7 @@ LABEL name="crunchydata/postgres-gis" \
 
 USER 0
 
-#RUN yum -y install --enablerepo=rhel-7-server-optional-rpms \
-RUN yum -y install --disableplugin=subscription-manager \
+RUN yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     R-core libRmath texinfo-tex texlive-epsf \
     postgis24_11 postgis24_11-client pgrouting_11 plr11 \
  && yum -y clean all

--- a/ubi7/11/Dockerfile.postgres.ubi7
+++ b/ubi7/11/Dockerfile.postgres.ubi7
@@ -3,21 +3,21 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/postgres" \
-        vendor="crunchy data" \
-	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-	summary="PostgreSQL 11.5 (PGDG) on a RHEL7 base image" \
-        description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="postgres container" \
-        io.k8s.display-name="Crunchy postgres container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      PostgresVersion="11" \
+      PostgresFullVersion="11.5" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="PostgreSQL 11.5 (PGDG) on a RHEL7 base image" \
+      description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="postgres container" \
+      io.k8s.display-name="Crunchy postgres container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/postgres/help.1 /help.1
 COPY conf/atomic/postgres/help.md /help.md
@@ -87,7 +87,7 @@ ADD conf/postgres /opt/cpm/conf
 ADD tools/pgmonitor/exporter/postgres /opt/cpm/bin/modules
 
 RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
+    chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 

--- a/ubi7/11/Dockerfile.postgres.ubi7
+++ b/ubi7/11/Dockerfile.postgres.ubi7
@@ -35,21 +35,19 @@ ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm 
-# && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     bind-utils \
-    epel-release \
     gettext \
     hostname \
     procps-ng \
     rsync \
     psmisc openssh-server openssh-clients \
  && yum -y reinstall --disableplugin=subscription-manager glibc-common \
- && yum -y install --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     postgresql11 postgresql11-contrib postgresql11-server \
     pgaudit11 pgaudit11_set_user postgresql11-plpython \
- && yum -y install --disableplugin=subscription-manager crunchy-backrest-"${BACKREST_VERSION}" \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y --setopt=tsflags='' install --disableplugin=subscription-manager pgaudit_analyze \
  && yum -y clean all
 

--- a/ubi7/11/Dockerfile.upgrade.ubi7
+++ b/ubi7/11/Dockerfile.upgrade.ubi7
@@ -36,16 +36,15 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 RUN rpm --import RPM-GPG-KEY-crunchydata
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 
-#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-# && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update \
+#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
  && yum -y update --disableplugin=subscription-manager glibc-common \
- && yum -y install --disableplugin=subscription-manager bind-utils \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False bind-utils \
 	gettext \
 	hostname \
 	procps-ng \
 	unzip \
- && yum -y install --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
  postgresql95 postgresql95-server postgresql95-contrib pgaudit95 \
  postgresql96 postgresql96-server postgresql96-contrib pgaudit96 \
  postgresql10 postgresql10-server postgresql10-contrib pgaudit10 \

--- a/ubi7/11/Dockerfile.upgrade.ubi7
+++ b/ubi7/11/Dockerfile.upgrade.ubi7
@@ -3,21 +3,21 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/upgrade" \
-        vendor="crunchy data" \
-	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="Provides a pg_upgrade capability that performs a major PostgreSQL upgrade." \
-        description="Provides a means to perform a major PostgreSQL upgrade from 9.5 to 9.6 and 9.6 to 10 and 10 to 11. Old data files are left intact." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="postgres upgrade container" \
-        io.k8s.display-name="Crunchy postgres upgrade container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      PostgresVersion="11" \
+      PostgresFullVersion="11.5" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Provides a pg_upgrade capability that performs a major PostgreSQL upgrade." \
+      description="Provides a means to perform a major PostgreSQL upgrade from 9.5 to 9.6 and 9.6 to 10 and 10 to 11. Old data files are left intact." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="postgres upgrade container" \
+      io.k8s.display-name="Crunchy postgres upgrade container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/upgrade/help.1 /help.1
 COPY conf/atomic/upgrade/help.md /help.md
@@ -40,15 +40,15 @@ ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN yum -y update --disableplugin=subscription-manager \
  && yum -y update --disableplugin=subscription-manager glibc-common \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False bind-utils \
-	gettext \
-	hostname \
-	procps-ng \
-	unzip \
+    gettext \
+    hostname \
+    procps-ng \
+    unzip \
  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
- postgresql95 postgresql95-server postgresql95-contrib pgaudit95 \
- postgresql96 postgresql96-server postgresql96-contrib pgaudit96 \
- postgresql10 postgresql10-server postgresql10-contrib pgaudit10 \
- postgresql11 postgresql11-server postgresql11-contrib pgaudit11 \
+    postgresql95 postgresql95-server postgresql95-contrib pgaudit95 \
+    postgresql96 postgresql96-server postgresql96-contrib pgaudit96 \
+    postgresql10 postgresql10-server postgresql10-contrib pgaudit10 \
+    postgresql11 postgresql11-server postgresql11-contrib pgaudit11 \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /pgolddata /pgnewdata /opt/cpm/conf
@@ -57,13 +57,13 @@ ADD bin/common /opt/cpm/bin
 ADD conf/upgrade/ /opt/cpm/conf
 
 RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
-        chmod -R g=u /opt/cpm /pgolddata /pgnewdata
+    chmod -R g=u /opt/cpm /pgolddata /pgnewdata
 
 VOLUME /pgolddata /pgnewdata
 
 RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-	
+    chmod g=u /etc/group
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 USER 26

--- a/ubi7/Dockerfile.grafana.ubi7
+++ b/ubi7/Dockerfile.grafana.ubi7
@@ -3,19 +3,19 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/grafana" \
-        vendor="crunchy data" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="Provides a Grafana web dashboard to view collected PostgreSQL metrics" \
-        description="Connect this container to the crunchy-prometheus container as a data source, then use the metrics to build dashboards. Works in conjunction with crunchy-collect and crunchy-prometheus." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="grafana container" \
-        io.k8s.display-name="Crunchy grafana container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Provides a Grafana web dashboard to view collected PostgreSQL metrics" \
+      description="Connect this container to the crunchy-prometheus container as a data source, then use the metrics to build dashboards. Works in conjunction with crunchy-collect and crunchy-prometheus." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="grafana container" \
+      io.k8s.display-name="Crunchy grafana container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/grafana/help.1 /help.1
 COPY conf/atomic/grafana/help.md /help.md
@@ -24,12 +24,12 @@ COPY licenses /licenses
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
-  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     bind-utils \
     gettext \
     hostname \
     procps-ng \
-  && yum clean all -y
+ && yum clean all -y
 
 RUN mkdir -p /data /opt/cpm/bin /opt/cpm/conf
 

--- a/ubi7/Dockerfile.grafana.ubi7
+++ b/ubi7/Dockerfile.grafana.ubi7
@@ -22,10 +22,9 @@ COPY conf/atomic/grafana/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-#  && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms update \
-RUN yum -y update  --disableplugin=subscription-manager \
-  && yum -y install --disableplugin=subscription-manager \
+#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum -y update --disableplugin=subscription-manager \
+  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     bind-utils \
     gettext \
     hostname \

--- a/ubi7/Dockerfile.node-exporter.ubi7
+++ b/ubi7/Dockerfile.node-exporter.ubi7
@@ -22,10 +22,9 @@ COPY conf/atomic/node-exporter/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-#  && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms update \
+#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
-  && yum -y install --disableplugin=subscription-manager \
+  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     bind-utils \
     gettext \
     hostname \

--- a/ubi7/Dockerfile.node-exporter.ubi7
+++ b/ubi7/Dockerfile.node-exporter.ubi7
@@ -3,19 +3,19 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/node-exporter" \
-        vendor="crunchy data" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="Provides host metrics for crunchy-postgres" \
-        description="Runs on all container hosts to collect host metrics.  Metrics are stored in Crunchy Prometheus and visualized by Crunchy Grafana" \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="node exporter container" \
-        io.k8s.display-name="Crunchy Node Exporter container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database,prometheus,exporter,metrics"
+      vendor="crunchy data" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Provides host metrics for crunchy-postgres" \
+      description="Runs on all container hosts to collect host metrics.  Metrics are stored in Crunchy Prometheus and visualized by Crunchy Grafana" \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="node exporter container" \
+      io.k8s.display-name="Crunchy Node Exporter container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database,prometheus,exporter,metrics"
 
 COPY conf/atomic/node-exporter/help.1 /help.1
 COPY conf/atomic/node-exporter/help.md /help.md
@@ -24,12 +24,12 @@ COPY licenses /licenses
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
-  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     bind-utils \
     gettext \
     hostname \
     procps-ng \
-  && yum clean all -y
+ && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /host/proc /host/sys
 

--- a/ubi7/Dockerfile.pgbasebackup-restore.ubi7
+++ b/ubi7/Dockerfile.pgbasebackup-restore.ubi7
@@ -1,16 +1,16 @@
 FROM ubi7
 
 LABEL name="crunchydata/pgbasebackup-restore" \
-        vendor="crunchy data" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="Restores a database using a pg_basebackup backup" \
-        description="Restores a database into a specified PGDATA directory using a pg_basebackup backup, while also preparing for PITR if a recovery target is specified." \
-        io.k8s.description="pg_basebackup restore container" \
-        io.k8s.display-name="Crunchy pg_basebackup restore container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Restores a database using a pg_basebackup backup" \
+      description="Restores a database into a specified PGDATA directory using a pg_basebackup backup, while also preparing for PITR if a recovery target is specified." \
+      io.k8s.description="pg_basebackup restore container" \
+      io.k8s.display-name="Crunchy pg_basebackup restore container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/pgbasebackup_restore/help.1 /help.1
 COPY conf/atomic/pgbasebackup_restore/help.md /help.md
@@ -22,7 +22,7 @@ RUN yum -y update --disableplugin=subscription-manager \
  && yum -y clean all
 
 RUN groupadd postgres -g 26 \
- &&  useradd postgres -g 26 -u 26
+ && useradd postgres -g 26 -u 26
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata
 

--- a/ubi7/Dockerfile.pgbasebackup-restore.ubi7
+++ b/ubi7/Dockerfile.pgbasebackup-restore.ubi7
@@ -18,7 +18,7 @@ COPY conf/licenses /licenses
 COPY licenses /licenses
 
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager rsync  \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False rsync  \
  && yum -y clean all
 
 RUN groupadd postgres -g 26 \

--- a/ubi7/Dockerfile.prometheus.ubi7
+++ b/ubi7/Dockerfile.prometheus.ubi7
@@ -22,10 +22,9 @@ COPY conf/atomic/prometheus/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-#  && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms update \
+#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
-  && yum -y install --disableplugin=subscription-manager \
+  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     bind-utils \
     gettext \
     hostname \

--- a/ubi7/Dockerfile.prometheus.ubi7
+++ b/ubi7/Dockerfile.prometheus.ubi7
@@ -3,19 +3,19 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/prometheus" \
-        vendor="crunchy data" \
-	Version="7.7" \
-	Release="2.4.2" \
-        url="https://crunchydata.com" \
-        summary="Prometheus server that stores metrics for crunchy-postgres" \
-        description="PostgreSQL collected metrics are stored here as defined by the Crunchy Container Suite.  Prometheus will scrape metrics from Crunchy Collect. Works in conjunction with crunchy-collect and crunchy-grafana." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="prometheus container" \
-        io.k8s.display-name="Crunchy prometheus container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+      vendor="crunchy data" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Prometheus server that stores metrics for crunchy-postgres" \
+      description="PostgreSQL collected metrics are stored here as defined by the Crunchy Container Suite.  Prometheus will scrape metrics from Crunchy Collect. Works in conjunction with crunchy-collect and crunchy-grafana." \
+      run="" \
+      start="" \
+      stop="" \
+      io.k8s.description="prometheus container" \
+      io.k8s.display-name="Crunchy prometheus container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/prometheus/help.1 /help.1
 COPY conf/atomic/prometheus/help.md /help.md
@@ -24,12 +24,12 @@ COPY licenses /licenses
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
-  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     bind-utils \
     gettext \
     hostname \
     procps-ng \
-  && yum clean all -y
+ && yum clean all -y
 
 RUN mkdir -p /data /conf /opt/cpm/bin /opt/cpm/conf
 

--- a/ubi7/Dockerfile.scheduler.ubi7
+++ b/ubi7/Dockerfile.scheduler.ubi7
@@ -3,16 +3,16 @@ FROM ubi7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/scheduler" \
-    vendor="crunchy data" \
-	Version="7.7" \
-	Release="2.4.2" \
-    url="https://crunchydata.com" \
-    summary="Crunchy Scheduler is a cron-like microservice for scheduling automatic backups" \
-    description="Crunchy Scheduler parses JSON configMaps with the label 'crunchy-scheduler=true' and transforms them into cron based tasks for automating pgBaseBackup and pgBackRest backups" \
-    io.k8s.description="scheduler container" \
-    io.k8s.display-name="Crunchy Scheduler container" \
-    io.openshift.expose-services="" \
-    io.openshift.tags="crunchy,database,cron"
+      vendor="crunchy data" \
+      Version="7.7" \
+      Release="2.4.2" \
+      url="https://crunchydata.com" \
+      summary="Crunchy Scheduler is a cron-like microservice for scheduling automatic backups" \
+      description="Crunchy Scheduler parses JSON configMaps with the label 'crunchy-scheduler=true' and transforms them into cron based tasks for automating pgBaseBackup and pgBackRest backups" \
+      io.k8s.description="scheduler container" \
+      io.k8s.display-name="Crunchy Scheduler container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="crunchy,database,cron"
 
 COPY conf/atomic/scheduler/help.1 /help.1
 COPY conf/atomic/scheduler/help.md /help.md
@@ -21,13 +21,13 @@ COPY licenses /licenses
 
 #RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
-  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     bind-utils \
     gettext \
     hostname \
     nss_wrapper \
     procps-ng \
-  && yum clean all -y
+ && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /configs \
  && chown -R 2:2 /opt/cpm /configs

--- a/ubi7/Dockerfile.scheduler.ubi7
+++ b/ubi7/Dockerfile.scheduler.ubi7
@@ -19,10 +19,9 @@ COPY conf/atomic/scheduler/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
- # && yum -y --enablerepo=rhel-7-server-ose-3.11-rpms update \
+#RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y update --disableplugin=subscription-manager \
-  && yum -y install --disableplugin=subscription-manager \
+  && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False \
     bind-utils \
     gettext \
     hostname \


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**

Yum has an interesting behavior where if you do "yum install a b c", and b is not available, it will say "package b is not found", and then install a and c, continuing. The error code is zero and yum considers that the process passed. Since this is not ideal, and we would rather fail whenever any package that's needed cannot be found, I added a flag to the yum installs for ubi images "--setopt=skip_missing_names_on_install=False". This flag will cause builds to fail if any needed dependency cannot be found.

**What is the new behavior (if this is a feature change)?**

Builds are hardened for UBI.


**Other information**:
