### PR TITLE
[ch6495] Add support for PostgreSQL tablespaces in the HA containers

### DIFF
--- a/bin/postgres-ha/post-bootstrap.sh
+++ b/bin/postgres-ha/post-bootstrap.sh
@@ -38,6 +38,22 @@ sed -i "s/PGHA_DATABASE/$PGHA_DATABASE/g" "/tmp/setup.sql"
 echo_info "Running setup.sql file"
 psql < "/tmp/setup.sql"
 
+# If there are any tablespaces, create them as a convenience to the user
+IFS=',' read -r -a TABLESPACES <<< "${PGHA_TABLESPACES}"
+# Iterate through the list and both create the tablespace in the PostgreSQL
+# instance, and ensure the PGHA_USER is able to utilize them
+for TABLESPACE in "${TABLESPACES[@]}"
+do
+  TABLESPACE_PATH="/tablespaces/${TABLESPACE}/${TABLESPACE}"
+  echo_info "Adding \"${TABLESPACE}\" at location \"${TABLESPACE_PATH}\" to PostgreSQL"
+
+  TABLESESPACE_SQL="CREATE TABLESPACE \"${TABLESPACE}\" LOCATION '${TABLESPACE_PATH}';"
+  psql -c "${TABLESESPACE_SQL}"
+
+  TABLESPACE_GRANT_SQL="GRANT CREATE ON TABLESPACE \"${TABLESPACE}\" TO \"${PGHA_USER}\";"
+  psql -c "${TABLESPACE_GRANT_SQL}"
+done
+
 # Run audit.sql file if exists
 if [[ -f "/pgconf/audit.sql" ]]
 then

--- a/centos7/Dockerfile.postgres-ha.centos7
+++ b/centos7/Dockerfile.postgres-ha.centos7
@@ -56,12 +56,17 @@ RUN useradd crunchyadm -g 0 -u 17
 
 ENV PATH="${PGROOT}/bin:${PATH}"
 
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backrestrepo /crunchyadm
+RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backrestrepo \
+	/crunchyadm /tablespaces
 
+# Adjust ownership for the folders to be the "postgres" user and allow the group
+# permissions to match the user ones EXCEPT for the /tablespaces folder, which
+# will only have permissions on the user
 RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
-	/pgdata /pgwal /pgconf /backrestrepo /crunchyadm &&  \
+	/pgdata /pgwal /pgconf /backrestrepo /crunchyadm /tablespaces &&  \
 	chmod -R g=u /opt/cpm /var/lib/pgsql \
-	/pgdata /pgwal /pgconf /backrestrepo /crunchyadm
+	/pgdata /pgwal /pgconf /backrestrepo /crunchyadm && \
+	chmod -R u=rwx,go= /tablespaces
 
 # open up the postgres port
 EXPOSE 5432

--- a/rhel7/Dockerfile.postgres-ha.rhel7
+++ b/rhel7/Dockerfile.postgres-ha.rhel7
@@ -62,12 +62,17 @@ RUN useradd crunchyadm -g 0 -u 17
 
 ENV PATH="${PGROOT}/bin:${PATH}"
 
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backrestrepo /crunchyadm
+RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backrestrepo \
+		/crunchyadm /tablespaces
 
+# Adjust ownership for the folders to be the "postgres" user and allow the group
+# permissions to match the user ones EXCEPT for the /tablespaces folder, which
+# will only have permissions on the user
 RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
-	/pgdata /pgwal /pgconf /backrestrepo /crunchyadm &&  \
+	/pgdata /pgwal /pgconf /backrestrepo /crunchyadm /tablespaces &&  \
 	chmod -R g=u /opt/cpm /var/lib/pgsql \
-	/pgdata /pgwal /pgconf /backrestrepo /crunchyadm
+	/pgdata /pgwal /pgconf /backrestrepo /crunchyadm && \
+	chmod -R u=rwx,go= /tablespaces
 
 # open up the postgres port
 EXPOSE 5432


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the new behavior (if this is a feature change)?**

Tablespaces can be used to spread out PostgreSQL workloads across
multiple volumes, which can be used for a variety of use cases:

- Partitioning larger data sets
- Putting data onto archival systems
- Utilizing hardware (or a storage class) for a particular database
object, e.g. an index

and more.

When the appropriate environmental variables that govern the tablespaces
are passed into the crunchy-postgres-ha and crunchy-postgres-gis HA
containers, the directories where the tablespaces reside are initialized
so PostgreSQL can appropriately access them. Additionally, when a
PostgreSQL cluster is initialized, the tablespace object is
automatically created (via CREATE TABLESPACE) and the initial user is
granted access to it.

Issue: [ch6495]