### PR TITLE
Fix for PostgreSQL 12 recovery settings being overwritten.

### DIFF
--- a/bin/postgres/start.sh
+++ b/bin/postgres/start.sh
@@ -273,7 +273,7 @@ function initialize_replica_post12() {
     echo "promote_trigger_file = '/tmp/pg-failover-trigger'" > $RECOVERY_FILE_TMP
     # the primary_conninfo string stays mostly the same
     PGCONF_PRIMARY_CONNINFO="application_name=${APPLICATION_NAME} host=${PG_PRIMARY_HOST} port=${PG_PRIMARY_PORT} user=${PG_PRIMARY_USER}"
-    echo "primary_conninfo = '${PGCONF_PRIMARY_CONNINFO}'" > $RECOVERY_FILE_TMP
+    echo "primary_conninfo = '${PGCONF_PRIMARY_CONNINFO}'" >> $RECOVERY_FILE_TMP
     # append the contents of $RECOVERY_FILE_TMP to the postgresql.conf file
     cat $RECOVERY_FILE_TMP >> $PGDATA/postgresql.conf
     # and put the server into standby mode


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

Commit b797fad1 introduced support for PostgreSQL 12, but also
included a bug where the "promote_trigger_file" GUC was being
immediately overwritten after being set.

**What is the new behavior (if this is a feature change)?**

This fix ensures that the "promote_trigger_file" GUC remains
after being set.

**Other information**:

Issue: #1164 