### PR TITLE
Updates containers to use ed25519 ssh keys

### DIFF
--- a/bin/postgres-ha/sshd.sh
+++ b/bin/postgres-ha/sshd.sh
@@ -18,8 +18,8 @@ then
     echo_info "Applying SSHD.."
     echo_info 'Checking for SSH Host Keys in /sshd..'
 
-    if [[ ! -f /sshd/ssh_host_rsa_key ]]; then
-        echo_err 'No ssh_host_rsa_key found in /sshd.  Exiting..'
+    if [[ ! -f /sshd/ssh_host_ed25519_key ]]; then
+        echo_err 'No ssh_host_ed25519_key found in /sshd.  Exiting..'
         exit 1
     fi
 
@@ -44,8 +44,8 @@ then
         mkdir ~/.ssh
     fi
     cp /sshd/config ~/.ssh/
-    cp /sshd/id_rsa /tmp
-    chmod 400 /tmp/id_rsa ~/.ssh/config
+    cp /sshd/id_ed25519 /tmp
+    chmod 400 /tmp/id_ed25519 ~/.ssh/config
 
     echo_info 'Starting SSHD..'
     /usr/sbin/sshd -f /sshd/sshd_config

--- a/bin/postgres/sshd.sh
+++ b/bin/postgres/sshd.sh
@@ -18,8 +18,8 @@ then
     echo_info "Applying SSHD.."
     echo_info 'Checking for SSH Host Keys in /sshd..'
 
-    if [[ ! -f /sshd/ssh_host_rsa_key ]]; then
-        echo_err 'No ssh_host_rsa_key found in /sshd.  Exiting..'
+    if [[ ! -f /sshd/ssh_host_ed25519_key ]]; then
+        echo_err 'No ssh_host_ed25519_key found in /sshd.  Exiting..'
         exit 1
     fi
 
@@ -40,8 +40,8 @@ then
     echo_info "setting up .ssh directory"
     mkdir ~/.ssh
     cp /sshd/config ~/.ssh/
-    cp /sshd/id_rsa /tmp
-    chmod 400 /tmp/id_rsa ~/.ssh/config
+    cp /sshd/id_ed25519 /tmp
+    chmod 400 /tmp/id_ed25519 ~/.ssh/config
 
     echo_info 'Starting SSHD..'
     /usr/sbin/sshd -f /sshd/sshd_config


### PR DESCRIPTION
In addition to the changes made in postgres operator to used ed25519 ssh keys
the postgres container images are updated to use the new ssh keys

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
Related postgres-operator pr [#1264](https://github.com/CrunchyData/postgres-operator/pull/1264)