### PR TITLE
Add Automated Tests for Postgres HA and Postgres GIS HA Examples

### DIFF
--- a/tools/test-harness/postgres_gis_ha_test.go
+++ b/tools/test-harness/postgres_gis_ha_test.go
@@ -1,0 +1,172 @@
+package tests
+
+import (
+	"testing"
+	"encoding/json"
+)
+
+// Test the Postgres HA container by running the relevant example and validated the
+// various resources are created and running with the correct statuses
+func TestPostgresGISHA(t *testing.T) {
+	t.Parallel()
+	t.Log("Testing the 'postgres-gis-ha' example...")
+	harness := setup(t, timeout, true)
+	var pods []string
+	env := []string{}
+
+	t.Run("Run the Postgres HA container example", func(t *testing.T) {
+		_, err := harness.runExample("examples/kube/postgres-gis-ha/run.sh", env, t)
+		if err != nil {
+			t.Fatalf("Could not run example: %s", err)
+		}
+	})
+
+	// Validate that deployments are created, that relevant pods are created for those deployments
+	// and validates that they are ready to use
+	t.Run("Checking pods statuses", func(t *testing.T) {
+		t.Log("Checking if postgres-gis-ha-01 deployment is ready...")
+		if ok, err := harness.Client.IsDeploymentReady(harness.Namespace, "postgres-gis-ha-01"); !ok {
+			t.Fatal(err)
+		}
+
+		t.Log("Checking if postgres-gis-ha-02 deployment is ready...")
+		if ok, err := harness.Client.IsDeploymentReady(harness.Namespace, "postgres-gis-ha-02"); !ok {
+			t.Fatal(err)
+		}
+
+		ha01, err := harness.Client.GetDeploymentPods(harness.Namespace, "postgres-gis-ha-01")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ha02, err := harness.Client.GetDeploymentPods(harness.Namespace, "postgres-gis-ha-02")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(ha01) == 0 {
+			t.Fatal("Postgres HA #1 deployment ready but no pods found")
+		}
+
+		if len(ha02) == 0 {
+			t.Fatal("Postgres HA #2 deployment ready but no pods found")
+		}
+
+		for _, pod := range ha01 {
+			pods = append(pods, pod)
+		}
+		for _, pod := range ha02 {
+			pods = append(pods, pod)
+		}
+
+		t.Log("Checking if Postgres HA pods are ready to use")
+		if err := harness.Client.CheckPods(harness.Namespace, pods); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+
+	t.Run("Testing database connectivity", func(t *testing.T) {
+		local, remote := randomPort(), 5432
+		proxy, err := harness.setupProxy(pods[0], local, remote)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer proxy.Close()
+
+		db, err := harness.setupDB("userdb", proxy.Hostname, "postgres", "password", "disable", local)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Check that extensions are installed
+		extensions, err := db.AllExtensions()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(extensions) < 1 {
+			t.Fatalf("extensions less then 1, it shouldn't be: %d", len(extensions))
+		} else {
+			t.Logf("Number of extensions: %v",len(extensions))
+		}
+
+		// Search through the installed extensions. If postgis is not installed
+		// the test fails
+		foundGIS := false
+		for _, extension := range extensions {
+			if extension.Name == "postgis" {
+				foundGIS = true
+				t.Log("PostGIS Installed Version: ")
+				t.Log(extension.InstalledVersion)
+			}
+		}
+		if !foundGIS {
+			t.Fatal("PostGIS installation information not found.")
+		}
+
+		defer db.Close()
+	})
+
+	t.Run("Grabbing Patroni output", func(t *testing.T) {
+		// Struct to hold relevant Patroni data
+		type PatroniData struct {
+			State string
+			Member string
+			Cluster string
+			Host string
+			Role string
+		}
+		// Exec into the first pod listed and run the Patroni client to gather status information
+		patronictl := []string{"patronictl", "list", "--format", "json"}
+		output, stderr, err := harness.Client.Exec(harness.Namespace, pods[0], "postgres", patronictl)
+		if err != nil {
+			t.Logf("\n%s", stderr)
+			t.Fatalf("Error execing into container: %s", err)
+		}
+
+		// Store unmarshalled 
+		var pd []PatroniData	
+		json.Unmarshal([]byte(output), &pd)
+		
+		// Variables to store numer of pods running and the number of leaders
+		numRunning := 0
+		numLeader := 0
+
+		// Print Patroni data gathered
+		t.Log("PATRONI DATA\n")
+		for _, element := range pd {
+			t.Logf("STATE: %+v\n", element.State)
+			if element.State == "running" {
+				numRunning += 1
+			}
+			t.Logf("MEMBER: %+v\n", element.Member)
+			t.Logf("CLUSTER: %+v\n", element.Cluster)
+			t.Logf("HOST: %+v\n", element.Host)
+			t.Logf("ROLE: %+v\n\n", element.Role)
+			if element.Role == "Leader" {
+				numLeader += 1
+			}
+		}
+
+		// Failure conditions are:
+		// 1) A Patroni enabled pod does not have a running status at this point
+		// 2) There is more than one 'leader' pod
+		// 3) There is not a 'leader' pod
+		if numRunning != len(pd){
+			t.Fatal("Not all Pods are running")
+		}
+		if numLeader > 1 {
+			t.Fatal("There is more than one leader.")
+		}
+		
+		if numLeader < 1 {
+			t.Fatal("There is no leader.")
+		}
+})
+	// Cleanup resources created for test
+	if harness.Cleanup {
+		defer harness.Client.DeleteNamespace(harness.Namespace)
+		defer harness.runExample("examples/kube/postgres-gis-ha/cleanup.sh", env, t)
+	}
+}

--- a/tools/test-harness/postgres_ha_test.go
+++ b/tools/test-harness/postgres_ha_test.go
@@ -1,0 +1,145 @@
+package tests
+
+import (
+	"testing"
+	"encoding/json"
+)
+
+// Test the Postgres HA container by running the relevant example and validated the
+// various resources are created and running with the correct statuses
+func TestPostgresHA(t *testing.T) {
+	t.Parallel()
+	t.Log("Testing the 'postgres-ha' example...")
+	harness := setup(t, timeout, true)
+	var pods []string
+	env := []string{}
+
+	t.Run("Run the Postgres HA container example", func(t *testing.T) {
+		_, err := harness.runExample("examples/kube/postgres-ha/run.sh", env, t)
+		if err != nil {
+			t.Fatalf("Could not run example: %s", err)
+		}
+	})
+
+	// Validate that deployments are created, that relevant pods are created for those deployments
+	// and validates that they are ready to use
+	t.Run("Checking pods statuses", func(t *testing.T) {
+		t.Log("Checking if postgres-ha-01 deployment is ready...")
+		if ok, err := harness.Client.IsDeploymentReady(harness.Namespace, "postgres-ha-01"); !ok {
+			t.Fatal(err)
+		}
+
+		t.Log("Checking if postgres-ha-02 deployment is ready...")
+		if ok, err := harness.Client.IsDeploymentReady(harness.Namespace, "postgres-ha-02"); !ok {
+			t.Fatal(err)
+		}
+
+		ha01, err := harness.Client.GetDeploymentPods(harness.Namespace, "postgres-ha-01")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ha02, err := harness.Client.GetDeploymentPods(harness.Namespace, "postgres-ha-02")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(ha01) == 0 {
+			t.Fatal("Postgres HA #1 deployment ready but no pods found")
+		}
+
+		if len(ha02) == 0 {
+			t.Fatal("Postgres HA #2 deployment ready but no pods found")
+		}
+
+		for _, pod := range ha01 {
+			pods = append(pods, pod)
+		}
+		for _, pod := range ha02 {
+			pods = append(pods, pod)
+		}
+
+		t.Log("Checking if Postgres HA pods are ready to use")
+		if err := harness.Client.CheckPods(harness.Namespace, pods); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+
+	t.Run("Testing database connectivity", func(t *testing.T) {
+		local, remote := randomPort(), 5432
+		proxy, err := harness.setupProxy(pods[0], local, remote)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer proxy.Close()
+
+		db, err := harness.setupDB("userdb", proxy.Hostname, "postgres", "password", "disable", local)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+	})
+
+	t.Run("Grabbing Patroni output", func(t *testing.T) {
+		// Struct to hold relevant Patroni data
+		type PatroniData struct {
+			State string
+			Member string
+			Cluster string
+			Host string
+			Role string
+		}
+		// Exec into the first pod listed and run the Patroni client to gather status information
+		patronictl := []string{"patronictl", "list", "--format", "json"}
+		output, stderr, err := harness.Client.Exec(harness.Namespace, pods[0], "postgres", patronictl)
+		if err != nil {
+			t.Logf("\n%s", stderr)
+			t.Fatalf("Error execing into container: %s", err)
+		}
+
+		// Store unmarshalled 
+		var pd []PatroniData	
+		json.Unmarshal([]byte(output), &pd)
+		
+		// Variables to store numer of pods running and the number of leaders
+		numRunning := 0
+		numLeader := 0
+
+		// Print Patroni data gathered
+		t.Log("PATRONI DATA\n")
+		for _, element := range pd {
+			t.Logf("STATE: %+v\n", element.State)
+			if element.State == "running" {
+				numRunning += 1
+			}
+			t.Logf("MEMBER: %+v\n", element.Member)
+			t.Logf("CLUSTER: %+v\n", element.Cluster)
+			t.Logf("HOST: %+v\n", element.Host)
+			t.Logf("ROLE: %+v\n\n", element.Role)
+			if element.Role == "Leader" {
+				numLeader += 1
+			}
+		}
+
+		// Failure conditions are:
+		// 1) A Patroni enabled pod does not have a running status at this point
+		// 2) There is more than one 'leader' pod
+		// 3) There is not a 'leader' pod
+		if numRunning != len(pd){
+			t.Fatal("Not all Pods are running")
+		}
+		if numLeader > 1 {
+			t.Fatal("There is more than one leader.")
+		}
+		
+		if numLeader < 1 {
+			t.Fatal("There is no leader.")
+		}
+})
+	// Cleanup resources created for test
+	if harness.Cleanup {
+		defer harness.Client.DeleteNamespace(harness.Namespace)
+		defer harness.runExample("examples/kube/postgres-ha/cleanup.sh", env, t)
+	}
+}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
New containers, Postgres HA and Postgres GIS HA have been added to the 
Crunchy Containers suite and need automated tests as already exist
for the other containers.


**What is the new behavior (if this is a feature change)?**
In keeping with the existing integration test suite, new tests are
added for the Postgres HA and Postgres GIS HA container examples.
These tests run the previously developed examples that deploy two
pods with the Patroni HA solution configured. The tests will run as
follows:

-In a new namespace, check that the relevant deployments and pods are
  created and ready
-Test the database connectivity on the first pod
(-For the GIS example, verify that the postgis extension is installed)
-Return the Patroni status information and validate the pods show as
  running and there is exactly one leader assigned to the Patroni cluster
-Cleanup the created resources

This ensures that the basic operation of the relevant examples are
working as expected.

**Other information**:
Please note: These tests do not currently work correction in an Openshift 
environment due to OCP's method of dynamically assigning an allowed User ID 
range when a new OCP project (aka namespace) is created. Because these tests are
designed to run in their own namespace, a more robust solution will need to be 
implemented in the future.

Issue: [ch6189]