### PR TITLE
Updates ports on the collect and pgbadger containers.

### DIFF
--- a/badger/badgerserver.go
+++ b/badger/badgerserver.go
@@ -25,6 +25,8 @@ import (
 )
 
 const REPORT = "/report/index.html"
+const PG_BADGER_SERVICE_PORT = "PGBADGER_SERVICE_PORT"
+const DEFAULT_PGBADGER_PORT = "10000"
 
 func init() {
 	log.SetOutput(os.Stdout)
@@ -35,7 +37,12 @@ func main() {
 	http.HandleFunc("/api/badgergenerate", BadgerGenerate)
 	http.Handle("/static/", http.StripPrefix("/static", http.FileServer(http.Dir("/report"))))
 	http.HandleFunc("/", RootPathRedirect)
-	log.Fatal(http.ListenAndServe(":10000", nil))
+	port := os.Getenv(PG_BADGER_SERVICE_PORT)
+	if port == "" {
+		log.Printf("PGBadger port not found. Using default %s\n", DEFAULT_PGBADGER_PORT)
+		port = DEFAULT_PGBADGER_PORT
+	}
+	log.Fatal(http.ListenAndServe(":" + port, nil))
 }
 
 // BadgerGenerate perform a pgbadger to create the HTML output file

--- a/bin/collect/start.sh
+++ b/bin/collect/start.sh
@@ -60,6 +60,12 @@ set_default_collect_env() {
         default_collect_env_vars+=("COLLECT_PG_USER=${COLLECT_PG_USER}")
     fi
 
+    if [[ ! -v POSTGRES_EXPORTER_PORT ]]
+    then
+        export POSTGRES_EXPORTER_PORT="9187"
+        default_collect_env_vars+=("POSTGRES_EXPORTER_PORT=${POSTGRES_EXPORTER_PORT}")
+    fi
+
     if [[ ! ${#default_collect_env_vars[@]} -eq 0 ]]
     then
         echo_info "Defaults have been set for the following collect env vars:"

--- a/bin/collect/start.sh
+++ b/bin/collect/start.sh
@@ -178,7 +178,7 @@ fi
 
 sed -i "s/#PGBACKREST_INFO_THROTTLE_MINUTES#/${PGBACKREST_INFO_THROTTLE_MINUTES:-10}/g" /tmp/queries.yml
 
-PG_OPTIONS="--extend.query-path=${QUERY_DIR?}/queries.yml"
+PG_OPTIONS="--extend.query-path=${QUERY_DIR?}/queries.yml  --web.listen-address=:${POSTGRES_EXPORTER_PORT}"
 
 echo_info "Starting postgres-exporter.."
 ${PG_EXP_HOME?}/postgres_exporter ${PG_OPTIONS?} >>/dev/stdout 2>&1 &

--- a/examples/kube/metrics/primary.json
+++ b/examples/kube/metrics/primary.json
@@ -98,6 +98,10 @@
                             {
                                 "name": "JOB_NAME",
                                 "value": "primary-metrics"
+                            },
+                            {
+                                "name": "POSTGRES_EXPORTER_PORT",
+                                "value": "9187"
                             }
                         ],
                         "volumeMounts": [

--- a/examples/kube/metrics/replica.json
+++ b/examples/kube/metrics/replica.json
@@ -94,6 +94,10 @@
                             {
                                 "name": "COLLECT_PG_PARAMS",
                                 "value": "sslmode=disable"
+                            },
+                            {
+                                "name": "POSTGRES_EXPORTER_PORT",
+                                "value": "9187"
                             }
                         ],
                         "volumeMounts": [

--- a/examples/kube/pgbadger/pgbadger.json
+++ b/examples/kube/pgbadger/pgbadger.json
@@ -146,6 +146,9 @@
                     {
                         "name": "BADGER_CUSTOM_OPTS",
                         "value": "--incremental --prefix='%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h'"
+                    },{
+                        "name": "PGBADGER_SERVICE_PORT",
+                        "value": "10000"
                     }
                 ],
                 "volumeMounts": [

--- a/hugo/content/container-specifications/crunchy-collect.md
+++ b/hugo/content/container-specifications/crunchy-collect.md
@@ -44,6 +44,7 @@ The crunchy-collect Docker image contains the following packages (versions vary 
 **COLLECT_PG_DATABASE**|postgres|Provides the name of the database used to generate the PostgreSQL URL required by the PostgreSQL Exporter to connect to a PG database|
 **DATA_SOURCE_NAME**|None|Explicitly defines the URL for connecting to the PostgreSQL database (must be in the form of `postgresql://`).  If provided, overrides all other settings provided to generate the connection URL.
 **CRUNCHY_DEBUG**|FALSE|Set this to true to enable debugging in logs. Note: this mode can reveal secrets in logs.
+**POSTGRES_EXPORTER_PORT**|9187|Set the postgres-exporter port to listen on for web interface and telemetry.
 
 ## Volumes
 

--- a/hugo/content/container-specifications/crunchy-pgbadger.md
+++ b/hugo/content/container-specifications/crunchy-pgbadger.md
@@ -33,3 +33,4 @@ The crunchy-badger Docker image contains the following packages:
 **BADGER_TARGET**|None|Only used in standalone mode to specify the name of the container. Also used to find the location of the database log files in `/pgdata/$BADGER_TARGET/pg_log/*.log`.
 **BADGER_CUSTOM_OPTS**|None|For a list of optional flags, see the [official pgBadger documentation](http://dalibo.github.io/pgbadger).
 **CRUNCHY_DEBUG**|FALSE|Set this to true to enable debugging in logs. Note: this mode can reveal secrets in logs.
+**PGBADGER_SERVICE_PORT**|10000|Set the service port for the pgBadger process.


### PR DESCRIPTION
The service ports for pgbadger and postgres-exporter are currently
hardcoded in the defaults for each. This commit updates the images
and start scripts so that the port can be set by an environment
variable. The examples are also updated to set the EXPORTER_PORT
in the container environment on creation.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable? (tested on kube)



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently ports for postgres-exporter and pgbadger are hardcoded


**What is the new behavior (if this is a feature change)?**
Ports are now set using an environment variable


**Other information**:
[ch1866]