### PR TITLE
Enable SSL in PG Database & Enable Client Cert for Replication User 

### DIFF
--- a/bin/postgres-ha/bootstrap-postgres-ha.sh
+++ b/bin/postgres-ha/bootstrap-postgres-ha.sh
@@ -246,7 +246,8 @@ remove_patroni_pause_key
  # Ensure any existing SSL certificates in PGDATA have the proper permissions
 chmod -f 0600 "${PATRONI_POSTGRESQL_DATA_DIR}/server.key" "${PATRONI_POSTGRESQL_DATA_DIR}/server.crt" \
     "${PATRONI_POSTGRESQL_DATA_DIR}/ca.crt" "${PATRONI_POSTGRESQL_DATA_DIR}/ca.crl" \
-    "${PATRONI_POSTGRESQL_DATA_DIR}/replicator.crt" "${PATRONI_POSTGRESQL_DATA_DIR}/replicator.key"
+    "${PATRONI_POSTGRESQL_DATA_DIR}/replicator.crt" "${PATRONI_POSTGRESQL_DATA_DIR}/replicator.key" \
+    "${PATRONI_POSTGRESQL_DATA_DIR}/replicator.crl"
 
 # Bootstrap the cluster
 bootstrap_cmd="$@ /tmp/postgres-ha-bootstrap.yaml"

--- a/bin/postgres-ha/pre-bootstrap.sh
+++ b/bin/postgres-ha/pre-bootstrap.sh
@@ -226,15 +226,25 @@ set_pg_user_credentials() {
         
         # Configure certificate-based authentication for replication if proper certs are available.
         # Otherwise use a password
-        if [[ -f "/pgconf/replicator.key" ]] && [[ -f "/pgconf/replicator.crt" ]] && [[ -f "/pgconf/ca.crt" ]]
+        if [[ -f "/pgconf/replicator.key" ]] && [[ -f "/pgconf/replicator.crt" ]]
         then
             export PATRONI_REPLICATION_SSLKEY="${PATRONI_POSTGRESQL_DATA_DIR}/replicator.key"
-            export PATRONI_REPLICATION_SSLCERT="${PATRONI_POSTGRESQL_DATA_DIR}/replicator.crt"
-            export PATRONI_REPLICATION_SSLROOTCERT="${PATRONI_POSTGRESQL_DATA_DIR}/ca.crt"
+            export PATRONI_REPLICATION_SSLCERT="${PATRONI_POSTGRESQL_DATA_DIR}/replicator.crt"            
         else
             PATRONI_REPLICATION_PASSWORD=$(cat /pgconf/pgreplicator/password)
             err_check "$?" "Set replication user password" "Unable to set PATRONI_REPLICATION_PASSWORD using secret"
             export PATRONI_REPLICATION_PASSWORD
+        fi
+
+        # set the server CA for the replication user if present
+        if [[ -f "${PATRONI_POSTGRESQL_DATA_DIR}/ca.crt" ]]
+        then
+            export PATRONI_REPLICATION_SSLROOTCERT="${PATRONI_POSTGRESQL_DATA_DIR}/ca.crt"
+        fi
+        # set the CRL for the replication user if present
+        if [[ -f "${PATRONI_POSTGRESQL_DATA_DIR}/replicator.crl" ]]
+        then
+            export PATRONI_REPLICATION_SSLCRL="${PATRONI_POSTGRESQL_DATA_DIR}/replicator.crl"
         fi
         
         PATRONI_REPLICATION_USERNAME=$(cat /pgconf/pgreplicator/username)

--- a/bin/postgres-ha/ssl-config.sh
+++ b/bin/postgres-ha/ssl-config.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+source /opt/cpm/bin/common_lib.sh
+enable_debugging
+
+PGHA_SSL_CONFIG=""
+
+custom_config() {
+    src=${1?}
+    dest=${2?}
+    mode=${3?}
+    if [[ -f ${src?} ]]
+    then
+        echo_info "Custom ${src?} detected.  Applying custom configuration.."
+
+        cp ${src?} ${dest?}
+        err_check "$?" "Applying custom configuration" "Could not copy ${src?} to ${dest?}"
+
+        chmod ${mode?} ${dest?}
+        err_check "$?" "Applying custom configuration" "Could not set mode ${mode?} on ${dest?}"
+        
+        case "${src?}" in
+            "/pgconf/server.key")
+            PGHA_SSL_CONFIG+=",\"ssl_key_file\":\"server.key\""
+            ;;
+            "/pgconf/server.crt")
+            PGHA_SSL_CONFIG+=",\"ssl_cert_file\":\"server.crt\""
+            ;;
+            "/pgconf/ca.crt")
+            PGHA_SSL_CONFIG+=",\"ssl_ca_file\":\"ca.crt\""
+            ;;
+            "/pgconf/ca.crl")
+            PGHA_SSL_CONFIG+=",\"ssl_crl_file\":\"ca.crl\""
+            ;;
+        esac
+    fi
+}
+
+# Call the custom-config function in order to configure any certificates available in the
+# '/pgconf' directory as needed to enable SSL
+custom_config "/pgconf/server.key" "${PATRONI_POSTGRESQL_DATA_DIR}/server.key" 600
+custom_config "/pgconf/server.crt" "${PATRONI_POSTGRESQL_DATA_DIR}/server.crt" 600
+custom_config "/pgconf/ca.crt" "${PATRONI_POSTGRESQL_DATA_DIR}/ca.crt" 600
+custom_config "/pgconf/ca.crl" "${PATRONI_POSTGRESQL_DATA_DIR}/ca.crl" 600
+custom_config "/pgconf/replicator.crt" "${PATRONI_POSTGRESQL_DATA_DIR}/replicator.crt" 600
+custom_config "/pgconf/replicator.key" "${PATRONI_POSTGRESQL_DATA_DIR}/replicator.key" 600
+
+export PGHA_SSL_CONFIG

--- a/bin/postgres-ha/ssl-config.sh
+++ b/bin/postgres-ha/ssl-config.sh
@@ -44,5 +44,6 @@ custom_config "/pgconf/ca.crt" "${PATRONI_POSTGRESQL_DATA_DIR}/ca.crt" 600
 custom_config "/pgconf/ca.crl" "${PATRONI_POSTGRESQL_DATA_DIR}/ca.crl" 600
 custom_config "/pgconf/replicator.crt" "${PATRONI_POSTGRESQL_DATA_DIR}/replicator.crt" 600
 custom_config "/pgconf/replicator.key" "${PATRONI_POSTGRESQL_DATA_DIR}/replicator.key" 600
+custom_config "/pgconf/replicator.crl" "${PATRONI_POSTGRESQL_DATA_DIR}/replicator.crl" 600
 
 export PGHA_SSL_CONFIG


### PR DESCRIPTION
With this change, it is possible to apply the required SSL configuration to enable SSL in the PG database.  Specifically, by mounting the appropriate certificates in the `pgconf` directory, it is possible to  configure the `ssl_key_file`, `ssl_cert_file`,`ssl_ca_file` and `ssl_crl_file` `postgresql.conf` settings for the cluster via the DCS, effectively enabling the use of SSL and client certificates when authenticating into the database.

In support of configuring the DCS for SSL, the mechanism for detecting that the local node has been
initialized has been updated.  Now, in addition to verifying that the node is in a running state, a check is performed to first determine whether the local node has the primary or replica role, and then whether or not the primary or replica endpoint (depending on the role identified) is returning status code 200.  This ensures that all initial configuration has been applied to the node prior to updating the DCS with the SSL configuration using a JSON patch.

And finally, it is now possible to specify the certificates needed to allow the replication user to authenticate via client certificate in lieu of using a replication password.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

- It is not possible to easily enable SSL for a cluster using the `crunchy-postgres-ha` container
- A password is required for the replication user

[ch6755]

**What is the new behavior (if this is a feature change)?**

- It is now possible to easily enable SSL for a cluster using the `crunchy-postgres-ha` container
- A client certificate can be used instead of a password for the replication user 

**Other information**:

N/A