### PR TITLE
Ensure crunchy-collect / pgMonitor facilities start up on PG 9.5/9.6

### DIFF
--- a/bin/collect/start.sh
+++ b/bin/collect/start.sh
@@ -75,7 +75,7 @@ set_default_collect_env() {
 
 # Set the PG user credentials for use in the postgres exporter PG connection string
 set_collect_pg_credentials() {
-    
+
     if [[ -d "/collect-pguser" ]]
     then
 	    echo_info "Setting credentials for collect PG user using file system"
@@ -144,7 +144,7 @@ else
     done
 
     VERSION=$(${PG_DIR?}/bin/psql "${DATA_SOURCE_NAME}" -qtAX -c "SELECT current_setting('server_version_num')")
-    if (( ${VERSION?} > 95000 )) && (( ${VERSION?} < 96000 ))
+    if (( ${VERSION?} >= 90500 )) && (( ${VERSION?} < 90600 ))
     then
         if [[ -f ${CONFIG_DIR?}/queries_pg95.yml ]]
         then
@@ -152,7 +152,7 @@ else
         else
             echo_err "Custom Query file queries_pg95.yml does not exist (it should).."
         fi
-    elif (( ${VERSION?} >= 96000 )) && (( ${VERSION?} < 100000 ))
+    elif (( ${VERSION?} >= 90600 )) && (( ${VERSION?} < 100000 ))
     then
         if [[ -f ${CONFIG_DIR?}/queries_pg96.yml ]]
         then

--- a/bin/postgres/modules/pgmonitor.sh
+++ b/bin/postgres/modules/pgmonitor.sh
@@ -26,10 +26,10 @@ then
         pgisready 'postgres' ${PGHOST?} "${PG_PRIMARY_PORT}" 'postgres'
         VERSION=$(psql --port="${PG_PRIMARY_PORT}" -d postgres -qtAX -c "SELECT current_setting('server_version_num')")
 
-        if (( ${VERSION?} > 95000 )) && (( ${VERSION?} < 96000 ))
+        if (( ${VERSION?} >= 90500 )) && (( ${VERSION?} < 90600 ))
         then
             function_file='/opt/cpm/bin/modules/setup_pg95.sql'
-        elif (( ${VERSION?} >= 96000 )) && (( ${VERSION?} < 100000 ))
+        elif (( ${VERSION?} >= 90600 )) && (( ${VERSION?} < 100000 ))
         then
             function_file='/opt/cpm/bin/modules/setup_pg96.sql'
         elif (( ${VERSION?} >= 100000 )) && (( ${VERSION?} < 110000 ))


### PR DESCRIPTION
3896128a1, which updated the Crunchy Container Suite to use
pgMonitor v3.2, added in additional version checking logic to load
the correct set of queries that pgMonitor relies on to scrape metrics.
A bug was introduced in this logic where any supported version of
PostgreSQL below version 10 would be treated as an unsupported version.

This fix adds in the appropriate version strings to check for 9.5/9.6

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The crunchy-collect container on PostgreSQL 9.5/9.6 won't load. In some cases this will also cause the crunchy-postgres container to fail as its validation checks do not work.  [ch6003]

**What is the new behavior (if this is a feature change)?**

This fixes this behavior.

**Other information**:
