### PR TITLE
Change targets to allow for building containers that don't require sp…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ endif
 .PHONY:	all versiontest
 
 # Default target
-all: pgimages extras
+all: pgimages pg-independent-images
 
 # Build images that use postgres
-pgimages: commands backup backrestrestore pgbasebackuprestore collect pgadmin4 pgbadger pgbench pgbouncer pgdump pgpool pgrestore postgres postgres-gis upgrade
+pgimages: commands backrestrestore collect pgrestore postgres postgres-gis upgrade
 
-# Build non-postgres images
-extras: grafana prometheus scheduler
+# Build images that either don't have a PG dependency or using the latest PG version is all that is needed
+pg-independent-images: backup pgadmin4 pgbadger pgbasebackuprestore pgbench pgbouncer pgdump pgpool grafana prometheus scheduler
 
 versiontest:
 ifndef CCP_BASEOS


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Behavior will not change by default


**What is the new behavior (if this is a feature change)?**
This just changes which containers are built by each target to allow for breaking the build out into a set of containers that are not dependent upon PostgreSQL and one that is.


**Other information**:
