### PR TITLE
Support for Synchronous Replication in the crunchy-postgres-ha Container

### DIFF
--- a/bin/postgres-ha/pre-bootstrap.sh
+++ b/bin/postgres-ha/pre-bootstrap.sh
@@ -71,10 +71,10 @@ set_default_pgha_autoconfig_env()  {
         default_pgha_autoconfig_env_vars+=("PGHA_CRUNCHYADM")
     fi
 
-    if [[ ! -v PGHA_REPLICA_REINIT_ON_START_FAIL ]]
+    if [[ ! -v PGHA_SYNC_REPLICATION ]]
     then
-        export PGHA_REPLICA_REINIT_ON_START_FAIL="true"
-        default_pgha_autoconfig_env_vars+=("PGHA_REPLICA_REINIT_ON_START_FAIL")
+        export PGHA_SYNC_REPLICATION="false"
+        default_pgha_autoconfig_env_vars+=("PGHA_SYNC_REPLICATION")
     fi
 
     if [[ ! ${#default_pgha_autoconfig_env_vars[@]} -eq 0 ]]
@@ -115,6 +115,12 @@ set_default_pgha_env()  {
     else
         echo_info "The use of the /pgwal directory for writing WAL is not enabled"
         echo_info "A default value will not be set for PGHA_WALDIR and any value provided for will be ignored"
+    fi
+
+    if [[ ! -v PGHA_REPLICA_REINIT_ON_START_FAIL ]]
+    then
+        export PGHA_REPLICA_REINIT_ON_START_FAIL="true"
+        pgha_env_vars+=("PGHA_REPLICA_REINIT_ON_START_FAIL")
     fi
 
     if [[ ! ${#default_pgha_env_vars[@]} -eq 0 ]]
@@ -309,6 +315,12 @@ build_bootstrap_config_file() {
         echo_info "PGDATA directory is empty on node identifed as Primary"
         echo_info "initdb configuration will be applied to intitilize a new database"
         /opt/cpm/bin/yq m -i -x "${bootstrap_file}" "/opt/cpm/conf/postgres-ha-initdb.yaml"
+    fi
+
+    if [[ "${PGHA_SYNC_REPLICATION}" == "true" ]]
+    then
+        echo_info "Applying synchronous replication settings to postgres-ha configuration"
+        /opt/cpm/bin/yq m -i -x "${bootstrap_file}" "/opt/cpm/conf/postgres-ha-sync.yaml"
     fi
 
     if [[ -f "/pgconf/postgres-ha.yaml" ]]

--- a/conf/postgres-ha/postgres-ha-sync.yaml
+++ b/conf/postgres-ha/postgres-ha-sync.yaml
@@ -1,0 +1,8 @@
+--- 
+bootstrap: 
+  dcs: 
+    postgresql: 
+      parameters: 
+        synchronous_commit: "on"
+        synchronous_standby_names: "*"
+    synchronous_mode: true


### PR DESCRIPTION
This commit adds support for enabling synchronous replication when bootstrapping a PG cluster using the `crunchy-postgres-ha` container.  Specifically, a new `PGHA_SYNC_REPLICATION` environment variable is now provided, which if set to `true` in the `crunchy-postgres-ha` environment will enable synchronous replication for the cluster by setting the following PG configuration settings in the Patroni configuration file:

- `synchronous_commit: "on"`
- `synchronous_standby_names: "*"`

Additionally, `synchronous_mode` is also set to `true` in the DCS when `PGHA_SYNC_REPLICATION` is `true`, which ensures that a replica will not be promoted unless Patroni is certain that it contains all transactions that may have returned a successful commit status to a client.  As the [Patroni docs state](https://patroni.readthedocs.io/en/latest/replication_modes.html), "this means that the system may be unavailable for writes even though some servers are available."

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

A PGHA configuration setting does not exist to enable synchronous replication in clusters created using the `crunchy-postgres-ha` container.

[ch6629]

**What is the new behavior (if this is a feature change)?**

A PGHA configuration setting now exists (specifically `PGHA_SYNC_REPLICATION`), which if set to `true` with automatically enable synchronous replication in clusters created using `crunchy-postgres-ha` container.

**Other information**:

N/A