### PR TITLE
Support Secret for Collect Credentials & Updates for Grafana and pgMonitor Compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,32 +48,32 @@ pgc:
 #=============================================
 
 backrestrestore: versiontest
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.backrest-restore.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-backrest-restore:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.backrest-restore.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-backrest-restore:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-backrest-restore:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-backrest-restore:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-backrest-restore:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-backrest-restore:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 
 
 backup:	versiontest
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.backup.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-backup:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.backup.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-backup:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-backup:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-backup:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-backup:$(CCP_IMAGE_TAG)  $(CCP_IMAGE_PREFIX)/crunchy-backup:$(CCP_IMAGE_TAG)
 
 pgbasebackuprestore:	versiontest
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.pgbasebackup-restore.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgbasebackup-restore:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.pgbasebackup-restore.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgbasebackup-restore:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-pgbasebackup-restore:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-pgbasebackup-restore:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-pgbasebackup-restore:$(CCP_IMAGE_TAG)  $(CCP_IMAGE_PREFIX)/crunchy-pgbasebackup-restore:$(CCP_IMAGE_TAG)
 collect: versiontest
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.collect.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-collect:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.collect.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-collect:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-collect:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-collect:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-collect:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-collect:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 
 grafana: versiontest
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.grafana.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-grafana:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.grafana.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-grafana:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-grafana:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-grafana:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-grafana:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-grafana:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 
 pgadmin4: versiontest
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgadmin4.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgadmin4:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgadmin4.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgadmin4:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-pgadmin4:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-pgadmin4:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-pgadmin4:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-pgadmin4:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 
@@ -82,58 +82,58 @@ pgbadger: versiontest
 	docker create --name extract $(CCP_IMAGE_PREFIX)/badgerserver:build
 	docker cp extract:/go/src/github.com/crunchydata/crunchy-containers/badgerserver ./bin/pgbadger/badgerserver
 	docker rm -f extract
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgbadger.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgbadger:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgbadger.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgbadger:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-pgbadger:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-pgbadger:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-pgbadger:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-pgbadger:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 
 pgbench: versiontest
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgbench.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgbench:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgbench.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgbench:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-pgbench:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-pgbench:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-pgbench:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-pgbench:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 
 pgbouncer: versiontest
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgbouncer.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgbouncer:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgbouncer.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgbouncer:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-pgbouncer:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-pgbouncer:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-pgbouncer:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-pgbouncer:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 
 pgdump: versiontest
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgdump.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgdump:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgdump.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgdump:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-pgdump:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-pgdump:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-pgdump:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION) $(CCP_IMAGE_PREFIX)/crunchy-pgdump:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 
 pgpool:	versiontest
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgpool.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgpool:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgpool.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgpool:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-pgpool:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-pgpool:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-pgpool:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-pgpool:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 
 pgrestore: versiontest
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgrestore.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgrestore:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.pgrestore.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-pgrestore:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-pgrestore:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-pgrestore:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-pgrestore:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-pgrestore:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 
 postgres: versiontest commands
 	cp $(GOBIN)/pgc bin/postgres
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-postgres:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-postgres:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-postgres:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-postgres:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-postgres:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-postgres:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 
 postgres-gis: versiontest commands
 	cp $(GOBIN)/pgc bin/postgres
 	expenv -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres-gis.$(CCP_BASEOS) > $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres-gis.$(CCP_BASEOS).tmp
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres-gis.$(CCP_BASEOS).tmp -t $(CCP_IMAGE_PREFIX)/crunchy-postgres-gis:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres-gis.$(CCP_BASEOS).tmp -t $(CCP_IMAGE_PREFIX)/crunchy-postgres-gis:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-postgres-gis:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-postgres-gis:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-postgres-gis:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-postgres-gis:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 	rm -f $(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres-gis.$(CCP_BASEOS).tmp
 
 postgres-appdev: versiontest commands
 	cp $(GOBIN)/pgc bin/postgres
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres-appdev.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-postgres-appdev:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.postgres-appdev.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-postgres-appdev:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-postgres-appdev:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-postgres-appdev:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-postgres-appdev:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-postgres-appdev:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-postgres-appdev:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-postgres-appdev:latest
 
 prometheus:	versiontest
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.prometheus.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-prometheus:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.prometheus.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-prometheus:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-prometheus:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-prometheus:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-prometheus:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-prometheus:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 
@@ -142,7 +142,7 @@ sample-app: versiontest
 	docker create --name extract $(CCP_IMAGE_PREFIX)/sample-app-build:build
 	docker cp extract:/go/src/github.com/crunchydata/sample-app/sample-app ./bin/sample-app
 	docker rm -f extract
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.sample-app.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-sample-app:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.sample-app.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-sample-app:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-sample-app:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-sample-app:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-sample-app:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-sample-app:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 
@@ -151,13 +151,13 @@ scheduler: versiontest
 	docker create --name extract $(CCP_IMAGE_PREFIX)/scheduler-build:build
 	docker cp extract:/go/src/github.com/crunchydata/crunchy-containers/scheduler ./bin/scheduler
 	docker rm -f extract
-	sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.scheduler.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-scheduler:$(CCP_IMAGE_TAG) $(CCPROOT)
+	sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.scheduler.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-scheduler:$(CCP_IMAGE_TAG) $(CCPROOT)
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-scheduler:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-scheduler:$(CCP_IMAGE_TAG)
 	docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-scheduler:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-scheduler:$(CCP_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_VERSION)
 
 upgrade: versiontest
 	if [[ '$(CCP_PGVERSION)' != '9.5' ]]; then \
-		sudo --preserve-env buildah bud $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.upgrade.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-upgrade:$(CCP_IMAGE_TAG) $(CCPROOT) ;\
+		sudo --preserve-env buildah bud --layers $(SQUASH) -f $(CCPROOT)/$(CCP_BASEOS)/$(CCP_PGVERSION)/Dockerfile.upgrade.$(CCP_BASEOS) -t $(CCP_IMAGE_PREFIX)/crunchy-upgrade:$(CCP_IMAGE_TAG) $(CCPROOT) ;\
 		sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-upgrade:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-upgrade:$(CCP_IMAGE_TAG) ;\
 		docker tag docker.io/$(CCP_IMAGE_PREFIX)/crunchy-upgrade:$(CCP_IMAGE_TAG) $(CCP_IMAGE_PREFIX)/crunchy-upgrade:$(CCP_IMAGE_TAG) ;\
 	fi

--- a/bin/collect/start.sh
+++ b/bin/collect/start.sh
@@ -22,7 +22,6 @@ POSTGRES_EXPORTER_PIDFILE=/tmp/postgres_exporter.pid
 CONFIG_DIR='/opt/cpm/conf'
 QUERIES=(
     queries_backrest
-    queries_bloat
     queries_common
     queries_per_db
 )
@@ -176,6 +175,8 @@ else
         exit 1
     fi
 fi
+
+sed -i "s/#PGBACKREST_INFO_THROTTLE_MINUTES#/${PGBACKREST_INFO_THROTTLE_MINUTES:-10}/g" /tmp/queries.yml
 
 PG_OPTIONS="--extend.query-path=${QUERY_DIR?}/queries.yml"
 

--- a/bin/grafana/start.sh
+++ b/bin/grafana/start.sh
@@ -72,7 +72,8 @@ else
     PROVISION_DIR='/data/grafana/provisioning'
     DASHBOARD_DIR="${PROVISION_DIR?}/dashboards"
     DATASOURCE_DIR="${PROVISION_DIR?}/datasources"
-    mkdir -p ${PROVISION_DIR?} ${DASHBOARD_DIR?} ${DATASOURCE_DIR?}
+    NOTIFIER_DIR="${PROVISION_DIR?}/notifiers"
+    mkdir -p ${PROVISION_DIR?} ${DASHBOARD_DIR?} ${DATASOURCE_DIR?} ${NOTIFIER_DIR}
 
     # Datasource setup
     cp ${CONFIG_DIR?}/prometheus_datasource.yml \

--- a/bin/postgres/modules/pgmonitor.sh
+++ b/bin/postgres/modules/pgmonitor.sh
@@ -17,6 +17,9 @@ if [[ -v PGMONITOR_PASSWORD ]]
 then
     if [[ ${PG_MODE?} == "primary" ]] || [[ ${PG_MODE?} == "master" ]]
     then
+
+        echo_info "PGMONITOR_PASSWORD detected.  Enabling pgMonitor support."
+
         source /opt/cpm/bin/common_lib.sh
         export PGHOST="${PGHOST:-/tmp}"
 
@@ -40,17 +43,21 @@ then
             exit 1
         fi
 
+        echo_info "Using setup file '${function_file}' for pgMonitor"
+        cp "${function_file}" "/tmp/setup_pg.sql"
+        sed -i "s/\/usr\/bin\/pgbackrest-info.sh/\/opt\/cpm\/bin\/pgbackrest_info.sh/g" "/tmp/setup_pg.sql"
+
         # TODO Add ON_ERROR_STOP and single transaction when
         # upstream pgmonitor changes setup SQL to check if the
         # role exists prior to creating it.
         psql -U postgres --port="${PG_PRIMARY_PORT}" -d postgres \
-            < ${function_file?} > /tmp/pgmonitor.stdout 2> /tmp/pgmonitor.stderr
+            < "/tmp/setup_pg.sql" > /tmp/pgmonitor-setup.stdout 2> /tmp/pgmonitor-setup.stderr
 
         #err_check "$?" "pgMonitor Setup" "Could not load pgMonitor functions: \n$(cat /tmp/pgmonitor.stderr)"
 
         psql -U postgres --port="${PG_PRIMARY_PORT}" -d postgres \
             -c "ALTER ROLE ccp_monitoring PASSWORD '${PGMONITOR_PASSWORD?}'" \
-            > /tmp/pgmonitor.stdout 2> /tmp/pgmonitor.stderr
+            > /tmp/pgmonitor-alter-role.stdout 2> /tmp/pgmonitor-alter-role.stderr
 
         #err_check "$?" "pgMonitor User Setup" "Could not alter ccp_monitor user's password: \n$(cat /tmp/pgmonitor.stderr)"
     fi

--- a/bin/postgres/pgbackrest_info.sh
+++ b/bin/postgres/pgbackrest_info.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright 2016 - 2019 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /opt/cpm/bin/pgbackrest_env.sh > /tmp/pgbackrest_env.stdout 2> /tmp/pgbackrest_env.stderr
+
+echo $(echo -n "$conf|" | tr '/' '_'; pgbackrest --output=json info | tr -d '\n')

--- a/examples/kube/metrics/metrics-secret.json
+++ b/examples/kube/metrics/metrics-secret.json
@@ -1,0 +1,16 @@
+{
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": {
+       "name": "collect-pguser",
+       "labels": {
+        "name": "collect-pguser",
+        "cleanup": "$CCP_NAMESPACE-metrics"
+    }
+    },
+    "type": "Opaque",
+    "stringData": {
+       "username": "ccp_monitoring",
+       "password": "password"
+    }
+ }

--- a/examples/kube/metrics/primary.json
+++ b/examples/kube/metrics/primary.json
@@ -84,8 +84,20 @@
                         },
                         "env": [
                             {
-                                "name": "DATA_SOURCE_NAME",
-                                "value": "postgresql://ccp_monitoring:password@127.0.0.1:5432/postgres?sslmode=disable"
+                                "name": "COLLECT_PG_HOST",
+                                "value": "127.0.0.1"
+                            },
+                            {
+                                "name": "COLLECT_PG_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "COLLECT_PG_DATABASE",
+                                "value": "postgres"
+                            },
+                            {
+                                "name": "COLLECT_PG_PARAMS",
+                                "value": "sslmode=disable"
                             },
                             {
                                 "name": "JOB_NAME",
@@ -107,6 +119,10 @@
                                 "mountPath": "/backrestrepo",
                                 "name": "backrestrepo",
                                 "readOnly": true
+                            },
+                            {
+                                "mountPath": "/collect-pguser",
+                                "name": "collect-pguser"
                             }
                         ]
                     },
@@ -234,6 +250,12 @@
                         "emptyDir": {
 			    "medium": "Memory"
 			}
+                    },
+                    {
+                        "name": "collect-pguser",
+                        "secret": {
+                            "secretName": "collect-pguser"
+                        }
                     }
                 ],
                 "restartPolicy": "Always",

--- a/examples/kube/metrics/primary.json
+++ b/examples/kube/metrics/primary.json
@@ -62,10 +62,6 @@
                             {
                                 "containerPort": 9187,
                                 "protocol": "TCP"
-                            },
-                            {
-                                "containerPort": 9100,
-                                "protocol": "TCP"
                             }
                         ],
                         "readinessProbe": {

--- a/examples/kube/metrics/replica.json
+++ b/examples/kube/metrics/replica.json
@@ -84,8 +84,20 @@
                         },
                         "env": [
                             {
-                                "name": "DATA_SOURCE_NAME",
-                                "value": "postgresql://ccp_monitoring:password@127.0.0.1:5432/postgres?sslmode=disable"
+                                "name": "COLLECT_PG_HOST",
+                                "value": "127.0.0.1"
+                            },
+                            {
+                                "name": "COLLECT_PG_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "COLLECT_PG_DATABASE",
+                                "value": "postgres"
+                            },
+                            {
+                                "name": "COLLECT_PG_PARAMS",
+                                "value": "sslmode=disable"
                             }
                         ],
                         "volumeMounts": [
@@ -103,6 +115,10 @@
                                 "mountPath": "/backrestrepo",
                                 "name": "backrestrepo",
                                 "readOnly": true
+                            },
+                            {
+                                "mountPath": "/collect-pguser",
+                                "name": "collect-pguser"
                             }
                         ]
                     },
@@ -234,6 +250,12 @@
                         "emptyDir": {
 			    "medium": "Memory"
 			}
+                    },
+                    {
+                        "name": "collect-pguser",
+                        "secret": {
+                            "secretName": "collect-pguser"
+                        }
                     }
                 ],
                 "restartPolicy": "Always",

--- a/examples/kube/metrics/replica.json
+++ b/examples/kube/metrics/replica.json
@@ -62,10 +62,6 @@
                             {
                                 "containerPort": 9187,
                                 "protocol": "TCP"
-                            },
-                            {
-                                "containerPort": 9100,
-                                "protocol": "TCP"
                             }
                         ],
                         "readinessProbe": {

--- a/examples/kube/metrics/run.sh
+++ b/examples/kube/metrics/run.sh
@@ -29,6 +29,8 @@ fi
 ${CCP_CLI?} label --namespace=${CCP_NAMESPACE?} configmap \
     metrics-pgconf cleanup=${CCP_NAMESPACE?}-metrics
 
+expenv -f $DIR/metrics-secret.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
+
 expenv -f $DIR/metrics.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 expenv -f $DIR/primary.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -
 expenv -f $DIR/replica.json | ${CCP_CLI?} create --namespace=${CCP_NAMESPACE?} -f -

--- a/hugo/content/container-specifications/crunchy-collect.md
+++ b/hugo/content/container-specifications/crunchy-collect.md
@@ -33,9 +33,20 @@ The crunchy-collect Docker image contains the following packages (versions vary 
 ### Required
 **Name**|**Default**|**Description**
 :-----|:-----|:-----
-**DATA_SOURCE_NAME**|None|The URL for the PostgreSQL server's data source name. This is *required* to be in the form of `postgresql://`.  The user should be `ccp_monitoring` and use the `PGMONITOR_PASSWORD` value set in the `PostgreSQL` container.
+**COLLECT_PG_PASSWORD**|none|Provides the password needed to generate the PostgreSQL URL required by the PostgreSQL Exporter to connect to a PG database.  Should typically match the `PGMONITOR_PASSWORD` value set in the `crunchy-postgres` container.|
 
 ### Optional
 **Name**|**Default**|**Description**
 :-----|:-----|:-----
+**COLLECT_PG_USER**|ccp_monitoring|Provides the username needed to generate the PostgreSQL URL required by the PostgreSQL Exporter to connect to a PG database.  Should typically be `ccp_monitoring` per the [crunchy-postgres](/container-specifications/crunchy-postgres) container specification (see environment varaible `PGMONITOR_PASSWORD`). 
+**COLLECT_PG_HOST**|127.0.0.1|Provides the host needed to generate the PostgreSQL URL required by the PostgreSQL Exporter to connect to a PG database|
+**COLLECT_PG_PORT**|5432|Provides the port needed to generate the PostgreSQL URL required by the PostgreSQL Exporter to connect to a PG database|
+**COLLECT_PG_DATABASE**|postgres|Provides the name of the database used to generate the PostgreSQL URL required by the PostgreSQL Exporter to connect to a PG database|
+**DATA_SOURCE_NAME**|None|Explicitly defines the URL for connecting to the PostgreSQL database (must be in the form of `postgresql://`).  If provided, overrides all other settings provided to generate the connection URL.
 **CRUNCHY_DEBUG**|FALSE|Set this to true to enable debugging in logs. Note: this mode can reveal secrets in logs.
+
+## Volumes
+
+**Name**|**Description**
+:-----|:-----
+**/collect-pguser**|Volume containing PG credentials stored in `username` and `password` files (e.g. mounted using a Kubernetes secret)


### PR DESCRIPTION
Provides the ability to leverage Kubernetes secrets to provide the **PostgreSQL Exporter** with
the credentials required to connect to a PG database.  Environment variables are now available for the various elements of the PostgreSQL URL that is used to form the `DATA_SOURCE_NAME` env var required by the **PostgreSQL Exporter**, and if credentials are identified on the file system, i.e. due to a mounted Kube secret, they are utilized as the user/pass in when forming the URL.  Additionally, defaults are provided for each of the above env vars, as documented in the `crunchy-collect` container spec.  However, please note that in order to maintain backwards compatibility, the `DATA_SOURCE_NAME` env var can still be explicitly provided.

Also updated the `crunchy-postgres`, `crunchy-collect` and `crunchy-grafana` containers as needed to support **Grafana v6.3.4** and **pgMonitor v3.2**.  For the `crunchy-grafana` container, this includes creating the `notifiers` directory during container initialization to avoid a missing `notifiers` directory error during Grafana startup.  For the `crunchy-collect` container, this includes ensuring the `PGBACKREST_INFO_THROTTLE_MINUTES` env var is properly set in the **PostgreSQL Exporter** queries file.  For the `crunchy-postgres` container, this includes creating and leveraging a custom shell script that can be utilized to obtain `pgBackRest` info, and ensuring the setup SQL file run during initialization of the **pgMonitor** module is properly configured to use the custom script.  Additionally, the metrics example has been updated to remove port 9100 from the `crunchy-collect` containers.

Also adds the `--layers` option to the `buildah bud` commands in the `Makefile` to enable image caching.  

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

A hard-coded username and password must be provided to the **PostgreSQL Exporter** in the `crunchy-collect` container using the `DATA_SOURCE_NAME` env var.

Various errors are thrown in the Grafana and Collect containers as a result of the upgrade to **Grafana v6.3.4** and **pgMonitor v3.2**.

[ch723]

**What is the new behavior (if this is a feature change)?**

A Kubernetes secret can be utilized to provide the **PostgreSQL Exporter** in the `crunchy-collect` container the credentials needed for the PG connection string defined using the `DATA_SOURCE_NAME` env var.

Errors are no longer thrown in the Grafana and Collect containers.

**Other information**:

N/A