### PR TITLE
Merge pgBackRest S3 Config & Wait for Cluster To Reach Consistent State

### DIFF
--- a/bin/postgres-ha/bootstrap-postgres-ha.sh
+++ b/bin/postgres-ha/bootstrap-postgres-ha.sh
@@ -162,7 +162,7 @@ then
     do
         "Database has not reached a consistent state, sleeping..."
         # sleep to give recovery a chance to complete
-        sleep 30
+        sleep 5
         # if no postgres process is running at this point then assume a failed start and attempt to
         # start again.  Otherwise check once again to see if recovery is complete
         if ! pgrep postgres

--- a/bin/postgres-ha/pre-bootstrap.sh
+++ b/bin/postgres-ha/pre-bootstrap.sh
@@ -300,11 +300,10 @@ build_bootstrap_config_file() {
     if [[ "${PGHA_PGBACKREST}" == "true" ]]
     then
         echo_info "Applying pgbackrest config to postgres-ha configuration"
+        /opt/cpm/bin/yq m -i -x "${bootstrap_file}" "/opt/cpm/conf/postgres-ha-pgbackrest.yaml"
         if [[ "${PGHA_PGBACKREST_LOCAL_S3_STORAGE}" == "true" ]]
         then
             /opt/cpm/bin/yq m -i -x "${bootstrap_file}" "/opt/cpm/conf/postgres-ha-pgbackrest-local-s3.yaml"
-        else
-            /opt/cpm/bin/yq m -i -x "${bootstrap_file}" "/opt/cpm/conf/postgres-ha-pgbackrest.yaml"
         fi
     else
         echo_info "pgBackRest config for postgres-ha configuration disabled"


### PR DESCRIPTION
This commit ensures the `pgBackRest` settings required to enable both local and AWS S3 storage are merged with the existing `pgBackRest` configuration settings during cluster initialization, instead of overwriting the existing `pgBackRest` configuration settings.

Additionally, when an existing database is started manually in order to then be converted to a Patroni cluster, the container will now wait indefinitely for the cluster to reach a consistent state and become ready.  Additionally, if the container detects that PostgreSQL is no longer running while waiting for the DB to reach a consistent state, the container will attempt to start the database again (e.g. in the event that recovery failed due to unavailable WAL on the first start attempt due to a connectivity issue).  This will ensure the DB will keep attempting to recover without the container crashing, providing the opportunity to auto-recover and/or intervene and address any issues that may exist.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

S3 configuration is applied instead of the base pgBackRest configuration.

The check used while waiting for the DB to reach a consistent state will timeout causing the container to exit.

**What is the new behavior (if this is a feature change)?**

S3 configuration is merged into the base pgBackRest configuration.

When an existing database is started manually in order to then be converted to a Patroni cluster, the container will now wait indefinitely for the cluster to reach a consistent state and become ready.

**Other information**:

N/A