### PR TITLE
Support for PostgreSQL 12.1, 11.6, 10.11, 9.6.16, & 9.5.20 [ch6300]

### DIFF
--- a/centos7/10/Dockerfile.backrest-restore.centos7
+++ b/centos7/10/Dockerfile.backrest-restore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.backup.centos7
+++ b/centos7/10/Dockerfile.backup.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/backup" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.collect.centos7
+++ b/centos7/10/Dockerfile.collect.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/collect" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.pgadmin4.centos7
+++ b/centos7/10/Dockerfile.pgadmin4.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.pgbadger.centos7
+++ b/centos7/10/Dockerfile.pgbadger.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.pgbench.centos7
+++ b/centos7/10/Dockerfile.pgbench.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.pgbouncer.centos7
+++ b/centos7/10/Dockerfile.pgbouncer.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.pgdump.centos7
+++ b/centos7/10/Dockerfile.pgdump.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.pgpool.centos7
+++ b/centos7/10/Dockerfile.pgpool.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.pgrestore.centos7
+++ b/centos7/10/Dockerfile.pgrestore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.postgres-gis.centos7
+++ b/centos7/10/Dockerfile.postgres-gis.centos7
@@ -3,7 +3,7 @@ FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.postgres.centos7
+++ b/centos7/10/Dockerfile.postgres.centos7
@@ -3,11 +3,11 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 10.10 (PGDG) on a Centos7 base image" \
+	summary="PostgreSQL 10.11 (PGDG) on a Centos7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         io.k8s.description="postgres container" \
         io.k8s.display-name="Crunchy postgres container" \

--- a/centos7/10/Dockerfile.upgrade.centos7
+++ b/centos7/10/Dockerfile.upgrade.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/upgrade" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.backrest-restore.centos7
+++ b/centos7/11/Dockerfile.backrest-restore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.backup.centos7
+++ b/centos7/11/Dockerfile.backup.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/backup" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.collect.centos7
+++ b/centos7/11/Dockerfile.collect.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/collect" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.pgadmin4.centos7
+++ b/centos7/11/Dockerfile.pgadmin4.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.pgbadger.centos7
+++ b/centos7/11/Dockerfile.pgbadger.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.pgbench.centos7
+++ b/centos7/11/Dockerfile.pgbench.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.pgbouncer.centos7
+++ b/centos7/11/Dockerfile.pgbouncer.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.pgdump.centos7
+++ b/centos7/11/Dockerfile.pgdump.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.pgpool.centos7
+++ b/centos7/11/Dockerfile.pgpool.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.pgrestore.centos7
+++ b/centos7/11/Dockerfile.pgrestore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.postgres-appdev.centos7
+++ b/centos7/11/Dockerfile.postgres-appdev.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/postgres-appdev" \
         vendor="crunchydata" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.postgres-gis.centos7
+++ b/centos7/11/Dockerfile.postgres-gis.centos7
@@ -3,7 +3,7 @@ FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.postgres.centos7
+++ b/centos7/11/Dockerfile.postgres.centos7
@@ -3,11 +3,11 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 11.5 (PGDG) on a Centos7 base image" \
+	summary="PostgreSQL 11.6 (PGDG) on a Centos7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         io.k8s.description="postgres container" \
         io.k8s.display-name="Crunchy postgres container" \

--- a/centos7/11/Dockerfile.upgrade.centos7
+++ b/centos7/11/Dockerfile.upgrade.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/upgrade" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.backrest-restore.centos7
+++ b/centos7/12/Dockerfile.backrest-restore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.backup.centos7
+++ b/centos7/12/Dockerfile.backup.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/backup" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.collect.centos7
+++ b/centos7/12/Dockerfile.collect.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/collect" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.pgadmin4.centos7
+++ b/centos7/12/Dockerfile.pgadmin4.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgadmin4" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.pgbadger.centos7
+++ b/centos7/12/Dockerfile.pgbadger.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbadger" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.pgbench.centos7
+++ b/centos7/12/Dockerfile.pgbench.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbench" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.pgbouncer.centos7
+++ b/centos7/12/Dockerfile.pgbouncer.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbouncer" \
 		vendor="Crunchy Data" \
 		PostgresVersion="12" \
-		PostgresFullVersion="12.0" \
+		PostgresFullVersion="12.1" \
 		Version="7.7" \
 		Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.pgdump.centos7
+++ b/centos7/12/Dockerfile.pgdump.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgdump" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.pgpool.centos7
+++ b/centos7/12/Dockerfile.pgpool.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgpool" \
 		vendor="Crunchy Data" \
 		PostgresVersion="12" \
-		PostgresFullVersion="12.0" \
+		PostgresFullVersion="12.1" \
 		Version="7.7" \
 		Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.pgrestore.centos7
+++ b/centos7/12/Dockerfile.pgrestore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/restore" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.postgres-gis.centos7
+++ b/centos7/12/Dockerfile.postgres-gis.centos7
@@ -3,7 +3,7 @@ FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 LABEL name="crunchydata/postgres-gis" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.postgres.centos7
+++ b/centos7/12/Dockerfile.postgres.centos7
@@ -3,11 +3,11 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \
-        summary="PostgreSQL 12.0 (PGDG) on a Centos7 base image" \
+        summary="PostgreSQL 12.1 (PGDG) on a Centos7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         io.k8s.description="postgres container" \
         io.k8s.display-name="Crunchy postgres container" \

--- a/centos7/12/Dockerfile.upgrade.centos7
+++ b/centos7/12/Dockerfile.upgrade.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/upgrade" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.5/Dockerfile.backrest-restore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.backup.centos7
+++ b/centos7/9.5/Dockerfile.backup.centos7
@@ -1,18 +1,18 @@
 FROM centos:7
 
 LABEL name="crunchydata/backup" \
-        vendor="crunchy data" \
-	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
-	Version="7.7" \
-	Release="4.1.1" \
-        url="https://crunchydata.com" \
-        summary="Performs a pg_basebackup full database backup on a database container" \
-        description="Meant to be executed upon demand, this container will run pg_basebackup against a running database container and write the backup files to a mounted directory." \
-        io.k8s.description="backup container" \
-        io.k8s.display-name="Crunchy backup container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+    vendor="crunchy data" \
+    PostgresVersion="9.5" \
+    PostgresFullVersion="9.5.20" \
+    Version="7.7" \
+    Release="4.1.1" \
+    url="https://crunchydata.com" \
+    summary="Performs a pg_basebackup full database backup on a database container" \
+    description="Meant to be executed upon demand, this container will run pg_basebackup against a running database container and write the backup files to a mounted directory." \
+    io.k8s.description="backup container" \
+    io.k8s.display-name="Crunchy backup container" \
+    io.openshift.expose-services="" \
+    io.openshift.tags="crunchy,database"
 
 COPY licenses /licenses
 
@@ -28,11 +28,11 @@ ADD bin/common /opt/cpm/bin
 ADD conf/backup/ /opt/cpm/conf
 
 RUN chown -R postgres:postgres  /opt/cpm /pgdata && \
-        chmod -R g=u /opt/cpm /pgdata 
+        chmod -R g=u /opt/cpm /pgdata
 
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
-	
+
 VOLUME ["/pgdata"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/centos7/9.5/Dockerfile.collect.centos7
+++ b/centos7/9.5/Dockerfile.collect.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/collect" \
 	vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
   url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.5/Dockerfile.pgadmin4.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.pgbadger.centos7
+++ b/centos7/9.5/Dockerfile.pgbadger.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbadger" \
 	vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.pgbench.centos7
+++ b/centos7/9.5/Dockerfile.pgbench.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.pgbouncer.centos7
+++ b/centos7/9.5/Dockerfile.pgbouncer.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.pgdump.centos7
+++ b/centos7/9.5/Dockerfile.pgdump.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.pgpool.centos7
+++ b/centos7/9.5/Dockerfile.pgpool.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.pgrestore.centos7
+++ b/centos7/9.5/Dockerfile.pgrestore.centos7
@@ -2,10 +2,10 @@ FROM centos:7
 
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
-	PostgresVersion="9.5" \
-      	PostgresFullRelease="9.5.13" \
-	Version="7.7" \
-	Release="4.1.1" \
+        PostgresVersion="9.5" \
+        PostgresFullVersion="9.5.20"
+        Version="7.7" \
+        Release="4.1.1" \
         url="https://crunchydata.com" \
         summary="Performs a pg_restore on a database container" \
         description="Meant to be executed upon demand, this container will run pg_restore against a running database container and write the backup files to a mounted directory." \
@@ -43,7 +43,7 @@ RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
 VOLUME ["/pgdata"]
-	
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 USER 26

--- a/centos7/9.5/Dockerfile.postgres-gis.centos7
+++ b/centos7/9.5/Dockerfile.postgres-gis.centos7
@@ -3,7 +3,7 @@ FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.postgres.centos7
+++ b/centos7/9.5/Dockerfile.postgres.centos7
@@ -3,11 +3,11 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 9.5.19 (PGDG) on a Centos7 base image" \
+	summary="PostgreSQL 9.5.20 (PGDG) on a Centos7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         io.k8s.description="postgres container" \
         io.k8s.display-name="Crunchy postgres container" \

--- a/centos7/9.6/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.6/Dockerfile.backrest-restore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.backup.centos7
+++ b/centos7/9.6/Dockerfile.backup.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/backup" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.collect.centos7
+++ b/centos7/9.6/Dockerfile.collect.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/collect" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.6/Dockerfile.pgadmin4.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.pgbadger.centos7
+++ b/centos7/9.6/Dockerfile.pgbadger.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.pgbench.centos7
+++ b/centos7/9.6/Dockerfile.pgbench.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.pgbouncer.centos7
+++ b/centos7/9.6/Dockerfile.pgbouncer.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.pgdump.centos7
+++ b/centos7/9.6/Dockerfile.pgdump.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.pgpool.centos7
+++ b/centos7/9.6/Dockerfile.pgpool.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.pgrestore.centos7
+++ b/centos7/9.6/Dockerfile.pgrestore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.postgres-gis.centos7
+++ b/centos7/9.6/Dockerfile.postgres-gis.centos7
@@ -3,7 +3,7 @@ FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.postgres.centos7
+++ b/centos7/9.6/Dockerfile.postgres.centos7
@@ -3,11 +3,11 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
 	vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 9.6.15 (PGDG) on a Centos7 base image" \
+	summary="PostgreSQL 9.6.16 (PGDG) on a Centos7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         io.k8s.description="postgres container" \
         io.k8s.display-name="Crunchy postgres container" \

--- a/centos7/9.6/Dockerfile.upgrade.centos7
+++ b/centos7/9.6/Dockerfile.upgrade.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/upgrade" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/examples/docker/swarm-service/docker-compose.yml
+++ b/examples/docker/swarm-service/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3.3"
 services:
   primary:
     hostname: 'primary'
-    image: crunchydata/crunchy-postgres:centos7-10.10-4.1.1
+    image: crunchydata/crunchy-postgres:centos7-10.11-4.1.1
     environment:
     - PGHOST=/tmp
     - MAX_CONNECTIONS=10
@@ -29,7 +29,7 @@ services:
         - node.labels.type == primary
         - node.role == worker
   replica:
-    image: crunchydata/crunchy-postgres:centos7-10.10-4.1.1
+    image: crunchydata/crunchy-postgres:centos7-10.11-4.1.1
     environment:
     - PGHOST=/tmp
     - MAX_CONNECTIONS=10

--- a/examples/helm/custom-config/README.md
+++ b/examples/helm/custom-config/README.md
@@ -66,10 +66,8 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install custom-config --name custom-config \
-  --set Image.tag=centos7-9.6.11-2.2.0
+  --set Image.tag=centos7-10.11-4.1.1
 ```
-
-The above command changes the image tag of the container from the default of `centos7-10.10-4.1.1` to `centos7-9.6.11-2.2.0`.
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
@@ -84,7 +82,7 @@ The above command changes the image tag of the container from the default of `ce
 | `.serviceType`      | The type of service      | `ClusterIP`               
 | `.image.repository` | The repository on DockerHub where the images are found.    | `crunchydata`                                           |
 | `.image.container` | The container to be pulled from the repository.    | `crunchy-postgres`                                                    |
-| `.image.tag` | The image tag to be used.    | `centos7-10.10-4.1.1`                                                    |
+| `.image.tag` | The image tag to be used.    | `centos7-10.11-4.1.1`                                                    |
 | `.resources.cpu` | Defines a limit for CPU    | `200m`                                                    |
 | `.resources.memory` | Defines a limit for memory    | `512Mi`                                                    |
 

--- a/examples/helm/custom-config/values.yaml
+++ b/examples/helm/custom-config/values.yaml
@@ -10,7 +10,7 @@ serviceType: ClusterIP
 image:
   repository: crunchydata
   container: crunchy-postgres
-  tag: centos7-10.10-4.1.1
+  tag: centos7-10.11-4.1.1
 resources:
   cpu: 200m
   memory: 512Mi

--- a/examples/helm/primary-replica/README.md
+++ b/examples/helm/primary-replica/README.md
@@ -102,10 +102,8 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install primary-replica --name primary-replica \
-  --set Image.tag=centos7-9.6.11-2.2.0
+  --set Image.tag=centos7-10.11-4.1.1
 ```
-
-The above command changes the image tag of the container from the default of `centos7-10.10-4.1.1` to `centos7-9.6.11-2.2.0`.
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
@@ -121,7 +119,7 @@ The above command changes the image tag of the container from the default of `ce
 | `.serviceType`      | The type of service      | `ClusterIP`               
 | `.image.repository` | The repository on DockerHub where the images are found.    | `crunchydata`                                           |
 | `.image.container` | The container to be pulled from the repository.    | `crunchy-postgres`                                                    |
-| `.image.tag` | The image tag to be used.    | `centos7-10.10-4.1.1`                                                    |
+| `.image.tag` | The image tag to be used.    | `centos7-10.11-4.1.1`                                                    |
 | `.pv.storage` | Size of persistent volume     | 400M                                                    |
 | `.pv.name` | Name of persistent volume    | `primary-pv`                                                    |
 | `.pv.mode` | The storage mode for the persistent volume    | `ReadWriteMany`                                                    |

--- a/examples/helm/primary-replica/values.yaml
+++ b/examples/helm/primary-replica/values.yaml
@@ -12,7 +12,7 @@ serviceType: ClusterIP
 image:
   repository: crunchydata
   container: crunchy-postgres
-  tag: centos7-10.10-4.1.1
+  tag: centos7-10.11-4.1.1
 pv:
   storage: 400M
   name: primary-pv

--- a/examples/helm/primary/README.md
+++ b/examples/helm/primary/README.md
@@ -65,10 +65,8 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install primary --name primary \
-  --set Image.tag=centos7-9.6.11-2.2.0
+  --set Image.tag=centos7-10.11-4.1.1
 ```
-
-The above command changes the image tag of the container from the default of `centos7-10.10-4.1.1` to `centos7-9.6.11-2.2.0`.
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
@@ -83,7 +81,7 @@ The above command changes the image tag of the container from the default of `ce
 | `.serviceType`      | The type of service      | `ClusterIP`               
 | `.image.repository` | The repository on DockerHub where the images are found.    | `crunchydata`                                           |
 | `.image.container` | The container to be pulled from the repository.    | `crunchy-postgres`                                                    |
-| `.image.tag` | The image tag to be used.    | `centos7-10.10-4.1.1`                                                    |
+| `.image.tag` | The image tag to be used.    | `centos7-10.11-4.1.1`                                                    |
 | `.resources.cpu` | Defines a limit for CPU    | `200m`                                                    |
 | `.resources.memory` | Defines a limit for memory    | `512Mi`                                                    |
 

--- a/examples/helm/primary/values.yaml
+++ b/examples/helm/primary/values.yaml
@@ -10,7 +10,7 @@ serviceType: ClusterIP
 image:
   repository: crunchydata
   container: crunchy-postgres
-  tag: centos7-10.10-4.1.1
+  tag: centos7-10.11-4.1.1
 resources:
   cpu: 200m
   memory: 512Mi

--- a/examples/helm/statefulset/README.md
+++ b/examples/helm/statefulset/README.md
@@ -104,10 +104,8 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install statefulset --name statefulset \
-  --set Image.tag=centos7-9.6.11-2.2.0
+  --set Image.tag=centos7-10.11-4.1.1
 ```
-
-The above command changes the image tag of the container from the default of `centos7-10.10-4.1.1` to `centos7-9.6.11-2.2.0`.
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
@@ -124,7 +122,7 @@ The above command changes the image tag of the container from the default of `ce
 | `.serviceType`      | The type of service      | `ClusterIP`               
 | `.image.repository` | The repository on DockerHub where the images are found.    | `crunchydata`                                           |
 | `.image.container` | The container to be pulled from the repository.    | `crunchy-postgres`                                                    |
-| `.image.tag` | The image tag to be used.    | `centos7-10.10-4.1.1`                                                    |
+| `.image.tag` | The image tag to be used.    | `centos7-10.11-4.1.1`                                                    |
 | `.pv.storage` | Size of persistent volume     | 400M                                                    |
 | `.pv.name` | Name of persistent volume    | `pgset-pv`                                                    |
 | `.pvc.name` | Name of persistent volume    | `pgset-pvc`                                                    |

--- a/examples/helm/statefulset/values.yaml
+++ b/examples/helm/statefulset/values.yaml
@@ -14,7 +14,7 @@ serviceType: ClusterIP
 image:
   repository: crunchydata
   container: crunchy-postgres
-  tag: centos7-10.10-4.1.1
+  tag: centos7-10.11-4.1.1
 pv:
   storage: 400M
   name: pgset-pv

--- a/examples/helm/template-small/README.md
+++ b/examples/helm/template-small/README.md
@@ -75,10 +75,8 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install template-small --name template-small \
-  --set Image.tag=centos7-9.6.11-2.2.0
+  --set Image.tag=centos7-10.11-4.1.1
 ```
-
-The above command changes the image tag of the container from the default of `centos7-10.10-4.1.1` to `centos7-9.6.11-2.2.0`.
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
@@ -93,7 +91,7 @@ The above command changes the image tag of the container from the default of `ce
 | `.serviceType`      | The type of service      | `ClusterIP`               
 | `.image.repository` | The repository on DockerHub where the images are found.    | `crunchydata`                                           |
 | `.image.container` | The container to be pulled from the repository.    | `crunchy-postgres`                                                    |
-| `.image.tag` | The image tag to be used.    | `centos7-10.10-4.1.1`                                                    |
+| `.image.tag` | The image tag to be used.    | `centos7-10.11-4.1.1`                                                    |
 | `.resources.cpu` | Defines a limit for CPU    | `200m`                                                    |
 | `.resources.memory` | Defines a limit for memory    | `512Mi`                                                    |
 

--- a/examples/helm/template-small/values.yaml
+++ b/examples/helm/template-small/values.yaml
@@ -12,7 +12,7 @@ serviceType: ClusterIP
 image:
   repository: crunchydata
   container: crunchy-postgres
-  tag: centos7-10.10-4.1.1
+  tag: centos7-10.11-4.1.1
 resources:
   cpu: 200m
   memory: 512Mi

--- a/hugo/content/container-specifications/crunchy-backrest-restore.md
+++ b/hugo/content/container-specifications/crunchy-backrest-restore.md
@@ -18,7 +18,7 @@ The following features are supported and required by the crunchy-backrest-restor
 
 The crunchy-backrest-restore Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.0, 11.5, 10.10, 9.6.15 and 9.5.19)
+* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
 * [pgBackRest](https://pgbackrest.org/) (2.18)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-backup.md
+++ b/hugo/content/container-specifications/crunchy-backup.md
@@ -19,7 +19,7 @@ The following features are supported by the `crunchy-backup` container:
 
 The crunchy-backup Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.0, 11.5, 10.10, 9.6.15 and 9.5.19)
+* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-collect.md
+++ b/hugo/content/container-specifications/crunchy-collect.md
@@ -23,7 +23,7 @@ can be specified for the API to collect. For an example of a queries.yml file, s
 
 The crunchy-collect Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.0, 11.5, 10.10, 9.6.15 and 9.5.19)
+* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 * [PostgreSQL Exporter](https://github.com/wrouesnel/postgres_exporter)

--- a/hugo/content/container-specifications/crunchy-pgadmin4.md
+++ b/hugo/content/container-specifications/crunchy-pgadmin4.md
@@ -28,7 +28,7 @@ The following features are supported by the crunchy-pgadmin4 container:
 
 The crunchy-pgadmin4 Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.0, 11.5, 10.10, 9.6.15 and 9.5.19)
+* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
 * [pgAdmin4](https://www.pgadmin.org/)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-pgbench.md
+++ b/hugo/content/container-specifications/crunchy-pgbench.md
@@ -19,7 +19,7 @@ The following features are supported by the `crunchy-pgbench` container:
 
 The crunchy-pgbench Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* pgBench (11.2, 10.7, 9.6.12 and 9.5.16)
+* pgBench (12.1, 11.6, 10.11, 9.6.16, 9.5.20)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-pgbouncer.md
+++ b/hugo/content/container-specifications/crunchy-pgbouncer.md
@@ -21,7 +21,7 @@ The following features are supported by the crunchy-pgbouncer container:
 
 The crunchy-pgbouncer Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.0, 11.5, 10.10, 9.6.15 and 9.5.19)
+* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
 * [pgBouncer](https://pgbouncer.github.io/)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-pgdump.md
+++ b/hugo/content/container-specifications/crunchy-pgdump.md
@@ -12,7 +12,7 @@ PostgreSQL database.
 
 The crunchy-pgdump Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.0, 11.5, 10.10, 9.6.15 and 9.5.19)
+* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-pgpool.md
+++ b/hugo/content/container-specifications/crunchy-pgpool.md
@@ -27,7 +27,7 @@ The following features are supported by the `crunchy-postgres` container:
 
 The crunchy-pgpool Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.0, 11.5, 10.10, 9.6.15 and 9.5.19)
+* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
 * [pgPool II](http://www.pgpool.net/mediawiki/index.php/Main_Page)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-pgrestore.md
+++ b/hugo/content/container-specifications/crunchy-pgrestore.md
@@ -13,7 +13,7 @@ to a PostgreSQL container database.
 
 The crunchy-pgrestore Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.0, 11.5, 10.10, 9.6.15 and 9.5.19)
+* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-postgres-gis.md
+++ b/hugo/content/container-specifications/crunchy-postgres-gis.md
@@ -22,7 +22,7 @@ The following features are supported by the `crunchy-postgres-gis` container:
 
 The crunchy-postgres-gis Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.0, 11.5, 10.10, 9.6.15 and 9.5.19)
+* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
 * [pgBackRest](https://pgbackrest.org/) (2.18)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-postgres.md
+++ b/hugo/content/container-specifications/crunchy-postgres.md
@@ -20,7 +20,7 @@ The following features are supported by the `crunchy-postgres` container:
 
 The crunchy-postgres Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.0, 11.5, 10.10, 9.6.15 and 9.5.19)
+* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
 * [pgBackRest](https://pgbackrest.org/) (2.18)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-upgrade.md
+++ b/hugo/content/container-specifications/crunchy-upgrade.md
@@ -35,7 +35,7 @@ The following features are supported by the crunchy-upgrade container:
 
 The crunchy-upgrade Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.0, 11.5, 10.10, 9.6.15 and 9.5.19)
+* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/examples/administration/upgrade.md
+++ b/hugo/content/examples/administration/upgrade.md
@@ -1,6 +1,6 @@
 ---
 title: "Upgrade"
-date: 
+date:
 draft: false
 weight: 81
 ---
@@ -8,16 +8,16 @@ weight: 81
 ## Major Upgrade
 
 {{% notice tip %}}
-This example assumes you have run *primary* using a PG 9.5 or 9.6 image
-such as `centos7-9.5.15-2.2.0` prior to running this upgrade.
+This example assumes you have run *primary* using a PostgreSQL 11 or 12 image
+such as `centos7-12.1-4.1.1` prior to running this upgrade.
 {{% /notice %}}
 
-The upgrade container will let you perform a `pg_upgrade` from a PostgreSQL version 9.5, 9.6, or 10 database to the available any of the higher versions of PostgreSQL versions that are currently support which are 9.6, 10, and 11. It does not do multi-version upgrades so you will need to for example do a 9.5 to 9.6 and then a 9.6 to 10 to get to version 10.
+The upgrade container will let you perform a `pg_upgrade` from a PostgreSQL version 9.5, 9.6, 10, 11 or 12 database to the available any of the higher versions of PostgreSQL versions that are currently support which are 9.6, 10, 11, and 12. It does not do multi-version upgrades so you will need to for example do a 10 to 11 and then a 11 to 12 to get to version 12.
 
 Prior to running this example, make sure your `CCP_IMAGE_TAG`
 environment variable is using the next major version of PostgreSQL that you
-want to upgrade to. For example, if you're upgrading from 9.5 to 9.6, make
-sure the variable references a PG 9.6 image such as `centos7-9.6.11-2.2.0`.
+want to upgrade to. For example, if you're upgrading from 11 to 12, make
+sure the variable references a PostgreSQL 12 image such as `centos7-12.1-4.1.1`.
 
 This will create the following in your Kubernetes environment:
 

--- a/hugo/content/examples/backup-restoration/pgbackrest.md
+++ b/hugo/content/examples/backup-restoration/pgbackrest.md
@@ -1,6 +1,6 @@
 ---
 title: "pgBackRest"
-date: 
+date:
 draft: false
 weight: 30
 ---
@@ -28,11 +28,11 @@ While setting `PGBACKREST` to `true` provides a simple method for enabling pgBac
 
 ```bash
 PGBACKREST_TYPE=time
-PITR_TARGET="2018-12-27 16:53:05.590156+00"
+PITR_TARGET="2019-10-27 16:53:05.590156+00"
 PGBACKREST_DELTA=y
 ```
 
-Full, incremental and differential backups of PostgreSQL databases deployed using the Crunchy Container Suite can scheduled using pgBackRest and the crunchy-scheduler container, and/or can also be performed manually by executing pgBackRest commands against the desired crunchy-postgres or crunchy-postgres-gis container.  Database restores, on the other hand, can be performed via the crunchy-backrest-restore container, which offers full pgBackRest restore capabilities, such as full, point-in-time and delta restores.  Further information and guidance for performing both backups and restores using the Crunchy Container Suite and pgBackRest will be provided in the examples below.  Additionally, for more information on utilizing the crunchy-scheduler container to schedule and perform pgBackRest database backups, please see the crunchy-scheduler [specifications](/container-specifications/crunchy-scheduler) and [examples](/examples/backup-restoration/scheduler/). 
+Full, incremental and differential backups of PostgreSQL databases deployed using the Crunchy Container Suite can scheduled using pgBackRest and the crunchy-scheduler container, and/or can also be performed manually by executing pgBackRest commands against the desired crunchy-postgres or crunchy-postgres-gis container.  Database restores, on the other hand, can be performed via the crunchy-backrest-restore container, which offers full pgBackRest restore capabilities, such as full, point-in-time and delta restores.  Further information and guidance for performing both backups and restores using the Crunchy Container Suite and pgBackRest will be provided in the examples below.  Additionally, for more information on utilizing the crunchy-scheduler container to schedule and perform pgBackRest database backups, please see the crunchy-scheduler [specifications](/container-specifications/crunchy-scheduler) and [examples](/examples/backup-restoration/scheduler/).
 
 In addition to providing the backup and restoration capabilities discussed above, pgBackRest supports the capability to asynchronously push and get write ahead logs (WAL) to and from a WAL archive.  To enable asychronous WAL archiving within a crunchy-postgres or crunchy-postgres-gis container, pgBackRest environment variable `PGBACKREST_ARCHIVE_ASYNC` must be set to `"y"` during deployment (`PGBACKREST_ARCHIVE_ASYNC=y`).  This will automatically enable WAL archiving within the container if not otherwise explicitly enabled, set the proper `pgbackrest archive` command within the `postgresql.conf` configuration file, and ensure the proper spool path has been created.  
 
@@ -51,8 +51,8 @@ As shown above, the default location of the spool path depends on whether or not
 The examples below will demonstrate the pgBackRest backup, restore and asynchronous archiving capabilities described above, while also providing insight into the proper configuration of pgBackBackrest within the Crunchy Container Suite.  For more information on these pgBackRest capabilities and associated configuration, please consult the [official pgBackRest documentation](https://pgbackrest.org/).  
 
 ## Kubernetes and OpenShift
- 
-***The pgBackRest examples for Kubernetes and OpenShift can be configured to use the PostGIS images by setting the following environment variable when running the examples:*** 
+
+***The pgBackRest examples for Kubernetes and OpenShift can be configured to use the PostGIS images by setting the following environment variable when running the examples:***
 ```bash
 export CCP_PG_IMAGE='-gis'
 ```
@@ -184,7 +184,7 @@ Prior to running the PITR restore, we will first verify the current state of the
 
 To verify the current state of the database, we will first verify that a table called **backrest_test_table** does not  exist in the database.
 
-```bash 
+```bash
 $ ${CCP_CLI} exec <backrest pod name> -- psql -c " table backrest_test_table"
 ERROR:  relation "backrest_test_table" does not exist
 LINE 1:  table backrest_test_table
@@ -198,7 +198,7 @@ Next, capture the current timestamp, which will be used later in the example whe
 $ ${CCP_CLI} exec <backrest pod name> -- psql -c "select current_timestamp"
        current_timestamp
 -------------------------------
- 2018-12-27 16:53:05.590156+00
+ 2019-10-27 16:53:05.590156+00
 (1 row)
 ```
 
@@ -222,7 +222,7 @@ With the table in place, we can now start the PITR.  However, the timestamp capt
 
 ```bash
 cd $CCPROOT/examples/kube/backrest/pitr
-CCP_BACKREST_TIMESTAMP="2018-12-20 09:49:02.275701+00" ./run.sh
+CCP_BACKREST_TIMESTAMP="2019-10-27 16:53:05.590156+00" ./run.sh
 ```
 
 This will create the following in your Kubernetes environment:
@@ -260,7 +260,7 @@ cd $CCPROOT/examples/kube/backrest/pitr
 
 Finally, once the **backrest-pitr-restored** deployment is running we can verify that the restore was successful by verifying that the table created prior to the restore no longer exists:
 
-```bash 
+```bash
 $ ${CCP_CLI} exec <backrest restored pod name> -- psql -c " table backrest_test_table"
 ERROR:  relation "backrest_test_table" does not exist
 LINE 1:  table backrest_test_table
@@ -277,7 +277,7 @@ Prior to running the delta restore, we will first verify the current state of th
 
 To verify the current state of the database, we will first verify that a table called **backrest_test_table** does not exist in the database.
 
-```bash 
+```bash
 $ ${CCP_CLI} exec <backrest pod name> -- psql -c " table backrest_test_table"
 ERROR:  relation "backrest_test_table" does not exist
 LINE 1:  table backrest_test_table
@@ -291,7 +291,7 @@ Next, capture the current timestamp, which will be used later in the example whe
 $ ${CCP_CLI} exec <backrest pod name> -- psql -c "select current_timestamp"
        current_timestamp
 -------------------------------
- 2018-12-27 16:53:05.590156+00
+ 2019-10-27 16:53:05.590156+00
 (1 row)
 ```
 
@@ -315,7 +315,7 @@ With the table in place, we can now start the delta restore.  When running the r
 
 ```bash
 cd $CCPROOT/examples/kube/backrest/delta
-CCP_BACKREST_TIMESTAMP="2018-12-20 09:49:02.275701+00" ./run.sh
+CCP_BACKREST_TIMESTAMP="2019-10-27 16:53:05.590156+00" ./run.sh
 ```
 
 This will create the following in your Kubernetes environment:
@@ -354,7 +354,7 @@ cd $CCPROOT/examples/kube/backrest/delta
 
 Finally, once the **backrest-delta-restored** deployment is running we can verify that the restore was successful by verifying that the table created prior to the restore no longer exists:
 
-```bash 
+```bash
 $ ${CCP_CLI} exec <backrest restored pod name> -- psql -c " table backrest_test_table"
 ERROR:  relation "backrest_test_table" does not exist
 LINE 1:  table backrest_test_table
@@ -535,7 +535,7 @@ As demonstrated with the full restore above, the default behavior of pgBackRest 
 Prior to running the PITR restore, we will first verify the current state of the database, after which we will then make a change to the database.  This will allow us to verify that the PITR is successful by providing a method of verifying that the database has been restored to its current state following the restore.
 
 To verify the current state of the database, we will first verify that a table called **backrest_test_table** does not  exist in the database.
-```bash 
+```bash
 $ docker exec backrest psql -c "table backrest_test_table"
 ERROR:  relation "backrest_test_table" does not exist
 LINE 1:  table backrest_test_table
@@ -548,7 +548,7 @@ Next, capture the current timestamp, which will be used later in the example whe
 $ docker exec backrest psql -c "select current_timestamp"
        current_timestamp
 -------------------------------
- 2018-12-27 16:53:05.590156+00
+ 2019-10-27 16:53:05.590156+00
 (1 row)
 ```
 
@@ -567,7 +567,7 @@ $ docker exec backrest psql -c "table backrest_test_table"
 With the table in place, we can now start the PITR.  However, the timestamp captured above must also be provided in order to instruct pgBackRest to recover to that specific point-in-time.  This is done using the `CCP_BACKREST_TIMESTAMP` variable, which allows us to then start the PITR as follows (replace the timestamp in the command below with the timestamp you captured above):
 ```bash
 cd $CCPROOT/examples/docker/backrest/pitr
-CCP_BACKREST_TIMESTAMP="2018-12-20 09:49:02.275701+00" ./run.sh
+CCP_BACKREST_TIMESTAMP="2019-10-27 16:53:05.590156+00" ./run.sh
 ```
 
 This will create the following in your Docker environment:
@@ -597,7 +597,7 @@ cd $CCPROOT/examples/docker/backrest/pitr
 ```
 
 Finally, once the **backrest-pitr-restored** container is running we can verify that the restore was successful by verifying that the table created prior to the restore no longer exists:
-```bash 
+```bash
 $ docker exec backrest-pitr-restored psql -c "table backrest_test_table"
 ERROR:  relation "backrest_test_table" does not exist
 LINE 1:  table backrest_test_table
@@ -613,7 +613,7 @@ By default, pgBackRest requires a clean/empty directory in order to perform a re
 Prior to running the delta restore, we will first verify the current state of the database, and we will then make a change to the database.  This will allow us to verify that the delta restore is successful by providing a method of verifying that the database has been restored to its current state following the restore.
 
 To verify the current state of the database, we will first verify that a table called **backrest_test_table** does not  exist in the database.
-```bash 
+```bash
 $ docker exec backrest psql -c "table backrest_test_table"
 ERROR:  relation "backrest_test_table" does not exist
 LINE 1:  table backrest_test_table
@@ -626,7 +626,7 @@ Next, capture the current timestamp, which will be used later in the example whe
 $ docker exec backrest psql -c "select current_timestamp"
        current_timestamp
 -------------------------------
- 2018-12-27 16:53:05.590156+00
+ 2019-10-27 16:53:05.590156+00
 (1 row)
 ```
 
@@ -646,7 +646,7 @@ $ docker exec backrest psql -c "table backrest_test_table"
 With the table in place, we can now start the delta restore.  When running the restore example the timestamp captured above must also be provided in order to instruct pgBackRest to recover to that specific point-in-time.  This is done using the `CCP_BACKREST_TIMESTAMP` variable, which allows us to then start the delta restore as follows (replace the timestamp in the command below with the timestamp you captured above):
 ```bash
 cd $CCPROOT/examples/docker/backrest/delta
-CCP_BACKREST_TIMESTAMP="2018-12-20 09:49:02.275701+00" ./run.sh
+CCP_BACKREST_TIMESTAMP="2019-10-27 16:53:05.590156+00" ./run.sh
 ```
 
 This will create the following in your Docker environment:
@@ -677,7 +677,7 @@ cd $CCPROOT/examples/docker/backrest/delta
 ```
 
 Finally, once the **backrest-delta-restored** container is running we can verify that the restore was successful by verifying that the table created prior to the restore no longer exists:
-```bash 
+```bash
 $ docker exec backrest-delta-restored psql -c "table backrest_test_table"
 ERROR:  relation "backrest_test_table" does not exist
 LINE 1:  table backrest_test_table

--- a/hugo/content/examples/postgresql/custom-config-ssl.md
+++ b/hugo/content/examples/postgresql/custom-config-ssl.md
@@ -83,7 +83,7 @@ sslkey=$CCPROOT/examples/kube/custom-config-ssl/certs/client.key"
 
 You should see a connection that looks like the following:
 ```
-psql (10.10)
+psql (10.11)
 SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
 Type "help" for help.
 

--- a/hugo/content/installation-guide/installation-guide.md
+++ b/hugo/content/installation-guide/installation-guide.md
@@ -5,7 +5,7 @@ draft: false
 weight: 100
 ---
 
-# Overview 
+# Overview
 
 This document serves four purposes:
 
@@ -16,11 +16,11 @@ This document serves four purposes:
 
 Where applicable, we will try to denote which installations and steps are required for the items above.
 
-When we set up the directories below, you will notice they seem to be quite deeply nested. We are 
-setting up a [Go programming language](https://golang.org/) workspace. Go has a specific folder structure 
-for it's [workspaces](https://golang.org/doc/code.html#Workspaces) with multiple projects in a workspace. 
-If you are **not** going build the container images you can ignore the deep directories below, but it will 
-not hurt you if you follow the directions exactly. 
+When we set up the directories below, you will notice they seem to be quite deeply nested. We are
+setting up a [Go programming language](https://golang.org/) workspace. Go has a specific folder structure
+for it's [workspaces](https://golang.org/doc/code.html#Workspaces) with multiple projects in a workspace.
+If you are **not** going build the container images you can ignore the deep directories below, but it will
+not hurt you if you follow the directions exactly.
 
 # Requirements
 
@@ -80,23 +80,23 @@ We also need to go fetch a Go module for expanding environement variables
 
 # Your Shell Environment
 
-We have found, that because of the way Go handles different projects, you may want to create a separate account 
-if are plan to build the containers and work on other Go projects. You could also look into some of the 
+We have found, that because of the way Go handles different projects, you may want to create a separate account
+if are plan to build the containers and work on other Go projects. You could also look into some of the
 GOPATH wrappers.
 
 If your goal is to simply run the containers, any properly configured user account should
-work. 
+work.
 
-Now we need to set the project paths and software version numbers. Edit your $HOME/.bashrc file with your 
-favorite editor and add the following information. You can leave out the comments at the end of each 
+Now we need to set the project paths and software version numbers. Edit your $HOME/.bashrc file with your
+favorite editor and add the following information. You can leave out the comments at the end of each
 line starting with #:
 
     export GOPATH=$HOME/cdev        # set path to your new Go workspace
-    export GOBIN=$GOPATH/bin        # set bin path 
+    export GOBIN=$GOPATH/bin        # set bin path
     export PATH=$PATH:$GOBIN        # add Go bin path to your overall path
     export CCP_BASEOS=centos7       # centos7 for Centos, rhel7 for Redhat
     export CCP_PGVERSION=10         # The PostgreSQL major version
-    export CCP_PG_FULLVERSION=10.10
+    export CCP_PG_FULLVERSION=10.11
     export CCP_VERSION=4.1.1
     export CCP_IMAGE_PREFIX=crunchydata # Prefix to put before all the container image names
     export CCP_IMAGE_TAG=$CCP_BASEOS-$CCP_PG_FULLVERSION-$CCP_VERSION   # Used to tag the images
@@ -110,12 +110,12 @@ effect.
 
     . ~/.bashrc
 
-At this point we have almost all the prequesites required to build the Crunchy Container Suite. 
+At this point we have almost all the prequesites required to build the Crunchy Container Suite.
 
 # Building RHEL Containers With Supported Crunchy Enterprise Software
 
-Before you can build supported containers on RHEL and Crunchy Supported Software, you need 
-to add the Crunchy repositories to your approved Yum repositories. Crunchy Enterprise Customer running on RHEL 
+Before you can build supported containers on RHEL and Crunchy Supported Software, you need
+to add the Crunchy repositories to your approved Yum repositories. Crunchy Enterprise Customer running on RHEL
 can login and download the Crunchy repository key and yum repository from <https://access.crunchydata.com/>
 on the downloads page. Once the files are downloaded please place them into the `$CCPROOT/conf` directory (defined
 above in the environment variable section).
@@ -155,7 +155,7 @@ Enable Docker service and start Docker (once all configuration is complete):
 
 {{% notice info %}}
 
-At this point you should be able to build the containers. Please to go to [Building the Containers](/contributing/building/) 
+At this point you should be able to build the containers. Please to go to [Building the Containers](/contributing/building/)
 page and continue from there.
 
 {{% / notice %}}
@@ -166,12 +166,12 @@ page and continue from there.
 {{% notice tip %}}
 
 You only need to install PostgreSQL locally if you want to use the examples - it is not required for
-either building the containers or installing the containers into Kubernetes. 
+either building the containers or installing the containers into Kubernetes.
 
 {{% / notice %}}
 
-These installation instructions 
-assume the installation of PostgreSQL 10 through the official Postgresql Development Group (PGDG) repository. 
+These installation instructions
+assume the installation of PostgreSQL 10 through the official Postgresql Development Group (PGDG) repository.
 View the documentation located [here](https://wiki.postgresql.org/wiki/YUM_Installation) in
 order to view more detailed notes or install a different version of PostgreSQL.
 
@@ -180,12 +180,12 @@ Locate and edit your distribution’s `.repo` file, located:
   - On **CentOS**: /etc/yum.repos.d/CentOS-Base.repo, \[base\] and \[updates\] sections
 
   - On **RHEL**: /etc/yum/pluginconf.d/rhnplugin.conf \[main\] section
- 
+
 To the section(s) identified above, depending on OS being used, you need to append a line to prevent dependencies
 from getting resolved to the PostgreSQL supplied by the base repository:
 
 - On **CentOS** and **RHEL**:
-    
+
     exclude=postgresql*
 
 Next, install the RPM relating to the base operating system and PostgreSQL version
@@ -215,8 +215,8 @@ Update the system:
 
 ## Configuring Storage for Kuberenetes Based Systems
 
-In addition to the environment variables we set earlier, you will need to add environment variables 
-for Kubernetes storage configuration. Please see the [Storage Configuration](/installation-guide/storage-configuration/) 
+In addition to the environment variables we set earlier, you will need to add environment variables
+for Kubernetes storage configuration. Please see the [Storage Configuration](/installation-guide/storage-configuration/)
 document for configuring storage using environment variables set in `.bashrc`.
 
 Don't forget to:

--- a/hugo/content/overview/overview.md
+++ b/hugo/content/overview/overview.md
@@ -29,11 +29,11 @@ Crunchy Container Suite provides two types of PostgreSQL database images:
 
 Supported major versions of these images are:
 
-- 9.5
-- 9.6
-- 10
-- 11
 - 12
+- 11
+- 10
+- 9.6
+- 9.5
 
 ### Crunchy PostgreSQL
 
@@ -153,11 +153,11 @@ it into an scheduled task.
 The Crunchy Upgrade image allows users to perform major upgrades of their Crunchy
 PostgreSQL containers.  The following upgrade versions of PostgreSQL are available:
 
-- 9.5
-- 9.6
-- 10
-- 11
 - 12
+- 11
+- 10
+- 9.6
+- 9.5
 
 ## Performance and Monitoring
 

--- a/rhel7/10/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/10/Dockerfile.backrest-restore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.backup.rhel7
+++ b/rhel7/10/Dockerfile.backup.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/backup" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.collect.rhel7
+++ b/rhel7/10/Dockerfile.collect.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/collect" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/10/Dockerfile.pgadmin4.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.pgbadger.rhel7
+++ b/rhel7/10/Dockerfile.pgbadger.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.pgbench.rhel7
+++ b/rhel7/10/Dockerfile.pgbench.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/10/Dockerfile.pgbouncer.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.pgdump.rhel7
+++ b/rhel7/10/Dockerfile.pgdump.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.pgpool.rhel7
+++ b/rhel7/10/Dockerfile.pgpool.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
   url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.pgrestore.rhel7
+++ b/rhel7/10/Dockerfile.pgrestore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/10/Dockerfile.postgres-gis.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.postgres.rhel7
+++ b/rhel7/10/Dockerfile.postgres.rhel7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 10.10 (PGDG) on a RHEL7 base image" \
+	summary="PostgreSQL 10.11 (PGDG) on a RHEL7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         run="" \
         start="" \

--- a/rhel7/10/Dockerfile.upgrade.rhel7
+++ b/rhel7/10/Dockerfile.upgrade.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/upgrade" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.10" \
+	PostgresFullVersion="10.11" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/11/Dockerfile.backrest-restore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.backup.rhel7
+++ b/rhel7/11/Dockerfile.backup.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/backup" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.collect.rhel7
+++ b/rhel7/11/Dockerfile.collect.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/collect" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/11/Dockerfile.pgadmin4.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.pgbadger.rhel7
+++ b/rhel7/11/Dockerfile.pgbadger.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.pgbench.rhel7
+++ b/rhel7/11/Dockerfile.pgbench.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/11/Dockerfile.pgbouncer.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.pgdump.rhel7
+++ b/rhel7/11/Dockerfile.pgdump.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.pgpool.rhel7
+++ b/rhel7/11/Dockerfile.pgpool.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
   url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.pgrestore.rhel7
+++ b/rhel7/11/Dockerfile.pgrestore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/11/Dockerfile.postgres-gis.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.postgres.rhel7
+++ b/rhel7/11/Dockerfile.postgres.rhel7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 11.5 (PGDG) on a RHEL7 base image" \
+	summary="PostgreSQL 11.6 (PGDG) on a RHEL7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         run="" \
         start="" \

--- a/rhel7/11/Dockerfile.upgrade.rhel7
+++ b/rhel7/11/Dockerfile.upgrade.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/upgrade" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.5" \
+	PostgresFullVersion="11.6" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/12/Dockerfile.backrest-restore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.backup.rhel7
+++ b/rhel7/12/Dockerfile.backup.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/backup" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.collect.rhel7
+++ b/rhel7/12/Dockerfile.collect.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/collect" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/12/Dockerfile.pgadmin4.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.pgbadger.rhel7
+++ b/rhel7/12/Dockerfile.pgbadger.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.pgbench.rhel7
+++ b/rhel7/12/Dockerfile.pgbench.rhel7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \
-    	summary="pgBench 12.0 (PGDG) on a RHEL7 base image" \
+    	summary="pgBench 12.1 (PGDG) on a RHEL7 base image" \
         description="pgbench is a simple program for running benchmark tests on PostgreSQL. It runs the same sequence of SQL commands over and over, possibly in multiple concurrent database sessions, and then calculates the average transaction rate (transactions per second)." \
         run="" \
         start="" \

--- a/rhel7/12/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/12/Dockerfile.pgbouncer.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbouncer" \
         vendor="crunchy data" \
 		PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.pgdump.rhel7
+++ b/rhel7/12/Dockerfile.pgdump.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.pgpool.rhel7
+++ b/rhel7/12/Dockerfile.pgpool.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgpool" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.pgrestore.rhel7
+++ b/rhel7/12/Dockerfile.pgrestore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/12/Dockerfile.postgres-gis.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.postgres.rhel7
+++ b/rhel7/12/Dockerfile.postgres.rhel7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \
-        summary="PostgreSQL 12.0 (PGDG) on a RHEL7 base image" \
+        summary="PostgreSQL 12.1 (PGDG) on a RHEL7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         run="" \
         start="" \

--- a/rhel7/12/Dockerfile.upgrade.rhel7
+++ b/rhel7/12/Dockerfile.upgrade.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/upgrade" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.0" \
+        PostgresFullVersion="12.1" \
         Version="7.7" \
         Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.5/Dockerfile.backrest-restore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.backup.rhel7
+++ b/rhel7/9.5/Dockerfile.backup.rhel7
@@ -3,21 +3,21 @@ FROM registry.access.redhat.com/rhel7
 MAINTAINER Crunchy Data <info@crunchydata.com>
 
 LABEL name="crunchydata/backup" \
-        vendor="crunchy data" \
-	PostgresVersion="9.5" \
-      	PostgresFullRelease="9.5.13" \
-	Version="7.7" \
-	Release="4.1.1" \
-        url="https://crunchydata.com" \
-        summary="Performs a pg_basebackup full database backup on a database container" \
-        description="Meant to be executed upon demand, this container will run pg_basebackup against a running database container and write the backup files to a mounted directory." \
-        run="" \
-        start="" \
-        stop="" \
-        io.k8s.description="backup container" \
-        io.k8s.display-name="Crunchy backup container" \
-        io.openshift.expose-services="" \
-        io.openshift.tags="crunchy,database"
+    vendor="crunchy data" \
+    PostgresVersion="9.5" \
+  	PostgresFullVersion="9.5.20"
+    Version="7.7" \
+    Release="4.1.1" \
+    url="https://crunchydata.com" \
+    summary="Performs a pg_basebackup full database backup on a database container" \
+    description="Meant to be executed upon demand, this container will run pg_basebackup against a running database container and write the backup files to a mounted directory." \
+    run="" \
+    start="" \
+    stop="" \
+    io.k8s.description="backup container" \
+    io.k8s.display-name="Crunchy backup container" \
+    io.openshift.expose-services="" \
+    io.openshift.tags="crunchy,database"
 
 COPY conf/atomic/backup/help.1 /help.1
 COPY conf/atomic/backup/help.md /help.md
@@ -50,13 +50,13 @@ ADD bin/common /opt/cpm/bin
 ADD conf/backup/ /opt/cpm/conf
 
 RUN chown -R postgres:postgres  /opt/cpm /pgdata && \
-        chmod -R g=u /opt/cpm /pgdata 
+        chmod -R g=u /opt/cpm /pgdata
 
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
 VOLUME ["/pgdata"]
-	
+
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
 
 USER 26

--- a/rhel7/9.5/Dockerfile.collect.rhel7
+++ b/rhel7/9.5/Dockerfile.collect.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/collect" \
 	vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
   url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/9.5/Dockerfile.pgadmin4.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbadger.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.pgbench.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbench.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbouncer.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.pgdump.rhel7
+++ b/rhel7/9.5/Dockerfile.pgdump.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.pgpool.rhel7
+++ b/rhel7/9.5/Dockerfile.pgpool.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
   url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.pgrestore.rhel7
+++ b/rhel7/9.5/Dockerfile.pgrestore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres-gis.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.postgres.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres.rhel7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.19" \
+	PostgresFullVersion="9.5.20" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 9.5.19 (PGDG) on a RHEL7 base image" \
+	summary="PostgreSQL 9.5.20 (PGDG) on a RHEL7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         run="" \
         start="" \

--- a/rhel7/9.6/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.6/Dockerfile.backrest-restore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.backup.rhel7
+++ b/rhel7/9.6/Dockerfile.backup.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/backup" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.collect.rhel7
+++ b/rhel7/9.6/Dockerfile.collect.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/collect" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/9.6/Dockerfile.pgadmin4.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbadger.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.pgbench.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbench.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbouncer.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.pgdump.rhel7
+++ b/rhel7/9.6/Dockerfile.pgdump.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.pgpool.rhel7
+++ b/rhel7/9.6/Dockerfile.pgpool.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.pgrestore.rhel7
+++ b/rhel7/9.6/Dockerfile.pgrestore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres-gis.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres-gis" \
 	vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.postgres.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres.rhel7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 9.6.15 (PGDG) on a RHEL7 base image" \
+	summary="PostgreSQL 9.6.16 (PGDG) on a RHEL7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         run="" \
         start="" \

--- a/rhel7/9.6/Dockerfile.upgrade.rhel7
+++ b/rhel7/9.6/Dockerfile.upgrade.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/upgrade" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.15" \
+	PostgresFullVersion="9.6.16" \
 	Version="7.7" \
 	Release="4.1.1" \
         url="https://crunchydata.com" \

--- a/tools/test-harness/data/data_types_test.go
+++ b/tools/test-harness/data/data_types_test.go
@@ -4,7 +4,7 @@ import (
 	dockertest "gopkg.in/ory-am/dockertest.v3"
 )
 
-var tag = "centos7-10.10-4.1.1"
+var tag = "centos7-11.6-4.1.1"
 
 var primaryEnv = []string{
 	"TEMP_BUFFERS=9MB",

--- a/ubi7/11/Dockerfile.backrest-restore.ubi7
+++ b/ubi7/11/Dockerfile.backrest-restore.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/crunchy-backrest-restore" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.5" \
+      PostgresFullVersion="11.6" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.backup.ubi7
+++ b/ubi7/11/Dockerfile.backup.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/backup" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.5" \
+      PostgresFullVersion="11.6" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.collect.ubi7
+++ b/ubi7/11/Dockerfile.collect.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/collect" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.5" \
+      PostgresFullVersion="11.6" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.pgadmin4.ubi7
+++ b/ubi7/11/Dockerfile.pgadmin4.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgadmin4" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.5" \
+      PostgresFullVersion="11.6" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.pgbadger.ubi7
+++ b/ubi7/11/Dockerfile.pgbadger.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbadger" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.5" \
+      PostgresFullVersion="11.6" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.pgbench.ubi7
+++ b/ubi7/11/Dockerfile.pgbench.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbench" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.5" \
+      PostgresFullVersion="11.6" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.pgbouncer.ubi7
+++ b/ubi7/11/Dockerfile.pgbouncer.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbouncer" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.5" \
+      PostgresFullVersion="11.6" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.pgdump.ubi7
+++ b/ubi7/11/Dockerfile.pgdump.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgdump" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.5" \
+      PostgresFullVersion="11.6" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.pgpool.ubi7
+++ b/ubi7/11/Dockerfile.pgpool.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgpool" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.5" \
+      PostgresFullVersion="11.6" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.pgrestore.ubi7
+++ b/ubi7/11/Dockerfile.pgrestore.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/restore" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.5" \
+      PostgresFullVersion="11.6" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.postgres-appdev.ubi7
+++ b/ubi7/11/Dockerfile.postgres-appdev.ubi7
@@ -3,7 +3,7 @@ FROM ubi7
 LABEL name="crunchydata/postgres-appdev" \
       vendor="crunchydata" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.5" \
+      PostgresFullVersion="11.6" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.postgres-gis.ubi7
+++ b/ubi7/11/Dockerfile.postgres-gis.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres-gis" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.5" \
+      PostgresFullVersion="11.6" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.postgres.ubi7
+++ b/ubi7/11/Dockerfile.postgres.ubi7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.5" \
+      PostgresFullVersion="11.6" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \
-      summary="PostgreSQL 11.5 (PGDG) on a RHEL7 base image" \
+      summary="PostgreSQL 11.6 (PGDG) on a RHEL7 base image" \
       description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
       run="" \
       start="" \

--- a/ubi7/11/Dockerfile.upgrade.ubi7
+++ b/ubi7/11/Dockerfile.upgrade.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/upgrade" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.5" \
+      PostgresFullVersion="11.6" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.backrest-restore.ubi7
+++ b/ubi7/12/Dockerfile.backrest-restore.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/crunchy-backrest-restore" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.0" \
+      PostgresFullVersion="12.1" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.backup.ubi7
+++ b/ubi7/12/Dockerfile.backup.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/backup" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.0" \
+      PostgresFullVersion="12.1" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.collect.ubi7
+++ b/ubi7/12/Dockerfile.collect.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/collect" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.0" \
+      PostgresFullVersion="12.1" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.pgadmin4.ubi7
+++ b/ubi7/12/Dockerfile.pgadmin4.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgadmin4" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.0" \
+      PostgresFullVersion="12.1" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.pgbadger.ubi7
+++ b/ubi7/12/Dockerfile.pgbadger.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbadger" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.0" \
+      PostgresFullVersion="12.1" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.pgbench.ubi7
+++ b/ubi7/12/Dockerfile.pgbench.ubi7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbench" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.0" \
+      PostgresFullVersion="12.1" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \
-      summary="pgBench 12.0 (PGDG) on a RHEL7 base image" \
+      summary="pgBench 12.1 (PGDG) on a RHEL7 base image" \
       description="pgbench is a simple program for running benchmark tests on PostgreSQL. It runs the same sequence of SQL commands over and over, possibly in multiple concurrent database sessions, and then calculates the average transaction rate (transactions per second)." \
       run="" \
       start="" \

--- a/ubi7/12/Dockerfile.pgbouncer.ubi7
+++ b/ubi7/12/Dockerfile.pgbouncer.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbouncer" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.0" \
+      PostgresFullVersion="12.1" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.pgdump.ubi7
+++ b/ubi7/12/Dockerfile.pgdump.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgdump" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.0" \
+      PostgresFullVersion="12.1" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.pgpool.ubi7
+++ b/ubi7/12/Dockerfile.pgpool.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgpool" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.0" \
+      PostgresFullVersion="12.1" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.pgrestore.ubi7
+++ b/ubi7/12/Dockerfile.pgrestore.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/restore" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.0" \
+      PostgresFullVersion="12.1" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.postgres-gis.ubi7
+++ b/ubi7/12/Dockerfile.postgres-gis.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres-gis" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.0" \
+      PostgresFullVersion="12.1" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.postgres.ubi7
+++ b/ubi7/12/Dockerfile.postgres.ubi7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.0" \
+      PostgresFullVersion="12.1" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \
-      summary="PostgreSQL 12.0 (PGDG) on a RHEL7 base image" \
+      summary="PostgreSQL 12.1 (PGDG) on a RHEL7 base image" \
       description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
       run="" \
       start="" \

--- a/ubi7/12/Dockerfile.upgrade.ubi7
+++ b/ubi7/12/Dockerfile.upgrade.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/upgrade" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.0" \
+      PostgresFullVersion="12.1" \
       Version="7.7" \
       Release="4.1.1" \
       url="https://crunchydata.com" \


### PR DESCRIPTION
This brings the container suite inline with the [2019-11-14 PostgreSQL release](https://www.postgresql.org/admin/news/newsarticle/1994/)

Issue: [ch6300]