### PR TITLE
Monitoring & Recovery from Failed PG Starts on Replicas

### DIFF
--- a/bin/crunchyadm/crunchyadm-readiness.sh
+++ b/bin/crunchyadm/crunchyadm-readiness.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright 2016 - 2019 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# peer authenticate via the unix socket as "crunchyadm" and run a simple query 
+# determine crunchyadm readiness
+psql -h /crunchyadm -U crunchyadm postgres -c "select now()"

--- a/bin/postgres-ha/pgbackrest-create-replica.sh
+++ b/bin/postgres-ha/pgbackrest-create-replica.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright 2016 - 2019 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
+source /opt/cpm/bin/pgha-common.sh
+export $(get_patroni_pgdata_dir)
+
+# If the PGDATA directory is empty or contains a valid PG database, then perform a delta restore.
+# If the PGDATA directory for the replica is invalid according to pgBackRest, then clear out
+# the directory and then perform a regular (i.e. non-delta) pgBackRest restore.  pgBackRest
+# specifically determines whether or not a PGDATA directory is valid by checking "for the
+# for the presence of PG_VERSION or backup.manifest (left over from an aborted restore). 
+# If neither file is found then --delta and --force will be disabled but the restore will proceed
+# unless there are files in the $PGDATA directory (or any tablespace directories) in which case the
+# operation will be aborted" (https://pgbackrest.org/release.html).
+if [[ -f "${PATRONI_POSTGRESQL_DATA_DIR}"/PG_VERSION || 
+    -f "${PATRONI_POSTGRESQL_DATA_DIR}"/backup.manifest ]]
+then
+    echo_info "Valid PGDATA dir found for replica, a delta restore will be peformed"
+    delta="--delta"
+elif [[ -z "$(ls -A ${PATRONI_POSTGRESQL_DATA_DIR})" ]]
+then
+    echo_info "Empty PGDATA dir found for replica, a non-delta restore will be peformed"
+else
+    echo_info "Invalid PGDATA directory found for replica, cleaning prior to restore"
+    while [[ ! -z "$(ls -A ${PATRONI_POSTGRESQL_DATA_DIR})" ]]
+    do
+        echo_info "Files still found in PGDATA, attempting cleanup"
+        rm -rf "${PATRONI_POSTGRESQL_DATA_DIR:?}"/*
+        sleep 3
+    done
+    echo_info "Replica PGDATA cleaned, a non-delta restore will be peformed"
+fi
+
+# perform the restore, setting the "--delta" option if populated
+pgbackrest restore ${delta}
+err_check "$?" "pgBackRest Replica Creation" "pgBackRest restore failed when creating replica"
+
+echo_info "Replica pgBackRest restore complete"

--- a/bin/postgres-ha/pgha-common.sh
+++ b/bin/postgres-ha/pgha-common.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Copyright 2016 - 2019 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PATRONI_PID=$(pgrep -f "patroni" | head -1)
+
+# Get the Patroni port from the running Patroni process
+get_patroni_port() {
+    pgha_patroni_port=$( tr '\0' '\n' < /proc/"${PATRONI_PID}"/environ  | grep ^PGHA_PATRONI_PORT= )
+    echo "${pgha_patroni_port}"
+}
+
+# Get the PGHA_PGBACKREST env var, which determines if pgBackRest is enabled
+get_pgbackrest_enabled() {
+    pgha_pgbackrest=$( tr '\0' '\n' < /proc/"${PATRONI_PID}"/environ  | \
+        grep ^PGHA_PGBACKREST= )
+    echo "${pgha_pgbackrest}"
+}
+
+# Get the PGHA_PGBACKREST env var to determine if replicas should reinit on a start failure
+get_replica_reinit_start_fail() {
+    pgha_replica_reinit_on_start_fail=$( tr '\0' '\n' < /proc/"${PATRONI_PID}"/environ | \
+        grep ^PGHA_REPLICA_REINIT_ON_START_FAIL= )
+    echo  "${pgha_replica_reinit_on_start_fail}"
+}
+
+# Get the PGHA_PGBACKREST env var to determine if replicas should reinit on a start failure
+get_patroni_name() {
+    patroni_name=$( tr '\0' '\n' < /proc/"${PATRONI_PID}"/environ | \
+        grep ^PATRONI_NAME= )
+    echo  "${patroni_name}"
+}
+
+# Get the PATRONI_POSTGRESQL_DATA_DIR env var to determine the PGDATA directory
+get_patroni_pgdata_dir() {
+    patroni_pgdata_dir=$( tr '\0' '\n' < /proc/"${PATRONI_PID}"/environ | \
+        grep ^PATRONI_POSTGRESQL_DATA_DIR= )
+    echo  "${patroni_pgdata_dir}"
+}

--- a/bin/postgres-ha/pgha-liveness.sh
+++ b/bin/postgres-ha/pgha-liveness.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright 2016 - 2019 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
+source /opt/cpm/bin/pgha-common.sh
+
+# set the Patroni port
+export $(get_patroni_port)
+
+# set PGHA_REPLICA_REINIT_ON_START_FAIL, which determines if replica should be reinitialized
+# if a start failure is detected
+export $(get_replica_reinit_start_fail)
+
+# set the name of this Patroni node, i.e. env var PATRONI_NAME
+export $(get_patroni_name)
+
+# get the role and state of the local Patroni node by calling the "patroni" endpoint
+local_node_json=$(curl --silent "127.0.0.1:${PGHA_PATRONI_PORT}/patroni" --stderr - )
+role=$(echo "${local_node_json}" | /opt/cpm/bin/yq r - role)
+state=$(echo "${local_node_json}" | /opt/cpm/bin/yq r - state)
+
+# determine if a backup is in progress following a failover (i.e. the promotion of a replica)
+# by looking for the "failover_backup_status" tag in the DCS
+primary_on_role_change=$(curl --silent "127.0.0.1:${PGHA_PATRONI_PORT}/config" \
+    | /opt/cpm/bin/yq r - tags.primary_on_role_change)
+            
+# if configured to reinit a replica when a "start failed" state is detected, and if a backup
+# is not current in progress following a failover, then reinitialize the replica by calling
+# the "reinitialize" endpoint on the local Patroni node
+if [[ "${PGHA_REPLICA_REINIT_ON_START_FAIL}" == "true" && "${role}" == "replica" \
+    && "${state}" == "start failed" && "${primary_on_role_change}" != "true" ]]
+then
+    # reinitialize the local Patroni node
+    curl --silent -XPOST -d '{"force":true}' "127.0.0.1:${PGHA_PATRONI_PORT}/reinitialize"
+fi
+
+
+# always exit with exit code 0 to prevent restarts
+exit 0

--- a/bin/postgres-ha/pgha-on-role-change.sh
+++ b/bin/postgres-ha/pgha-on-role-change.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright 2016 - 2019 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
+source /opt/cpm/bin/pgha-common.sh
+
+# set the Patroni port
+export $(get_patroni_port)
+
+# set PGHA_PGBACKREST to determine if backrest is enabled
+export $(get_pgbackrest_enabled)
+
+# get the node's current role (e.g. "replica") from the second parameter provided by Patroni when 
+# calling this callback script
+action="${1}"
+role="${2}"
+cluster="${3}"
+echo_info "${action} callback called (action=${action} role=${role} cluster=${cluster})"
+
+# get pgbackrest env vars
+source /tmp/pgbackrest_env.sh
+
+# if pgBackRest is enabled and the node has been promoted to "primary" (i.e. "master"), and if 
+# pgBackRest is enabled and is not utilizing a dedicated repository host, then take a new backup
+# to ensure the proper creation of replicas.  Also, write a tag to the DCS while the backup is in 
+# progress to inform other nodes that a backup is in progress.  If a dedicated repository host 
+# is being utilized (e.g. with the PostgreSQL Operator), then this process will be handled 
+# externally (e.g. within the PostgreSQL Operator when the repo host is updated following the
+# promotion of a replica to primary)
+if [[ "${role}" ==  "master" && "${PGHA_PGBACKREST}" == "true" ]] 
+then
+    curl -s -XPATCH -d '{"tags":{"primary_on_role_change":"true"}}' "localhost:${PGHA_PATRONI_PORT}/config"
+    if [[ ! -v PGBACKREST_REPO1_HOST && ! -v PGBACKREST_REPO_HOST ]]
+    then
+        pgbackrest backup
+        curl -s -XPATCH -d '{"tags":{"primary_on_role_change":null}}' "localhost:${PGHA_PATRONI_PORT}/config"
+    fi
+fi

--- a/bin/postgres-ha/pgha-readiness.sh
+++ b/bin/postgres-ha/pgha-readiness.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright 2016 - 2019 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
+source /opt/cpm/bin/pgha-common.sh
+
+# while the cluster is initializing, readiness is determined based on whether or not the
+# 'pgha_initialized' file exists.  Once the cluster has been initialized and this file has been
+# created, the Patroni "health" endpoint will then be utilized for any future readiness checks.
+if [[ -f "/crunchyadm/pgha_initialized" ]]
+then
+
+    # set the Patroni port
+    export $(get_patroni_port)
+
+    # obtain HTTP status code returned from the "health" endpoint
+    status_code=$(curl -o /dev/stderr -w "%{http_code}" "127.0.0.1:${PGHA_PATRONI_PORT}/health" 2> /dev/null)
+
+    # the local node is considered heathly if the HTTP status code returned from the local "health"
+    # endpoint is greated than 200 or less than 400, in accordance with the Kubernetes documenation
+    # for HTTP readiness checks, i.e. per the docs "any code greater than or equal to 200 and less 
+    # than 400 indicates success. Any other code indicates failure."
+    if [[ $status_code -ge 200 && $status_code -lt 400 ]]
+    then
+        exit 0
+    fi
+fi
+
+# return exit code 1 if not initialized or health endpoint check fails
+exit 1

--- a/bin/postgres-ha/pre-bootstrap.sh
+++ b/bin/postgres-ha/pre-bootstrap.sh
@@ -71,6 +71,12 @@ set_default_pgha_autoconfig_env()  {
         default_pgha_autoconfig_env_vars+=("PGHA_CRUNCHYADM")
     fi
 
+    if [[ ! -v PGHA_REPLICA_REINIT_ON_START_FAIL ]]
+    then
+        export PGHA_REPLICA_REINIT_ON_START_FAIL="true"
+        default_pgha_autoconfig_env_vars+=("PGHA_REPLICA_REINIT_ON_START_FAIL")
+    fi
+
     if [[ ! ${#default_pgha_autoconfig_env_vars[@]} -eq 0 ]]
     then
         pgha_autoconfig_env_vars=$(printf ', %s' "${default_pgha_autoconfig_env_vars[@]}")

--- a/centos7/Dockerfile.admin.centos7
+++ b/centos7/Dockerfile.admin.centos7
@@ -16,6 +16,7 @@ LABEL name="crunchydata/admin" \
 ENV PGROOT="/usr/pgsql-${PG_MAJOR}"
 ENV PATH="${PGROOT}/bin:${PATH}"
 
+ADD bin/crunchyadm /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 
 RUN chmod g=u /etc/passwd && \

--- a/conf/postgres-ha/postgres-ha-pgconf.yaml
+++ b/conf/postgres-ha/postgres-ha-pgconf.yaml
@@ -12,7 +12,9 @@ postgresql:
     - pgbackrest
     - basebackup
   pgbackrest:
-    command: 'pgbackrest --delta restore'
+    command: '/opt/cpm/bin/pgbackrest-create-replica.sh'
     keep_data: true
     no_params: true
   remove_data_directory_on_rewind_failure: true
+  callbacks:
+    on_role_change: /opt/cpm/bin/pgha-on-role-change.sh

--- a/examples/kube/postgres-ha/postgres-ha.json
+++ b/examples/kube/postgres-ha/postgres-ha.json
@@ -98,14 +98,20 @@
                         "readinessProbe": {
                             "exec": {
                                 "command": [
-                                    "/bin/bash",
-                                    "-c",
-                                    "[[ -f '/crunchyadm/pgha_initialized' ]]",
-                                    "&& pg_isready -h /crunchyadm -U crunchyready"
-                                 ]
+                                    "/opt/cpm/bin/pgha-readiness.sh"
+                                ]
+                            },
+                            "initialDelaySeconds": 30
+                        },
+                        "livenessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/opt/cpm/bin/pgha-liveness.sh"
+                                ]
                             },
                             "initialDelaySeconds": 30,
-                            "timeoutSeconds": 8
+                            "periodSeconds": 15,
+                            "timeoutSeconds": 10
                         },
                         "env": [
                             {
@@ -203,6 +209,10 @@
                             {
                                 "name": "PGHA_CRUNCHYADM",
                                 "value": "true"
+                            },
+                            {
+                                "name": "PGHA_REPLICA_REINIT_ON_START_FAIL",
+                                "value": "true"
                             }
                         ],
                         "volumeMounts": [
@@ -255,14 +265,11 @@
                         "readinessProbe": {
                             "exec": {
                                 "command": [
-                                    "/bin/bash",
-                                    "-c",
-                                    "[[ -f '/crunchyadm/pgha_initialized' ]]",
-                                    "&& pg_isready -h /crunchyadm -U crunchyready"
-                                 ]
+                                    "/opt/cpm/bin/crunchyadm-readiness.sh"
+                                ]
                             },
                             "initialDelaySeconds": 30,
-                            "timeoutSeconds": 8
+                            "timeoutSeconds": 10
                         },
                         "env": [
                             {
@@ -367,14 +374,20 @@
                         "readinessProbe": {
                             "exec": {
                                 "command": [
-                                    "/bin/bash",
-                                    "-c",
-                                    "[[ -f '/crunchyadm/pgha_initialized' ]]",
-                                    "&& pg_isready -h /crunchyadm -U crunchyready"
-                                 ]
+                                    "/opt/cpm/bin/pgha-readiness.sh"
+                                ]
+                            },
+                            "initialDelaySeconds": 30
+                        },
+                        "livenessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/opt/cpm/bin/pgha-liveness.sh"
+                                ]
                             },
                             "initialDelaySeconds": 30,
-                            "timeoutSeconds": 8
+                            "periodSeconds": 15,
+                            "timeoutSeconds": 10
                         },
                         "env": [
                             {
@@ -399,6 +412,10 @@
                             },
                             {
                                 "name": "PGHA_CRUNCHYADM",
+                                "value": "true"
+                            },
+                            {
+                                "name": "PGHA_REPLICA_REINIT_ON_START_FAIL",
                                 "value": "true"
                             }
                         ],
@@ -452,14 +469,11 @@
                         "readinessProbe": {
                             "exec": {
                                 "command": [
-                                    "/bin/bash",
-                                    "-c",
-                                    "[[ -f '/crunchyadm/pgha_initialized' ]]",
-                                    "&& pg_isready -h /crunchyadm -U crunchyready"
-                                 ]
+                                    "/opt/cpm/bin/crunchyadm-readiness.sh"
+                                ]
                             },
                             "initialDelaySeconds": 30,
-                            "timeoutSeconds": 8
+                            "timeoutSeconds": 10
                         },
                         "env": [
                             {

--- a/rhel7/Dockerfile.admin.rhel7
+++ b/rhel7/Dockerfile.admin.rhel7
@@ -16,6 +16,7 @@ LABEL name="crunchydata/admin" \
 ENV PGROOT="/usr/pgsql-${PG_MAJOR}"
 ENV PATH="${PGROOT}/bin:${PATH}"
 
+ADD bin/crunchyadm /opt/cpm/bin
 ADD bin/common /opt/cpm/bin
 
 RUN chmod g=u /etc/passwd && \


### PR DESCRIPTION
This PR adds monitoring for failed PG starts on replicas, specifically in the form of Kubernetes liveness checks that determine whether or not a replica is in a `start failed` state, and then reacts then the Patroni "reinitialize" REST  endpoint is called on the local Patroni node to reinitialize the replica (please note that the container is never restarted due to a failed liveness check).  This change therefore assists with auto-healing PG clusters, specifically taking action to attempt to bring a replica back online in the event that it is stuck in a `start failed` state.

Additionally, now when a replica is promoted to primary following a failover (or switchover), a Patroni `on_role_change` callback script is now called, which creates a new `pgBackRest` backup.  This enables the best practice of creating a fresh/new backup following a failover (or switchover), specifically by ensuring a backup is automatically taken following a failover event. The creation of the backup following a failover event (i.e. when a replica is promoted to primary) also has the added benefit of ensuring that any replicas are able to initialize or be re-initialized using a recent/up-to-date backup, preventing issues (e.g. incorrect timelines), in the event that WAL archives are missing when attempting to restore from an older backup to bring a replica online.

Also included are changes to the pgBackRest replica creation process.  Specifically, a script is now included to ensure the proper type of restore is performed.  For instance, if the PGDATA directory is empty, then a non-delta restore is used.  Further, if valid `PGDATA` directory is identified, the a delta restore is performed.  And lastly, if determined that the `PGDATA` directory is invalid (i.e. it is missing the `PGVERSION` file), then all files are first deleted followed by performing a non-delta restore.  These changes ensure `pgBackRest` can always be used to initialize/re-initialize a replica (e.g. even if the `PGDATA` directory is invalid), while also preventing certain pgBackRest warnings from appearing in container logs (e.g. warning when doing a delta restore into an empty directory).

Further, readiness probes have been updated for both the `crunchy-postgres-ha` and 'crunchyadm' containers. Specifically, the `crunchy-postgres-ha` readiness probe now checks the Patroni `health` endpoint to determine if the pod is healthy, and is therefore ready to accept traffic (while also still using the presence of the `pgha_initialized` file to first determine that the node was fully initialized).  The `crunchy-admin` readiness probe now attempts to connect to the database and run a query as the `crunchyadm` user, specifically connecting via a Unix socket to verify that peer authentication is working properly for the `crunchyadm` user.

And finally, logging has been updated to ensure various initialization and `start failed` detection activities are properly logged. Please also note that all changes discussed above are reflected and implemented within the `postgres-ha` example for Kube as contained within the Crunchy Container Suite.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

If a `crunchy-postgres-ha` (or GIS equivalent) container identified as a replica ends up in a state where it is unable to start (i.e. the `start failed` state), it will remain stuck in this state until action is manually take (e.g. manually re-initializing the Patroni node).

Additionally, a backup is not automatically taken following a failover event.

[ch6599]

**What is the new behavior (if this is a feature change)?**

A `start failed` state can now automatically be detected in a replica, followed by automatically reinitializing that replica.

Also, a backup is now automatically taken following a failure event to ensure the successful creation and/or re-initialization of replicas.

**Other information**:

N/A