### PR TITLE
fixes implicit rule failures for docker builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,10 +239,10 @@ backrest-restore-pgimg-docker: backrest-restore-pgimg-build
 %-pgimg-buildah: %-pgimg-build
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-$*:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-$*:$(CCP_IMAGE_TAG)
 
-%-pgimg-docker: %-pgimg-build
+%-pgimg-docker: %-pgimg-build ;
 
 # ----- Extra images -----
-%-img-build: $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.%.$(CCP_BASEOS) 
+%-img-build: ccbase-image $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.%.$(CCP_BASEOS) 
 	$(IMGCMDSTEM) \
 		-f $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.$*.$(CCP_BASEOS) \
 		-t $(CCP_IMAGE_PREFIX)/crunchy-$*:$(CCP_IMAGE_TAG) \
@@ -252,22 +252,20 @@ backrest-restore-pgimg-docker: backrest-restore-pgimg-build
 		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
 		$(CCPROOT)
 
-%-img-buildah: ccbase-image-buildah %-img-build
+%-img-buildah: %-img-build
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-$*:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-$*:$(CCP_IMAGE_TAG)
 
-%-img-docker: ccbase-image-docker %-img-build
+%-img-docker: %-img-build ;
 
 # ----- Upgrade Images -----
 upgrade: upgrade-$(CCP_PGVERSION)
 
-upgrade-9.5: # Do nothing
-	$(info Upgrade build skipped for 9.5)
-upgrade-9.6: upgrade-9.6-pgimg-$(IMGBUILDER)
-upgrade-10: upgrade-10-pgimg-$(IMGBUILDER)
-upgrade-11: upgrade-11-pgimg-$(IMGBUILDER)
-upgrade-12: upgrade-12-pgimg-$(IMGBUILDER)
+upgrade-%: upgrade-%-pgimg-$(IMGBUILDER) ;
 
-upgrade-%-pgimg-build: $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.upgrade-%.$(CCP_BASEOS)
+upgrade-9.5: # Do nothing but log to avoid erroring out on missing Dockerfile
+	$(info Upgrade build skipped for 9.5)
+
+upgrade-%-pgimg-build: cc-pg-base-image $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.upgrade-%.$(CCP_BASEOS)
 	$(IMGCMDSTEM) \
 		-f $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.upgrade-$*.$(CCP_BASEOS) \
 		-t $(CCP_IMAGE_PREFIX)/crunchy-upgrade:$(CCP_IMAGE_TAG) \
@@ -276,10 +274,10 @@ upgrade-%-pgimg-build: $(CCPROOT)/$(CCP_BASEOS)/Dockerfile.upgrade-%.$(CCP_BASEO
 		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
 		$(CCPROOT)
 
-upgrade-%-pgimg-buildah: cc-pg-base-image-buildah upgrade-%-pgimg-build
+upgrade-%-pgimg-buildah: upgrade-%-pgimg-build
 	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-upgrade:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-upgrade:$(CCP_IMAGE_TAG)
 
-upgrade-%-pgimg-docker: cc-pg-base-image-docker upgrade-%-pgimg-build
+upgrade-%-pgimg-docker: upgrade-%-pgimg-build ;
 
 
 #=================


### PR DESCRIPTION
The removal of the extraneous docker tag command left some implicit
rules without a recipe. This particular syntax, however, is the
implicit-rule cancel syntax:
http://www.gnu.org/software/make/manual/make.html#Canceling-Rules

To remedy this syntax, make needs to be explicitly told the recipe is
empty via the trailing semicolon.

Other changes:
 * Fixing the implicit rule syntax helped explain my failed attempts to
use a generic rule for upgrades with a single 9.5 exclusion
 * The build rules for non-pg images and upgrade images had the base
dependency moved to them instead of one layer out, to be consistent
with the rest of the build rules

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
