### PR TITLE
Change targets to allow for building containers that don't require sp…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,13 @@ ifeq ("$(CCP_BASEOS)", "ubi7")
 	DFSET=rhel7
 endif
 
-.PHONY:	all extras pgimages
+.PHONY:	all pg-independent-images pgimages
 
 # Default target
-all: cc-pg-base-image pgimages extras
+all: cc-pg-base-image pgimages pg-independent-images
 
 # Build images that either don't have a PG dependency or using the latest PG version is all that is needed
-extras: backup pgadmin4 pgbadger pgbasebackuprestore pgbench pgbouncer pgdump pgpool grafana prometheus scheduler
+pg-independent-images: backup pgadmin4 pgbadger pgbasebackuprestore pgbench pgbouncer pgdump pgpool grafana prometheus scheduler
 
 # Build images that require a specific postgres version - ordered for potential concurrent benefits
 pgimages: postgres postgres-ha backrestrestore collect crunchyadm postgres-gis postgres-gis-ha pgrestore upgrade

--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,11 @@ endif
 # Default target
 all: cc-pg-base-image pgimages extras
 
-# Build non-postgres images
-extras: grafana prometheus scheduler
+# Build images that either don't have a PG dependency or using the latest PG version is all that is needed
+extras: backup pgadmin4 pgbadger pgbasebackuprestore pgbench pgbouncer pgdump pgpool grafana prometheus scheduler
 
-# Build images that use postgres - ordered for potential concurrent benefits
-pgimages: postgres postgres-ha backup backrestrestore collect crunchyadm pgadmin4 pgbadger pgbasebackuprestore postgres-gis postgres-gis-ha pgbench pgbouncer pgdump pgpool pgrestore upgrade
+# Build images that require a specific postgres version - ordered for potential concurrent benefits
+pgimages: postgres postgres-ha backrestrestore collect crunchyadm postgres-gis postgres-gis-ha pgrestore upgrade
 
 
 #===========================================


### PR DESCRIPTION
…ecific PG versions

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
This change will not affect the general build "all" target at all.  I am just rearranging what containers are in which target.  This allows me to build anything that is not specific to a PostgreSQL version in a separate build while the all target remains unaffected.


**What is the new behavior (if this is a feature change)?**
Just changes the targets in extras and pgimages to break them out so "pgimages" is only containers that must be compiled for every specific PG version while the "extras" target are the list of containers that only need to be built using the latest PG version and will work with all versions.


**Other information**:
