### PR TITLE
Crunchy PG HA Initialization & Replica Creation Updates

### DIFF
--- a/bin/postgres-ha/pgbackrest-create-replica.sh
+++ b/bin/postgres-ha/pgbackrest-create-replica.sh
@@ -35,6 +35,14 @@ then
 elif [[ -z "$(ls -A ${PATRONI_POSTGRESQL_DATA_DIR})" ]]
 then
     echo_info "Empty PGDATA dir found for replica, a non-delta restore will be peformed"
+
+    # create the PGDATA directory if needed (e.g. in the event it was deleted)
+    # and set the proper permissions
+    if [[ ! -d "${PATRONI_POSTGRESQL_DATA_DIR}" ]]
+    then
+        mkdir -p "${PATRONI_POSTGRESQL_DATA_DIR}"
+        chmod 0700 "${PATRONI_POSTGRESQL_DATA_DIR}"
+    fi
 else
     echo_info "Invalid PGDATA directory found for replica, cleaning prior to restore"
     while [[ ! -z "$(ls -A ${PATRONI_POSTGRESQL_DATA_DIR})" ]]

--- a/bin/postgres-ha/pgbackrest_info.sh
+++ b/bin/postgres-ha/pgbackrest_info.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright 2016 - 2019 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /opt/cpm/bin/pgbackrest_env.sh > /tmp/pgbackrest_env.stdout 2> /tmp/pgbackrest_env.stderr
+
+echo $(echo -n "$conf|" | tr '/' '_'; pgbackrest --output=json info | tr -d '\n')

--- a/bin/postgres-ha/pre-bootstrap.sh
+++ b/bin/postgres-ha/pre-bootstrap.sh
@@ -309,7 +309,7 @@ build_bootstrap_config_file() {
         echo_info "pgBackRest config for postgres-ha configuration disabled"
     fi
 
-    if [[ "${PGHA_INIT}" == "true" && ! -f "${PATRONI_POSTGRESQL_DATA_DIR}/PG_VERSION" ]]
+    if [[ "${PGHA_INIT}" == "true" ]]
     then
         echo_info "PGDATA directory is empty on node identifed as Primary"
         echo_info "initdb configuration will be applied to intitilize a new database"


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

- If the `PGDATA` directory is empty when re-initializing a node as a replica (e.g. because it has been deleted) then an error is thrown when attempting to perform the `pgBackRest` restore required to create the replica
-  When an existing database is being started manually prior to initializing Patroni, a check does not occur to determine if the `postgresql.conf` file needs to be cleaned and reconfigured by Patroni
- The `pgbackrest_info.sh` script is missing from `/opt/cpm/bin`, leading to errors when it is called during initialization of `pgMonitor`

**What is the new behavior (if this is a feature change)?**

- If the `PGDATA` directory is empty when re-initializing a node as a replica (e.g. because it has been deleted) it will be created prior to performing the `pgBackRest` restore required to create the replica
-  When an existing database is being started manually prior to initializing Patroni, a check occurs to determine if the `postgresql.conf` file needs to be cleaned and reconfigured by Patroni.   If the Patroni bootstrap configuration file is configured to use a custom PG config file using the `custom_config` parameter, or if a `postgresql.base.conf` file is present in the `PGDATA` directory, then the script assume those files are the base `postgresql.conf` parameters for the database in accordance with the [Patroni documentation](https://patroni.readthedocs.io/en/latest/dynamic_configuration.html) for applying PG configuration to a cluster, and therefore cleans out the contents of the existing `postgresql.conf` file if it exists (otherwise an empty file will simply be created).  If a custom or base config file is not found, then the `postgresql.conf` will remain untouched, and will then become the base configuration is accordance with the Patroni documentation for applying PG configuration.
- The `pgbackrest_info.sh` script is missing from `/opt/cpm/bin`, leading to errors when it is called during initialization of `pgMonitor`


**Other information**:

N/A