### PR TITLE
Enable pg_rewind in crunchy-postgres-ha & Reject non-Replication Connections as Replication User

### DIFF
--- a/conf/postgres-ha/postgres-ha-initdb.yaml
+++ b/conf/postgres-ha/postgres-ha-initdb.yaml
@@ -2,6 +2,7 @@
 bootstrap:
   dcs:
     postgresql:
+      use_pg_rewind: true
       parameters:
         log_directory: pg_log
         shared_buffers: 128MB

--- a/conf/postgres-ha/postgres-ha-pgconf.yaml
+++ b/conf/postgres-ha/postgres-ha-pgconf.yaml
@@ -15,3 +15,4 @@ postgresql:
     command: 'pgbackrest --delta restore'
     keep_data: true
     no_params: true
+  remove_data_directory_on_rewind_failure: true

--- a/conf/postgres-ha/postgres-ha-pgconf.yaml
+++ b/conf/postgres-ha/postgres-ha-pgconf.yaml
@@ -4,6 +4,7 @@ postgresql:
     - local all postgres peer
     - local all crunchyadm peer
     - host replication PATRONI_REPLICATION_USERNAME 0.0.0.0/0 md5
+    - host all PATRONI_REPLICATION_USERNAME 0.0.0.0/0 reject
     - host all all 0.0.0.0/0 md5
   use_unix_socket: true
   pgpass: /tmp/.pgpass


### PR DESCRIPTION
This PR enables `pg_rewind` support in the default `crunchy-postgres-ha` Patroni config, specifically setting `use_pg_rewind` to `true` in the default Patroni bootstrap config file.  With this setting enabled, when the default configuration is utilized and Patroni detects that a former primary's timeline has diverged from the current/new primary following a failover, Patroni will attempt to use `pg_rewind` to synchronize the old primary primary with the new primary, so that it can rejoin the cluster as a replica.

Additionally, the `remove_data_directory_on_rewind_failure` Patroni configuration setting has been set to `true` in the default local postgresql configuration for the `crunchy-postgres-ha` container.  With this setting in place, if a `pg_rewind` attempt fails, the `PGDATA` directory for the PG node will be deleted, and the replica will be reinitialized (by default using `pgbackrest restore --delta`).
 
And finally,  a reject rule has been added for the `replication` user in default `pg_hba.conf` configuration provided in the `crunchy-postgres-ha` container.  This reject rule will prevent users from connecting DB as the replication user, therefore ensuring replica creation remains stable.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

`pg_rewind` is not enabled for the `crunchy-postgres-ha` container by default, and non-replication connections to the database as the replication user are allowed.

**What is the new behavior (if this is a feature change)?**

`pg_rewind` is now enabled for the `crunchy-postgres-ha` container by default, and non-replication connections to the database as the replication user are no longer allowed.

[ch6465]

**Other information**:

N/A