### PR TITLE
Move VOLUME Directives After all RUN Directives in all Dockerfiles (4.2 patch)

### DIFF
--- a/centos7/Dockerfile.backrest-restore.centos7
+++ b/centos7/Dockerfile.backrest-restore.centos7
@@ -34,9 +34,6 @@ RUN chown -R postgres:postgres /opt/cpm  \
 	/pgdata /backrestrepo \
 	/var/lib/pgsql /var/log/pgbackrest
 
-# volume backrestrepo for pgbackrest to restore from and log
-VOLUME /pgdata /backrestrepo
-
 ADD bin/backrest_restore /opt/cpm/bin
 
 #removed to allow separate version of common_lib.sh for this container only. Its in
@@ -44,6 +41,11 @@ ADD bin/backrest_restore /opt/cpm/bin
 #ADD bin/common /opt/cpm/bin
 
 ADD conf/backrest_restore /opt/cpm/conf
+
+# volume backrestrepo for pgbackrest to restore from and log
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
+VOLUME /pgdata /backrestrepo
 
 USER 26
 CMD ["/opt/cpm/bin/start.sh"]

--- a/centos7/Dockerfile.backup.centos7
+++ b/centos7/Dockerfile.backup.centos7
@@ -34,6 +34,8 @@ RUN chown -R postgres:postgres  /opt/cpm /pgdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/centos7/Dockerfile.collect.centos7
+++ b/centos7/Dockerfile.collect.centos7
@@ -31,6 +31,8 @@ EXPOSE 9187
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/conf"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_daemon.sh"]

--- a/centos7/Dockerfile.grafana.centos7
+++ b/centos7/Dockerfile.grafana.centos7
@@ -27,6 +27,8 @@ EXPOSE 3000
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/data", "/conf"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/centos7/Dockerfile.pgadmin4.centos7
+++ b/centos7/Dockerfile.pgadmin4.centos7
@@ -49,6 +49,8 @@ EXPOSE 5050
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/var/lib/pgadmin", "/certs", "/run/httpd"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/centos7/Dockerfile.pgbadger.centos7
+++ b/centos7/Dockerfile.pgbadger.centos7
@@ -47,6 +47,8 @@ EXPOSE 10000
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata", "/report"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/centos7/Dockerfile.pgbasebackup-restore.centos7
+++ b/centos7/Dockerfile.pgbasebackup-restore.centos7
@@ -30,6 +30,8 @@ ADD bin/common /opt/cpm/bin
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/backup","/pgdata"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]

--- a/centos7/Dockerfile.pgbench.centos7
+++ b/centos7/Dockerfile.pgbench.centos7
@@ -32,9 +32,11 @@ ADD conf/pgbench /opt/cpm/conf
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
-ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
-
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgconf"]
+
+ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 
 USER 26
 

--- a/centos7/Dockerfile.pgbouncer.centos7
+++ b/centos7/Dockerfile.pgbouncer.centos7
@@ -33,6 +33,8 @@ EXPOSE 6432
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgconf"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/centos7/Dockerfile.pgdump.centos7
+++ b/centos7/Dockerfile.pgdump.centos7
@@ -33,6 +33,8 @@ RUN chgrp -R 0 /opt/cpm /pgdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/centos7/Dockerfile.pgpool.centos7
+++ b/centos7/Dockerfile.pgpool.centos7
@@ -40,6 +40,8 @@ EXPOSE 5432
 RUN chmod g=u /etc/passwd
 
 # add volumes to allow override of pgpool config files
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgconf"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/centos7/Dockerfile.pgrestore.centos7
+++ b/centos7/Dockerfile.pgrestore.centos7
@@ -33,6 +33,8 @@ RUN chown -R postgres:postgres /opt/cpm /pgdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/centos7/Dockerfile.postgres-appdev.centos7
+++ b/centos7/Dockerfile.postgres-appdev.centos7
@@ -65,6 +65,8 @@ RUN chmod g=u /etc/passwd && \
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 
 # add volumes to allow override of pg_hba.conf and postgresql.conf
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgconf", "/pgdata"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]

--- a/centos7/Dockerfile.postgres-ha.centos7
+++ b/centos7/Dockerfile.postgres-ha.centos7
@@ -77,6 +77,8 @@ RUN chmod g=u /etc/passwd \
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata", "/pgwal", "/pgconf", "/backrestrepo", "/sshd"]
 
 ENTRYPOINT ["/opt/cpm/bin/bootstrap-postgres-ha.sh"]

--- a/centos7/Dockerfile.postgres.centos7
+++ b/centos7/Dockerfile.postgres.centos7
@@ -51,14 +51,6 @@ RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
 	chmod -R g=u /opt/cpm /var/lib/pgsql \
 		/pgdata /pgwal /pgconf /recover /backrestrepo
 
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
-
 # open up the postgres port
 EXPOSE 5432
 
@@ -71,6 +63,15 @@ RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+
+# add volumes to allow override of pg_hba.conf and postgresql.conf
+# add volumes to offer a restore feature
+# add volumes to allow storage of postgres WAL segment files
+# add volumes to locate WAL files to recover with
+# add volumes for pgbackrest to write to
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
+VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/Dockerfile.prometheus.centos7
+++ b/centos7/Dockerfile.prometheus.centos7
@@ -26,6 +26,8 @@ EXPOSE 9090
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/data", "/conf"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/centos7/Dockerfile.upgrade-10.centos7
+++ b/centos7/Dockerfile.upgrade-10.centos7
@@ -38,6 +38,8 @@ RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME /pgolddata /pgnewdata
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/centos7/Dockerfile.upgrade-11.centos7
+++ b/centos7/Dockerfile.upgrade-11.centos7
@@ -42,6 +42,8 @@ RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME /pgolddata /pgnewdata
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/centos7/Dockerfile.upgrade-12.centos7
+++ b/centos7/Dockerfile.upgrade-12.centos7
@@ -46,6 +46,8 @@ RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME /pgolddata /pgnewdata
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/centos7/Dockerfile.upgrade-9.6.centos7
+++ b/centos7/Dockerfile.upgrade-9.6.centos7
@@ -34,6 +34,8 @@ RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME /pgolddata /pgnewdata
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/rhel7/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/Dockerfile.backrest-restore.rhel7
@@ -36,12 +36,14 @@ RUN chown -R postgres:postgres /opt/cpm  \
 	/pgdata /backrestrepo \
 	/var/lib/pgsql /var/log/pgbackrest
 
-# volume backrestrepo for pgbackrest to restore from and log
-VOLUME /pgdata /backrestrepo
-
 ADD bin/backrest_restore /opt/cpm/bin
 
 ADD conf/backrest_restore /opt/cpm/conf
+
+# volume backrestrepo for pgbackrest to restore from and log
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
+VOLUME /pgdata /backrestrepo
 
 USER 26
 CMD ["/opt/cpm/bin/start.sh"]

--- a/rhel7/Dockerfile.backup.rhel7
+++ b/rhel7/Dockerfile.backup.rhel7
@@ -34,6 +34,8 @@ RUN chown -R postgres:postgres  /opt/cpm /pgdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/rhel7/Dockerfile.collect.rhel7
+++ b/rhel7/Dockerfile.collect.rhel7
@@ -31,6 +31,8 @@ EXPOSE 9187
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/conf"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_daemon.sh"]

--- a/rhel7/Dockerfile.grafana.rhel7
+++ b/rhel7/Dockerfile.grafana.rhel7
@@ -27,6 +27,8 @@ EXPOSE 3000
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/data", "/conf"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/rhel7/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/Dockerfile.pgadmin4.rhel7
@@ -50,6 +50,8 @@ EXPOSE 5050
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/var/lib/pgadmin", "/certs", "/run/httpd"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/rhel7/Dockerfile.pgbadger.rhel7
+++ b/rhel7/Dockerfile.pgbadger.rhel7
@@ -48,6 +48,8 @@ EXPOSE 10000
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata", "/report"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/rhel7/Dockerfile.pgbasebackup-restore.rhel7
+++ b/rhel7/Dockerfile.pgbasebackup-restore.rhel7
@@ -30,6 +30,8 @@ ADD bin/common /opt/cpm/bin
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/backup","/pgdata"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]

--- a/rhel7/Dockerfile.pgbench.rhel7
+++ b/rhel7/Dockerfile.pgbench.rhel7
@@ -32,9 +32,11 @@ ADD conf/pgbench /opt/cpm/conf
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
-ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
-
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgconf"]
+
+ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 
 USER 26
 

--- a/rhel7/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/Dockerfile.pgbouncer.rhel7
@@ -33,6 +33,8 @@ EXPOSE 6432
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgconf"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/rhel7/Dockerfile.pgdump.rhel7
+++ b/rhel7/Dockerfile.pgdump.rhel7
@@ -33,6 +33,8 @@ RUN chgrp -R 0 /opt/cpm /pgdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/rhel7/Dockerfile.pgpool.rhel7
+++ b/rhel7/Dockerfile.pgpool.rhel7
@@ -40,6 +40,8 @@ EXPOSE 5432
 RUN chmod g=u /etc/passwd
 
 # add volumes to allow override of pgpool config files
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgconf"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/rhel7/Dockerfile.pgrestore.rhel7
+++ b/rhel7/Dockerfile.pgrestore.rhel7
@@ -33,6 +33,8 @@ RUN chown -R postgres:postgres /opt/cpm /pgdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/rhel7/Dockerfile.postgres-ha.rhel7
+++ b/rhel7/Dockerfile.postgres-ha.rhel7
@@ -83,6 +83,8 @@ RUN chmod g=u /etc/passwd \
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata", "/pgwal", "/pgconf", "/backrestrepo", "/sshd"]
 
 ENTRYPOINT ["/opt/cpm/bin/bootstrap-postgres-ha.sh"]

--- a/rhel7/Dockerfile.postgres.rhel7
+++ b/rhel7/Dockerfile.postgres.rhel7
@@ -58,14 +58,6 @@ RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
 	chmod -R g=u /opt/cpm /var/lib/pgsql \
 		/pgdata /pgwal /pgconf /recover /backrestrepo
 
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
-
 # open up the postgres port
 EXPOSE 5432
 
@@ -78,6 +70,15 @@ RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+
+# add volumes to allow override of pg_hba.conf and postgresql.conf
+# add volumes to offer a restore feature
+# add volumes to allow storage of postgres WAL segment files
+# add volumes to locate WAL files to recover with
+# add volumes for pgbackrest to write to
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
+VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/Dockerfile.prometheus.rhel7
+++ b/rhel7/Dockerfile.prometheus.rhel7
@@ -26,6 +26,8 @@ EXPOSE 9090
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/data", "/conf"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/rhel7/Dockerfile.upgrade-10.rhel7
+++ b/rhel7/Dockerfile.upgrade-10.rhel7
@@ -42,6 +42,8 @@ RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME /pgolddata /pgnewdata
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/rhel7/Dockerfile.upgrade-11.rhel7
+++ b/rhel7/Dockerfile.upgrade-11.rhel7
@@ -47,6 +47,8 @@ RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME /pgolddata /pgnewdata
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/rhel7/Dockerfile.upgrade-12.rhel7
+++ b/rhel7/Dockerfile.upgrade-12.rhel7
@@ -52,6 +52,8 @@ RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME /pgolddata /pgnewdata
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/rhel7/Dockerfile.upgrade-9.6.rhel7
+++ b/rhel7/Dockerfile.upgrade-9.6.rhel7
@@ -37,6 +37,8 @@ RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME /pgolddata /pgnewdata
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/ubi7/Dockerfile.backrest-restore.ubi7
+++ b/ubi7/Dockerfile.backrest-restore.ubi7
@@ -38,12 +38,14 @@ RUN chown -R postgres:postgres /opt/cpm  \
 	/pgdata /backrestrepo \
 	/var/lib/pgsql /var/log/pgbackrest
 
-# volume backrestrepo for pgbackrest to restore from and log
-VOLUME /pgdata /backrestrepo
-
 ADD bin/backrest_restore /opt/cpm/bin
 
 ADD conf/backrest_restore /opt/cpm/conf
+
+# volume backrestrepo for pgbackrest to restore from and log
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
+VOLUME /pgdata /backrestrepo
 
 USER 26
 CMD ["/opt/cpm/bin/start.sh"]

--- a/ubi7/Dockerfile.backup.ubi7
+++ b/ubi7/Dockerfile.backup.ubi7
@@ -35,6 +35,8 @@ RUN chown -R postgres:postgres  /opt/cpm /pgdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/ubi7/Dockerfile.collect.ubi7
+++ b/ubi7/Dockerfile.collect.ubi7
@@ -31,6 +31,8 @@ EXPOSE 9187
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/conf"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_daemon.sh"]

--- a/ubi7/Dockerfile.grafana.ubi7
+++ b/ubi7/Dockerfile.grafana.ubi7
@@ -27,6 +27,8 @@ EXPOSE 3000
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/data", "/conf"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/ubi7/Dockerfile.pgadmin4.ubi7
+++ b/ubi7/Dockerfile.pgadmin4.ubi7
@@ -50,6 +50,8 @@ EXPOSE 5050
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/var/lib/pgadmin", "/certs", "/run/httpd"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/ubi7/Dockerfile.pgbadger.ubi7
+++ b/ubi7/Dockerfile.pgbadger.ubi7
@@ -48,6 +48,8 @@ EXPOSE 10000
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata", "/report"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/ubi7/Dockerfile.pgbasebackup-restore.ubi7
+++ b/ubi7/Dockerfile.pgbasebackup-restore.ubi7
@@ -31,6 +31,8 @@ ADD bin/common /opt/cpm/bin
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/backup","/pgdata"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]

--- a/ubi7/Dockerfile.pgbench.ubi7
+++ b/ubi7/Dockerfile.pgbench.ubi7
@@ -35,6 +35,8 @@ RUN chmod g=u /etc/passwd && \
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgconf"]
 
 USER 26

--- a/ubi7/Dockerfile.pgbouncer.ubi7
+++ b/ubi7/Dockerfile.pgbouncer.ubi7
@@ -34,6 +34,8 @@ EXPOSE 6432
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgconf"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/ubi7/Dockerfile.pgdump.ubi7
+++ b/ubi7/Dockerfile.pgdump.ubi7
@@ -34,6 +34,8 @@ RUN chgrp -R 0 /opt/cpm /pgdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/ubi7/Dockerfile.pgpool.ubi7
+++ b/ubi7/Dockerfile.pgpool.ubi7
@@ -41,6 +41,8 @@ EXPOSE 5432
 RUN chmod g=u /etc/passwd
 
 # add volumes to allow override of pgpool config files
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgconf"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/ubi7/Dockerfile.pgrestore.ubi7
+++ b/ubi7/Dockerfile.pgrestore.ubi7
@@ -34,6 +34,8 @@ RUN chown -R postgres:postgres /opt/cpm /pgdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/ubi7/Dockerfile.postgres-ha.ubi7
+++ b/ubi7/Dockerfile.postgres-ha.ubi7
@@ -82,6 +82,8 @@ RUN chmod g=u /etc/passwd \
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/pgdata", "/pgwal", "/pgconf", "/backrestrepo", "/sshd"]
 
 ENTRYPOINT ["/opt/cpm/bin/bootstrap-postgres-ha.sh"]

--- a/ubi7/Dockerfile.postgres.ubi7
+++ b/ubi7/Dockerfile.postgres.ubi7
@@ -56,14 +56,6 @@ RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
 	chmod -R g=u /opt/cpm /var/lib/pgsql \
 		/pgdata /pgwal /pgconf /recover /backrestrepo
 
-# add volumes to allow override of pg_hba.conf and postgresql.conf
-# add volumes to offer a restore feature
-# add volumes to allow storage of postgres WAL segment files
-# add volumes to locate WAL files to recover with
-# add volumes for pgbackrest to write to
-
-VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
-
 # open up the postgres port
 EXPOSE 5432
 
@@ -76,6 +68,15 @@ RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+
+# add volumes to allow override of pg_hba.conf and postgresql.conf
+# add volumes to offer a restore feature
+# add volumes to allow storage of postgres WAL segment files
+# add volumes to locate WAL files to recover with
+# add volumes for pgbackrest to write to
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
+VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/ubi7/Dockerfile.prometheus.ubi7
+++ b/ubi7/Dockerfile.prometheus.ubi7
@@ -26,6 +26,8 @@ EXPOSE 9090
 
 RUN chmod g=u /etc/passwd
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME ["/data", "/conf"]
 
 ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]

--- a/ubi7/Dockerfile.upgrade-11.ubi7
+++ b/ubi7/Dockerfile.upgrade-11.ubi7
@@ -48,6 +48,8 @@ RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME /pgolddata /pgnewdata
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]

--- a/ubi7/Dockerfile.upgrade-12.ubi7
+++ b/ubi7/Dockerfile.upgrade-12.ubi7
@@ -53,6 +53,8 @@ RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata \
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
 VOLUME /pgolddata /pgnewdata
 
 ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]


### PR DESCRIPTION
Updated all CentOS, RHEL and UBI Dockerfiles across the Crunchy Container Suite to ensure any/all `VOLUME` directives appear after any/all `RUN` directives.  This ensures that the proper permissions are applied to any volumes defined using the `VOLUME` directive when building using Buildah (`RUN` directives after the `VOLUME`directive can result in invalid volume permissions when building using Buildah).

Additionally, a comment has been added to the `VOLUME` directive across all Dockerfiles to indicate that the VOLUME directive should always appear after any/all RUN directives.  And finally, this change adds consistency to all Dockerfiles in the Crunchy Container Suite by including the `VOLUME` directive in the same location across all Dockerfiles, i.e. prior to the `ENTRYPOINT` directive (or prior to the USER directive if no `ENTRYPOINT` is included).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The VOLUME instruction does not appear after all RUN instructions across all Dockerfiles in the Crunchy Container Suite.

[ch6877]

**What is the new behavior (if this is a feature change)?**

The `VOLUME` instruction now always appears after all `RUN` instructions across all Dockerfiles in the Crunchy Container Suite.

**Other information**:

N/A
