### PR TITLE
Updates for pgBouncer Support in PostgreSQL HA Container

### DIFF
--- a/bin/postgres-ha/sql/pgbouncer/pgbouncer-install.sql
+++ b/bin/postgres-ha/sql/pgbouncer/pgbouncer-install.sql
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2016 - 2020 Crunchy Data Solutions, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * pgbouncer-install.sql creates the general infrastructure for using pgBouncer
+ * with the PostgreSQL Operator
+ * This is intended to be executed in the "template1" file as well as any
+ * database that exists at the time this script is being executed.
+ */
+
+/**
+ * First, check that there is a "pgbouncer" administrative user
+ */
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pgbouncer') THEN
+        /**
+         * NOTE: we disallow login here as we are only enabling the ability
+         * for the PostgreSQL Operator to use pgBouncer. We require that the
+         * user/Operator explicitly turns on
+         */
+        CREATE ROLE pgbouncer NOLOGIN;
+    END IF;
+END
+$$;
+
+
+/**
+ * We also want to explicitly ensure that the pgbouncer user can only
+ * access its one function, to be defined further down. This means
+ * explicitly revoking all privileges from the public schema
+ *
+ * It's fine to execute this every time we init. If for some reason, the user
+ * wants to have the pgbouncer user access the public schema...well, open up
+ * an issue on GitHub and we can chat.
+ */
+REVOKE ALL PRIVILEGES ON SCHEMA public FROM pgbouncer;
+
+/**
+ * All of the administrative functions for pgbouncer will live in its own
+ * schema, conveniently titled "pgbouncer"
+ */
+CREATE SCHEMA IF NOT EXISTS pgbouncer;
+/**
+ * ...but even though pgbouncer gets its own schema, lock down what it can do
+ * on it
+ */
+REVOKE ALL PRIVILEGES ON SCHEMA pgbouncer FROM pgbouncer;
+GRANT USAGE ON SCHEMA pgbouncer TO pgbouncer;
+
+/**
+ * The "get_auth" function allows us to return the appropriate login credentials
+ * for a user that is using a password based authentication method so it can work
+ * with pgbouncer's "auth_query" parameter.
+ *
+ * See: http://www.pgbouncer.org/config.html#auth_query
+ */
+CREATE OR REPLACE FUNCTION pgbouncer.get_auth(username TEXT)
+RETURNS TABLE(username TEXT, password TEXT) AS
+$$
+  SELECT rolname::TEXT, rolpassword::TEXT
+  FROM pg_authid
+  WHERE
+    NOT pg_authid.rolsuper AND
+    NOT pg_authid.rolreplication AND
+    pg_authid.rolcanlogin AND
+    pg_authid.rolname <> 'pgbouncer' AND (
+      pg_authid.rolvaliduntil IS NULL OR
+      pg_authid.rolvaliduntil >= CURRENT_TIMESTAMP
+    ) AND
+    pg_authid.rolname = $1;
+$$
+LANGUAGE SQL STABLE SECURITY DEFINER;
+
+/**
+ * As mentioned, the pgbouncer user will only be able to access its one function
+ * and all it can do is execute. Here is where it does exactly that
+ */
+REVOKE ALL ON FUNCTION pgbouncer.get_auth(username TEXT) FROM PUBLIC, pgbouncer;
+GRANT EXECUTE ON FUNCTION pgbouncer.get_auth(username TEXT) TO pgbouncer;

--- a/bin/postgres-ha/sql/pgbouncer/pgbouncer-uninstall.sql
+++ b/bin/postgres-ha/sql/pgbouncer/pgbouncer-uninstall.sql
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2016 - 2020 Crunchy Data Solutions, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * pgbouncer-uninstall.sql removes the general infrastructure for using pgBouncer
+ * with the PostgreSQL Operator
+ *
+ * This has to be executed in every database that had pgbouncer made available
+ * to as well as template1
+ */
+
+/**
+ * Remove the SECURITY DEFINER function that returns non-privileged and
+ * non-system user credentials
+ */
+DROP FUNCTION IF EXISTS pgbouncer.get_auth(username TEXT);
+
+/**
+ * Drop the "pgbouncer" schema, and if anything exists in it, ensure it is
+ * wiped out. Woe to those who used a system schema to store their own things...
+ */
+DROP SCHEMA IF EXISTS pgbouncer CASCADE;
+
+/**
+ * Drop anything owned by the pgbouncer user. It should be nothing at this
+ * point, but better safe than sorry...
+ */
+DROP OWNED BY pgbouncer CASCADE;
+
+/**
+ * So, we can't drop the pgbouncer role as this file runs on an individual
+ * database. We need **all** objects associated "pgbouncer" dropped before we
+ * can execute `DROP ROLE pgbouncer;`
+ */


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)

**What is the new behavior (if this is a feature change)?**

The PostgreSQL Operator would provide some embedded SQL to help with
this process, but arguably was doing too much work. The requirements
it has for using pgBouncer are fairly straightforward:

- Have a pgBouncer user
- Have a pgBouncer schema created in all accessible databases
- Have a "get_auth" function that follows the ["auth_query" pattern
defined in the pgBouncer docs](http://www.pgbouncer.org/config.html#auth_query)
- Lock everything down as much as possible regarding what the pgboucner
user can do

This commit creates the pgbouncer user every time the PostgreSQL HA
container is initialized, but it explicitly creates it with NOLOGIN and
does not set a password. Even though the machinery is in place, the
user must explicitly opt-in to having pgBouncer support.

Additionally, the machinery is placed into PostgreSQL's "template1"
template, so that it is created every time a new PostgreSQL database is
added.