### PR TITLE
Allow for customizing timeouts around specific pg_ctl commands.

### DIFF
--- a/bin/postgres/promote.sh
+++ b/bin/postgres/promote.sh
@@ -17,4 +17,5 @@ source /opt/cpm/bin/common_lib.sh
 enable_debugging
 
 source /opt/cpm/bin/setenv.sh
-pg_ctl promote
+
+PGCTLTIMEOUT=${PG_CTL_PROMOTE_TIMEOUT} pg_ctl promote

--- a/examples/kube/primary/primary.json
+++ b/examples/kube/primary/primary.json
@@ -135,7 +135,7 @@
                     }
                 ],
                 "restartPolicy": "Always",
-                "terminationGracePeriodSeconds": 30,
+                "terminationGracePeriodSeconds": 62,
                 "dnsPolicy": "ClusterFirst",
                 "securityContext": {
                     $CCP_SECURITY_CONTEXT

--- a/hugo/content/container-specifications/crunchy-postgres-gis.md
+++ b/hugo/content/container-specifications/crunchy-postgres-gis.md
@@ -66,6 +66,9 @@ The crunchy-postgres-gis Docker image contains the following packages (versions 
 **PGBACKREST**|false| Set this value to `true` in order to enable and initialize pgBackRest in the container
 **BACKREST_SKIP_CREATE_STANZA**|false| Set this value to `true` in order to skip the configuration check and the automatic creation of a stanza while initializing pgBackRest in the container
 **PG_CTL_OPTS**|None| Set this value to supply custom `pg_ctl` options (ex: `-c shared_preload_libraries=pgaudit`) during the initialization phase the container start.
+**PG_CTL_START_TIMEOUT**|None| Set this value to determine how long pg_ctl will wait for start to complete. This is not set by default, but will use the default value set in PostgreSQL (60 seconds).
+**PG_CTL_STOP_TIMEOUT**|None| Set this value to determine how long pg_ctl will wait for shutdown to complete after the container is terminated. This is not set by default, but will use the default value set in PostgreSQL (60 seconds). It is recommended that in a Kubernetes environment that you set the `terminationGracePeriodSeconds` parameter to be two (2) seconds higher than this value.
+**PG_CTL_PROMOTE_TIMEOUT**|None| Set this value to determine how long pg_ctl will wait for a promotion to complete. This is not set by default, but will use the default value set in PostgreSQL (60 seconds).
 
 ## Volumes
 

--- a/hugo/content/container-specifications/crunchy-postgres.md
+++ b/hugo/content/container-specifications/crunchy-postgres.md
@@ -65,6 +65,9 @@ The crunchy-postgres Docker image contains the following packages (versions vary
 **PGBACKREST**|false| Set this value to `true` in order to enable and initialize pgBackRest in the container
 **BACKREST_SKIP_CREATE_STANZA**|false| Set this value to `true` in order to skip the configuration check and the automatic creation of a stanza while initializing pgBackRest in the container
 **PG_CTL_OPTS**|None| Set this value to supply custom `pg_ctl` options (ex: `-c shared_preload_libraries=pgaudit`) during the initialization phase the container start.
+**PG_CTL_START_TIMEOUT**|None| Set this value to determine how long pg_ctl will wait for start to complete. This is not set by default, but will use the default value set in PostgreSQL (60 seconds).
+**PG_CTL_STOP_TIMEOUT**|None| Set this value to determine how long pg_ctl will wait for shutdown to complete after the container is terminated. This is not set by default, but will use the default value set in PostgreSQL (60 seconds). It is recommended that in a Kubernetes environment that you set the `terminationGracePeriodSeconds` parameter to be two (2) seconds higher than this value.
+**PG_CTL_PROMOTE_TIMEOUT**|None| Set this value to determine how long pg_ctl will wait for a promotion to complete. This is not set by default, but will use the default value set in PostgreSQL (60 seconds).
 
 ## Volumes
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**

This introduces three additional parameters for managing timeouts around
three specific `pg_ctl` commands:

- PG_CTL_START_TIMEOUT
- PG_CTL_STOP_TIMEOUT
- PG_CTL_PROMOTE_TIMEOUT

which coorespond with the "start", "stop", and "promote" pg_ctl commands
respectively.

These interface with the PostgreSQL "PGCTLTIMEOUT" environmental variable
and override the PostgreSQL default value as needed.

This is particularly helpful for "stop" events in a Kubernetes environment
to ensure that a pod does not terminate before PostgreSQL has fully flushed
its data to disk.

**Other information**:

This build on the work of #1128 

Future work in Kubernetes environments should better utilize the
`terminationGracePeriodSeconds` pod variable so that it can automatically
set the timeout time based on this value.