### PR TITLE
PostgreSQL February 2020 Release Preparation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ endif
 # Default values if not already set
 CCP_BASEOS ?= centos7
 CCP_PG_VERSION ?= 12
-CCP_PG_FULLVERSION ?= 12.1
+CCP_PG_FULLVERSION ?= 12.2
 CCP_PATRONI_VERSION ?= 1.6.4
 CCP_BACKREST_VERSION ?= 2.20
 CCP_VERSION ?= 4.3.0

--- a/hugo/content/container-specifications/crunchy-backrest-restore.md
+++ b/hugo/content/container-specifications/crunchy-backrest-restore.md
@@ -18,7 +18,7 @@ The following features are supported and required by the crunchy-backrest-restor
 
 The crunchy-backrest-restore Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgBackRest](https://pgbackrest.org/) (2.20)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-backup.md
+++ b/hugo/content/container-specifications/crunchy-backup.md
@@ -19,7 +19,7 @@ The following features are supported by the `crunchy-backup` container:
 
 The crunchy-backup Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-collect.md
+++ b/hugo/content/container-specifications/crunchy-collect.md
@@ -23,7 +23,7 @@ can be specified for the API to collect. For an example of a queries.yml file, s
 
 The crunchy-collect Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 * [PostgreSQL Exporter](https://github.com/wrouesnel/postgres_exporter)

--- a/hugo/content/container-specifications/crunchy-pgadmin4.md
+++ b/hugo/content/container-specifications/crunchy-pgadmin4.md
@@ -28,7 +28,7 @@ The following features are supported by the crunchy-pgadmin4 container:
 
 The crunchy-pgadmin4 Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgAdmin4](https://www.pgadmin.org/)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-pgbench.md
+++ b/hugo/content/container-specifications/crunchy-pgbench.md
@@ -19,7 +19,7 @@ The following features are supported by the `crunchy-pgbench` container:
 
 The crunchy-pgbench Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* pgBench (12.1, 11.6, 10.11, 9.6.16, 9.5.20)
+* pgBench (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-pgbouncer.md
+++ b/hugo/content/container-specifications/crunchy-pgbouncer.md
@@ -21,7 +21,7 @@ The following features are supported by the crunchy-pgbouncer container:
 
 The crunchy-pgbouncer Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgBouncer](https://pgbouncer.github.io/)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-pgdump.md
+++ b/hugo/content/container-specifications/crunchy-pgdump.md
@@ -12,7 +12,7 @@ PostgreSQL database.
 
 The crunchy-pgdump Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-pgpool.md
+++ b/hugo/content/container-specifications/crunchy-pgpool.md
@@ -27,7 +27,7 @@ The following features are supported by the `crunchy-postgres` container:
 
 The crunchy-pgpool Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgPool II](http://www.pgpool.net/mediawiki/index.php/Main_Page)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-pgrestore.md
+++ b/hugo/content/container-specifications/crunchy-pgrestore.md
@@ -13,7 +13,7 @@ to a PostgreSQL container database.
 
 The crunchy-pgrestore Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-postgres-gis.md
+++ b/hugo/content/container-specifications/crunchy-postgres-gis.md
@@ -22,7 +22,7 @@ The following features are supported by the `crunchy-postgres-gis` container:
 
 The crunchy-postgres-gis Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgBackRest](https://pgbackrest.org/) (2.20)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-postgres.md
+++ b/hugo/content/container-specifications/crunchy-postgres.md
@@ -20,7 +20,7 @@ The following features are supported by the `crunchy-postgres` container:
 
 The crunchy-postgres Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgBackRest](https://pgbackrest.org/) (2.20)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-upgrade.md
+++ b/hugo/content/container-specifications/crunchy-upgrade.md
@@ -35,7 +35,7 @@ The following features are supported by the crunchy-upgrade container:
 
 The crunchy-upgrade Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/examples/administration/upgrade.md
+++ b/hugo/content/examples/administration/upgrade.md
@@ -9,7 +9,7 @@ weight: 81
 
 {{% notice tip %}}
 This example assumes you have run *primary* using a PostgreSQL 11 or 12 image
-such as `centos7-12.1-4.3.0` prior to running this upgrade.
+such as `centos7-12.2-4.3.0` prior to running this upgrade.
 {{% /notice %}}
 
 The upgrade container will let you perform a `pg_upgrade` from a PostgreSQL version 9.5, 9.6, 10, 11 or 12 database to the available any of the higher versions of PostgreSQL versions that are currently support which are 9.6, 10, 11, and 12. It does not do multi-version upgrades so you will need to for example do a 10 to 11 and then a 11 to 12 to get to version 12.
@@ -17,7 +17,7 @@ The upgrade container will let you perform a `pg_upgrade` from a PostgreSQL vers
 Prior to running this example, make sure your `CCP_IMAGE_TAG`
 environment variable is using the next major version of PostgreSQL that you
 want to upgrade to. For example, if you're upgrading from 11 to 12, make
-sure the variable references a PostgreSQL 12 image such as `centos7-12.1-4.3.0`.
+sure the variable references a PostgreSQL 12 image such as `centos7-12.2-4.3.0`.
 
 This will create the following in your Kubernetes environment:
 


### PR DESCRIPTION
Updated for PostgreSQL 12.2, 11.7, 10.12, 9.6.17, 9.5.21