### PR TITLE
Set Unix Socket Directory to '/tmp' for Manual Start of Existing PG Database

### DIFF
--- a/bin/postgres-ha/bootstrap-postgres-ha.sh
+++ b/bin/postgres-ha/bootstrap-postgres-ha.sh
@@ -172,7 +172,7 @@ then
     fi
 
     echo_info "Starting database manually prior to starting Patroni"
-    pg_ctl -D "${PATRONI_POSTGRESQL_DATA_DIR}" -o "${manual_start_pg_ctl_options}" start
+    pg_ctl -D "${PATRONI_POSTGRESQL_DATA_DIR}" -o "-c unix_socket_directories='/tmp'" -o "${manual_start_pg_ctl_options}" start
     echo_info "Database manually started"
 
     echo_info "Waiting to reach a consistent state"


### PR DESCRIPTION
 With this change, the unix socket directories will be explicitly set to '/tmp' when manually starting an existing database using `pg_ctl start`.  This is to avoid permissions issue in certain environments (e.g. GKE-OCP) when PG attempts to use the default `/var/run/postgresql` directory.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The unix socket directories are not explicitly set when starting an existing DB using `pg_ctl start`.  This can lead to permissions issues in certain environments when PG attempts to use the default `/var/run/postgresql` directory.

**What is the new behavior (if this is a feature change)?**

The unix socket directories are explicitly set when starting an existing DB using `pg_ctl start`. 

**Other information**:

N/A
