### PR TITLE
adds warning for missing Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,9 @@ scheduler: scheduler-img-$(IMGBUILDER)
 # Pattern-based image generation targets
 #===========================================
 
+$(CCPROOT)/$(CCP_BASEOS)/Dockerfile.%.$(CCP_BASEOS):
+	$(error No Dockerfile found for $* naming pattern: [$@])
+
 # ----- Base Image -----
 ccbase-image: ccbase-image-$(IMGBUILDER)
 


### PR DESCRIPTION
This commit captures a feature added to the operator makefile which
did not make it to the containers makefile.

Prior to this change, a misconfiguration in path gave an unclear
error regarding missing make rules when in fact the dependency of
the dockerfile for a given rule was missing.

This change replaces the 'missing rule' with one that emits a
clear error by displaying the attempted dockerfile resolution path

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
