### PR TITLE
 PostgreSQL February 2020 Release Preparation (4.1)

### DIFF
--- a/centos7/10/Dockerfile.backrest-restore.centos7
+++ b/centos7/10/Dockerfile.backrest-restore.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg*" PGDG_REPO_ENABLE="pgdg10"\
-    BACKREST_VERSION="2.18"
+    BACKREST_VERSION="2.20"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.backrest-restore.centos7
+++ b/centos7/10/Dockerfile.backrest-restore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.backup.centos7
+++ b/centos7/10/Dockerfile.backup.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/backup" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.collect.centos7
+++ b/centos7/10/Dockerfile.collect.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/collect" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.pgadmin4.centos7
+++ b/centos7/10/Dockerfile.pgadmin4.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.pgbadger.centos7
+++ b/centos7/10/Dockerfile.pgbadger.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.pgbench.centos7
+++ b/centos7/10/Dockerfile.pgbench.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.pgbouncer.centos7
+++ b/centos7/10/Dockerfile.pgbouncer.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.pgdump.centos7
+++ b/centos7/10/Dockerfile.pgdump.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.pgpool.centos7
+++ b/centos7/10/Dockerfile.pgpool.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.pgrestore.centos7
+++ b/centos7/10/Dockerfile.pgrestore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.postgres-gis.centos7
+++ b/centos7/10/Dockerfile.postgres-gis.centos7
@@ -3,7 +3,7 @@ FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/10/Dockerfile.postgres.centos7
+++ b/centos7/10/Dockerfile.postgres.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="10" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg*" PGDG_REPO_ENABLE="pgdg10" \
-    BACKREST_VERSION="2.18"
+    BACKREST_VERSION="2.20"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/10/Dockerfile.postgres.centos7
+++ b/centos7/10/Dockerfile.postgres.centos7
@@ -3,11 +3,11 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 10.11 (PGDG) on a Centos7 base image" \
+	summary="PostgreSQL 10.12 (PGDG) on a Centos7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         io.k8s.description="postgres container" \
         io.k8s.display-name="Crunchy postgres container" \

--- a/centos7/10/Dockerfile.upgrade.centos7
+++ b/centos7/10/Dockerfile.upgrade.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/upgrade" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.backrest-restore.centos7
+++ b/centos7/11/Dockerfile.backrest-restore.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg*" PGDG_REPO_ENABLE="pgdg11"\
-    BACKREST_VERSION="2.18"
+    BACKREST_VERSION="2.20"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.backrest-restore.centos7
+++ b/centos7/11/Dockerfile.backrest-restore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.backup.centos7
+++ b/centos7/11/Dockerfile.backup.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/backup" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.collect.centos7
+++ b/centos7/11/Dockerfile.collect.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/collect" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.pgadmin4.centos7
+++ b/centos7/11/Dockerfile.pgadmin4.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.pgbadger.centos7
+++ b/centos7/11/Dockerfile.pgbadger.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.pgbench.centos7
+++ b/centos7/11/Dockerfile.pgbench.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.pgbouncer.centos7
+++ b/centos7/11/Dockerfile.pgbouncer.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.pgdump.centos7
+++ b/centos7/11/Dockerfile.pgdump.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.pgpool.centos7
+++ b/centos7/11/Dockerfile.pgpool.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.pgrestore.centos7
+++ b/centos7/11/Dockerfile.pgrestore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.postgres-appdev.centos7
+++ b/centos7/11/Dockerfile.postgres-appdev.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/postgres-appdev" \
         vendor="crunchydata" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.postgres-gis.centos7
+++ b/centos7/11/Dockerfile.postgres-gis.centos7
@@ -3,7 +3,7 @@ FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/11/Dockerfile.postgres.centos7
+++ b/centos7/11/Dockerfile.postgres.centos7
@@ -3,11 +3,11 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 11.6 (PGDG) on a Centos7 base image" \
+	summary="PostgreSQL 11.7 (PGDG) on a Centos7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         io.k8s.description="postgres container" \
         io.k8s.display-name="Crunchy postgres container" \

--- a/centos7/11/Dockerfile.postgres.centos7
+++ b/centos7/11/Dockerfile.postgres.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg*" PGDG_REPO_ENABLE="pgdg11" \
-    BACKREST_VERSION="2.18"
+    BACKREST_VERSION="2.20"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/11/Dockerfile.upgrade.centos7
+++ b/centos7/11/Dockerfile.upgrade.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/upgrade" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.backrest-restore.centos7
+++ b/centos7/12/Dockerfile.backrest-restore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.backrest-restore.centos7
+++ b/centos7/12/Dockerfile.backrest-restore.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="12" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg*" PGDG_REPO_ENABLE="pgdg12"\
-    BACKREST_VERSION="2.18"
+    BACKREST_VERSION="2.20"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/12/Dockerfile.backup.centos7
+++ b/centos7/12/Dockerfile.backup.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/backup" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.collect.centos7
+++ b/centos7/12/Dockerfile.collect.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/collect" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.pgadmin4.centos7
+++ b/centos7/12/Dockerfile.pgadmin4.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgadmin4" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.pgbadger.centos7
+++ b/centos7/12/Dockerfile.pgbadger.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbadger" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.pgbench.centos7
+++ b/centos7/12/Dockerfile.pgbench.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbench" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.pgbouncer.centos7
+++ b/centos7/12/Dockerfile.pgbouncer.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbouncer" \
 		vendor="Crunchy Data" \
 		PostgresVersion="12" \
-		PostgresFullVersion="12.1" \
+		PostgresFullVersion="12.2" \
 		Version="7.7" \
 		Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.pgdump.centos7
+++ b/centos7/12/Dockerfile.pgdump.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgdump" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.pgpool.centos7
+++ b/centos7/12/Dockerfile.pgpool.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgpool" \
 		vendor="Crunchy Data" \
 		PostgresVersion="12" \
-		PostgresFullVersion="12.1" \
+		PostgresFullVersion="12.2" \
 		Version="7.7" \
 		Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.pgrestore.centos7
+++ b/centos7/12/Dockerfile.pgrestore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/restore" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.postgres-gis.centos7
+++ b/centos7/12/Dockerfile.postgres-gis.centos7
@@ -3,7 +3,7 @@ FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 LABEL name="crunchydata/postgres-gis" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/12/Dockerfile.postgres.centos7
+++ b/centos7/12/Dockerfile.postgres.centos7
@@ -3,11 +3,11 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \
-        summary="PostgreSQL 12.1 (PGDG) on a Centos7 base image" \
+        summary="PostgreSQL 12.2 (PGDG) on a Centos7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         io.k8s.description="postgres container" \
         io.k8s.display-name="Crunchy postgres container" \

--- a/centos7/12/Dockerfile.postgres.centos7
+++ b/centos7/12/Dockerfile.postgres.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="12" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg*" PGDG_REPO_ENABLE="pgdg12" \
-    BACKREST_VERSION="2.18"
+    BACKREST_VERSION="2.20"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/12/Dockerfile.upgrade.centos7
+++ b/centos7/12/Dockerfile.upgrade.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/upgrade" \
         vendor="Crunchy Data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.5/Dockerfile.backrest-restore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.5/Dockerfile.backrest-restore.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg*" PGDG_REPO_ENABLE="pgdg95" \
-    BACKREST_VERSION="2.18"
+    BACKREST_VERSION="2.20"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.backup.centos7
+++ b/centos7/9.5/Dockerfile.backup.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/backup" \
     vendor="crunchy data" \
     PostgresVersion="9.5" \
-    PostgresFullVersion="9.5.20" \
+    PostgresFullVersion="9.5.21" \
     Version="7.7" \
     Release="4.1.2" \
     url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.collect.centos7
+++ b/centos7/9.5/Dockerfile.collect.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/collect" \
 	vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
   url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.5/Dockerfile.pgadmin4.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.pgbadger.centos7
+++ b/centos7/9.5/Dockerfile.pgbadger.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbadger" \
 	vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.pgbench.centos7
+++ b/centos7/9.5/Dockerfile.pgbench.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.pgbouncer.centos7
+++ b/centos7/9.5/Dockerfile.pgbouncer.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.pgdump.centos7
+++ b/centos7/9.5/Dockerfile.pgdump.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.pgpool.centos7
+++ b/centos7/9.5/Dockerfile.pgpool.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.pgrestore.centos7
+++ b/centos7/9.5/Dockerfile.pgrestore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
         PostgresVersion="9.5" \
-        PostgresFullVersion="9.5.20" \
+        PostgresFullVersion="9.5.21" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.postgres-gis.centos7
+++ b/centos7/9.5/Dockerfile.postgres-gis.centos7
@@ -3,7 +3,7 @@ FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.5/Dockerfile.postgres.centos7
+++ b/centos7/9.5/Dockerfile.postgres.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="9.5" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg*" PGDG_REPO_ENABLE="pgdg95"\
-    BACKREST_VERSION="2.18"
+    BACKREST_VERSION="2.20"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.5/Dockerfile.postgres.centos7
+++ b/centos7/9.5/Dockerfile.postgres.centos7
@@ -3,11 +3,11 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 9.5.20 (PGDG) on a Centos7 base image" \
+	summary="PostgreSQL 9.5.21 (PGDG) on a Centos7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         io.k8s.description="postgres container" \
         io.k8s.display-name="Crunchy postgres container" \

--- a/centos7/9.6/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.6/Dockerfile.backrest-restore.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg*" PGDG_REPO_ENABLE="pgdg96" \
-    BACKREST_VERSION="2.18"
+    BACKREST_VERSION="2.20"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.backrest-restore.centos7
+++ b/centos7/9.6/Dockerfile.backrest-restore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.backup.centos7
+++ b/centos7/9.6/Dockerfile.backup.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/backup" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.collect.centos7
+++ b/centos7/9.6/Dockerfile.collect.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/collect" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.pgadmin4.centos7
+++ b/centos7/9.6/Dockerfile.pgadmin4.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.pgbadger.centos7
+++ b/centos7/9.6/Dockerfile.pgbadger.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.pgbench.centos7
+++ b/centos7/9.6/Dockerfile.pgbench.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.pgbouncer.centos7
+++ b/centos7/9.6/Dockerfile.pgbouncer.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.pgdump.centos7
+++ b/centos7/9.6/Dockerfile.pgdump.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.pgpool.centos7
+++ b/centos7/9.6/Dockerfile.pgpool.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.pgrestore.centos7
+++ b/centos7/9.6/Dockerfile.pgrestore.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.postgres-gis.centos7
+++ b/centos7/9.6/Dockerfile.postgres-gis.centos7
@@ -3,7 +3,7 @@ FROM $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/centos7/9.6/Dockerfile.postgres.centos7
+++ b/centos7/9.6/Dockerfile.postgres.centos7
@@ -17,7 +17,7 @@ LABEL name="crunchydata/postgres" \
 COPY licenses /licenses
 
 ENV PGVERSION="9.6" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg*" PGDG_REPO_ENABLE="pgdg96" \
-    BACKREST_VERSION="2.18"
+    BACKREST_VERSION="2.20"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/9.6/Dockerfile.postgres.centos7
+++ b/centos7/9.6/Dockerfile.postgres.centos7
@@ -3,11 +3,11 @@ FROM centos:7
 LABEL name="crunchydata/postgres" \
 	vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 9.6.16 (PGDG) on a Centos7 base image" \
+	summary="PostgreSQL 9.6.17 (PGDG) on a Centos7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         io.k8s.description="postgres container" \
         io.k8s.display-name="Crunchy postgres container" \

--- a/centos7/9.6/Dockerfile.upgrade.centos7
+++ b/centos7/9.6/Dockerfile.upgrade.centos7
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL name="crunchydata/upgrade" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/examples/docker/swarm-service/docker-compose.yml
+++ b/examples/docker/swarm-service/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3.3"
 services:
   primary:
     hostname: 'primary'
-    image: crunchydata/crunchy-postgres:centos7-10.11-4.1.2
+    image: crunchydata/crunchy-postgres:centos7-10.12-4.1.2
     environment:
     - PGHOST=/tmp
     - MAX_CONNECTIONS=10
@@ -29,7 +29,7 @@ services:
         - node.labels.type == primary
         - node.role == worker
   replica:
-    image: crunchydata/crunchy-postgres:centos7-10.11-4.1.2
+    image: crunchydata/crunchy-postgres:centos7-10.12-4.1.2
     environment:
     - PGHOST=/tmp
     - MAX_CONNECTIONS=10

--- a/examples/helm/custom-config/README.md
+++ b/examples/helm/custom-config/README.md
@@ -66,7 +66,7 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install custom-config --name custom-config \
-  --set Image.tag=centos7-10.11-4.1.2
+  --set Image.tag=centos7-10.12-4.1.2
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -82,7 +82,7 @@ $ helm install custom-config --name custom-config \
 | `.serviceType`      | The type of service      | `ClusterIP`               
 | `.image.repository` | The repository on DockerHub where the images are found.    | `crunchydata`                                           |
 | `.image.container` | The container to be pulled from the repository.    | `crunchy-postgres`                                                    |
-| `.image.tag` | The image tag to be used.    | `centos7-10.11-4.1.2`                                                    |
+| `.image.tag` | The image tag to be used.    | `centos7-10.12-4.1.2`                                                    |
 | `.resources.cpu` | Defines a limit for CPU    | `200m`                                                    |
 | `.resources.memory` | Defines a limit for memory    | `512Mi`                                                    |
 

--- a/examples/helm/custom-config/values.yaml
+++ b/examples/helm/custom-config/values.yaml
@@ -10,7 +10,7 @@ serviceType: ClusterIP
 image:
   repository: crunchydata
   container: crunchy-postgres
-  tag: centos7-10.11-4.1.2
+  tag: centos7-10.12-4.1.2
 resources:
   cpu: 200m
   memory: 512Mi

--- a/examples/helm/primary-replica/README.md
+++ b/examples/helm/primary-replica/README.md
@@ -102,7 +102,7 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install primary-replica --name primary-replica \
-  --set Image.tag=centos7-10.11-4.1.2
+  --set Image.tag=centos7-10.12-4.1.2
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -119,7 +119,7 @@ $ helm install primary-replica --name primary-replica \
 | `.serviceType`      | The type of service      | `ClusterIP`               
 | `.image.repository` | The repository on DockerHub where the images are found.    | `crunchydata`                                           |
 | `.image.container` | The container to be pulled from the repository.    | `crunchy-postgres`                                                    |
-| `.image.tag` | The image tag to be used.    | `centos7-10.11-4.1.2`                                                    |
+| `.image.tag` | The image tag to be used.    | `centos7-10.12-4.1.2`                                                    |
 | `.pv.storage` | Size of persistent volume     | 400M                                                    |
 | `.pv.name` | Name of persistent volume    | `primary-pv`                                                    |
 | `.pv.mode` | The storage mode for the persistent volume    | `ReadWriteMany`                                                    |

--- a/examples/helm/primary-replica/values.yaml
+++ b/examples/helm/primary-replica/values.yaml
@@ -12,7 +12,7 @@ serviceType: ClusterIP
 image:
   repository: crunchydata
   container: crunchy-postgres
-  tag: centos7-10.11-4.1.2
+  tag: centos7-10.12-4.1.2
 pv:
   storage: 400M
   name: primary-pv

--- a/examples/helm/primary/README.md
+++ b/examples/helm/primary/README.md
@@ -65,7 +65,7 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install primary --name primary \
-  --set Image.tag=centos7-10.11-4.1.2
+  --set Image.tag=centos7-10.12-4.1.2
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -81,7 +81,7 @@ $ helm install primary --name primary \
 | `.serviceType`      | The type of service      | `ClusterIP`               
 | `.image.repository` | The repository on DockerHub where the images are found.    | `crunchydata`                                           |
 | `.image.container` | The container to be pulled from the repository.    | `crunchy-postgres`                                                    |
-| `.image.tag` | The image tag to be used.    | `centos7-10.11-4.1.2`                                                    |
+| `.image.tag` | The image tag to be used.    | `centos7-10.12-4.1.2`                                                    |
 | `.resources.cpu` | Defines a limit for CPU    | `200m`                                                    |
 | `.resources.memory` | Defines a limit for memory    | `512Mi`                                                    |
 

--- a/examples/helm/primary/values.yaml
+++ b/examples/helm/primary/values.yaml
@@ -10,7 +10,7 @@ serviceType: ClusterIP
 image:
   repository: crunchydata
   container: crunchy-postgres
-  tag: centos7-10.11-4.1.2
+  tag: centos7-10.12-4.1.2
 resources:
   cpu: 200m
   memory: 512Mi

--- a/examples/helm/statefulset/README.md
+++ b/examples/helm/statefulset/README.md
@@ -104,7 +104,7 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install statefulset --name statefulset \
-  --set Image.tag=centos7-10.11-4.1.2
+  --set Image.tag=centos7-10.12-4.1.2
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -122,7 +122,7 @@ $ helm install statefulset --name statefulset \
 | `.serviceType`      | The type of service      | `ClusterIP`               
 | `.image.repository` | The repository on DockerHub where the images are found.    | `crunchydata`                                           |
 | `.image.container` | The container to be pulled from the repository.    | `crunchy-postgres`                                                    |
-| `.image.tag` | The image tag to be used.    | `centos7-10.11-4.1.2`                                                    |
+| `.image.tag` | The image tag to be used.    | `centos7-10.12-4.1.2`                                                    |
 | `.pv.storage` | Size of persistent volume     | 400M                                                    |
 | `.pv.name` | Name of persistent volume    | `pgset-pv`                                                    |
 | `.pvc.name` | Name of persistent volume    | `pgset-pvc`                                                    |

--- a/examples/helm/statefulset/values.yaml
+++ b/examples/helm/statefulset/values.yaml
@@ -14,7 +14,7 @@ serviceType: ClusterIP
 image:
   repository: crunchydata
   container: crunchy-postgres
-  tag: centos7-10.11-4.1.2
+  tag: centos7-10.12-4.1.2
 pv:
   storage: 400M
   name: pgset-pv

--- a/examples/helm/template-small/README.md
+++ b/examples/helm/template-small/README.md
@@ -75,7 +75,7 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install template-small --name template-small \
-  --set Image.tag=centos7-10.11-4.1.2
+  --set Image.tag=centos7-10.12-4.1.2
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -91,7 +91,7 @@ $ helm install template-small --name template-small \
 | `.serviceType`      | The type of service      | `ClusterIP`               
 | `.image.repository` | The repository on DockerHub where the images are found.    | `crunchydata`                                           |
 | `.image.container` | The container to be pulled from the repository.    | `crunchy-postgres`                                                    |
-| `.image.tag` | The image tag to be used.    | `centos7-10.11-4.1.2`                                                    |
+| `.image.tag` | The image tag to be used.    | `centos7-10.12-4.1.2`                                                    |
 | `.resources.cpu` | Defines a limit for CPU    | `200m`                                                    |
 | `.resources.memory` | Defines a limit for memory    | `512Mi`                                                    |
 

--- a/examples/helm/template-small/values.yaml
+++ b/examples/helm/template-small/values.yaml
@@ -12,7 +12,7 @@ serviceType: ClusterIP
 image:
   repository: crunchydata
   container: crunchy-postgres
-  tag: centos7-10.11-4.1.2
+  tag: centos7-10.12-4.1.2
 resources:
   cpu: 200m
   memory: 512Mi

--- a/hugo/content/container-specifications/crunchy-backrest-restore.md
+++ b/hugo/content/container-specifications/crunchy-backrest-restore.md
@@ -18,7 +18,7 @@ The following features are supported and required by the crunchy-backrest-restor
 
 The crunchy-backrest-restore Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgBackRest](https://pgbackrest.org/) (2.18)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-backrest-restore.md
+++ b/hugo/content/container-specifications/crunchy-backrest-restore.md
@@ -19,7 +19,7 @@ The following features are supported and required by the crunchy-backrest-restor
 The crunchy-backrest-restore Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
 * PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
-* [pgBackRest](https://pgbackrest.org/) (2.18)
+* [pgBackRest](https://pgbackrest.org/) (2.20)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-backup.md
+++ b/hugo/content/container-specifications/crunchy-backup.md
@@ -19,7 +19,7 @@ The following features are supported by the `crunchy-backup` container:
 
 The crunchy-backup Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-collect.md
+++ b/hugo/content/container-specifications/crunchy-collect.md
@@ -23,7 +23,7 @@ can be specified for the API to collect. For an example of a queries.yml file, s
 
 The crunchy-collect Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 * [PostgreSQL Exporter](https://github.com/wrouesnel/postgres_exporter)

--- a/hugo/content/container-specifications/crunchy-pgadmin4.md
+++ b/hugo/content/container-specifications/crunchy-pgadmin4.md
@@ -28,7 +28,7 @@ The following features are supported by the crunchy-pgadmin4 container:
 
 The crunchy-pgadmin4 Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgAdmin4](https://www.pgadmin.org/)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-pgbench.md
+++ b/hugo/content/container-specifications/crunchy-pgbench.md
@@ -19,7 +19,7 @@ The following features are supported by the `crunchy-pgbench` container:
 
 The crunchy-pgbench Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* pgBench (12.1, 11.6, 10.11, 9.6.16, 9.5.20)
+* pgBench (12.2, 11.7, 10.12, 9.6.17, 9.5.21)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-pgbouncer.md
+++ b/hugo/content/container-specifications/crunchy-pgbouncer.md
@@ -21,7 +21,7 @@ The following features are supported by the crunchy-pgbouncer container:
 
 The crunchy-pgbouncer Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgBouncer](https://pgbouncer.github.io/)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-pgdump.md
+++ b/hugo/content/container-specifications/crunchy-pgdump.md
@@ -12,7 +12,7 @@ PostgreSQL database.
 
 The crunchy-pgdump Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-pgpool.md
+++ b/hugo/content/container-specifications/crunchy-pgpool.md
@@ -27,7 +27,7 @@ The following features are supported by the `crunchy-postgres` container:
 
 The crunchy-pgpool Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgPool II](http://www.pgpool.net/mediawiki/index.php/Main_Page)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-pgrestore.md
+++ b/hugo/content/container-specifications/crunchy-pgrestore.md
@@ -13,7 +13,7 @@ to a PostgreSQL container database.
 
 The crunchy-pgrestore Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-postgres-gis.md
+++ b/hugo/content/container-specifications/crunchy-postgres-gis.md
@@ -23,7 +23,7 @@ The following features are supported by the `crunchy-postgres-gis` container:
 The crunchy-postgres-gis Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
 * PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
-* [pgBackRest](https://pgbackrest.org/) (2.18)
+* [pgBackRest](https://pgbackrest.org/) (2.20)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-postgres-gis.md
+++ b/hugo/content/container-specifications/crunchy-postgres-gis.md
@@ -22,7 +22,7 @@ The following features are supported by the `crunchy-postgres-gis` container:
 
 The crunchy-postgres-gis Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgBackRest](https://pgbackrest.org/) (2.18)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-postgres.md
+++ b/hugo/content/container-specifications/crunchy-postgres.md
@@ -21,7 +21,7 @@ The following features are supported by the `crunchy-postgres` container:
 The crunchy-postgres Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
 * PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
-* [pgBackRest](https://pgbackrest.org/) (2.18)
+* [pgBackRest](https://pgbackrest.org/) (2.20)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/container-specifications/crunchy-postgres.md
+++ b/hugo/content/container-specifications/crunchy-postgres.md
@@ -20,7 +20,7 @@ The following features are supported by the `crunchy-postgres` container:
 
 The crunchy-postgres Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgBackRest](https://pgbackrest.org/) (2.18)
 * CentOS7 - publicly available
 * RHEL7 - customers only

--- a/hugo/content/container-specifications/crunchy-upgrade.md
+++ b/hugo/content/container-specifications/crunchy-upgrade.md
@@ -35,7 +35,7 @@ The following features are supported by the crunchy-upgrade container:
 
 The crunchy-upgrade Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL (12.1, 11.6, 10.11, 9.6.16 and 9.5.20)
+* PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
 * RHEL7 - customers only
 

--- a/hugo/content/examples/administration/upgrade.md
+++ b/hugo/content/examples/administration/upgrade.md
@@ -9,7 +9,7 @@ weight: 81
 
 {{% notice tip %}}
 This example assumes you have run *primary* using a PostgreSQL 11 or 12 image
-such as `centos7-12.1-4.1.2` prior to running this upgrade.
+such as `centos7-12.2-4.1.2` prior to running this upgrade.
 {{% /notice %}}
 
 The upgrade container will let you perform a `pg_upgrade` from a PostgreSQL version 9.5, 9.6, 10, 11 or 12 database to the available any of the higher versions of PostgreSQL versions that are currently support which are 9.6, 10, 11, and 12. It does not do multi-version upgrades so you will need to for example do a 10 to 11 and then a 11 to 12 to get to version 12.
@@ -17,7 +17,7 @@ The upgrade container will let you perform a `pg_upgrade` from a PostgreSQL vers
 Prior to running this example, make sure your `CCP_IMAGE_TAG`
 environment variable is using the next major version of PostgreSQL that you
 want to upgrade to. For example, if you're upgrading from 11 to 12, make
-sure the variable references a PostgreSQL 12 image such as `centos7-12.1-4.1.2`.
+sure the variable references a PostgreSQL 12 image such as `centos7-12.2-4.1.2`.
 
 This will create the following in your Kubernetes environment:
 

--- a/hugo/content/examples/postgresql/custom-config-ssl.md
+++ b/hugo/content/examples/postgresql/custom-config-ssl.md
@@ -83,7 +83,7 @@ sslkey=$CCPROOT/examples/kube/custom-config-ssl/certs/client.key"
 
 You should see a connection that looks like the following:
 ```
-psql (10.11)
+psql (10.12)
 SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
 Type "help" for help.
 

--- a/hugo/content/installation-guide/installation-guide.md
+++ b/hugo/content/installation-guide/installation-guide.md
@@ -96,7 +96,7 @@ line starting with #:
     export PATH=$PATH:$GOBIN        # add Go bin path to your overall path
     export CCP_BASEOS=centos7       # centos7 for Centos, rhel7 for Redhat
     export CCP_PGVERSION=10         # The PostgreSQL major version
-    export CCP_PG_FULLVERSION=10.11
+    export CCP_PG_FULLVERSION=10.12
     export CCP_VERSION=4.1.2
     export CCP_IMAGE_PREFIX=crunchydata # Prefix to put before all the container image names
     export CCP_IMAGE_TAG=$CCP_BASEOS-$CCP_PG_FULLVERSION-$CCP_VERSION   # Used to tag the images

--- a/hugo/content/overview/overview.md
+++ b/hugo/content/overview/overview.md
@@ -74,7 +74,7 @@ Crunchy Container Suite provides two types of backup images:
 
 *Physical* backup and restoration tools included in the Crunchy Container suite are:
 
-* [pgBackRest](2.18)
+* [pgBackRest](2.20)
   PostgreSQL images
 * [pg_basebackup](https://www.postgresql.org/docs/current/app-pgbasebackup.html) -
   provided by the Crunchy Backup image

--- a/rhel7/10/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/10/Dockerfile.backrest-restore.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="10" BACKREST_VERSION="2.18"
+ENV PGVERSION="10" BACKREST_VERSION="2.20"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /

--- a/rhel7/10/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/10/Dockerfile.backrest-restore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.backup.rhel7
+++ b/rhel7/10/Dockerfile.backup.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/backup" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.collect.rhel7
+++ b/rhel7/10/Dockerfile.collect.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/collect" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/10/Dockerfile.pgadmin4.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.pgbadger.rhel7
+++ b/rhel7/10/Dockerfile.pgbadger.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.pgbench.rhel7
+++ b/rhel7/10/Dockerfile.pgbench.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/10/Dockerfile.pgbouncer.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.pgdump.rhel7
+++ b/rhel7/10/Dockerfile.pgdump.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.pgpool.rhel7
+++ b/rhel7/10/Dockerfile.pgpool.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
   url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.pgrestore.rhel7
+++ b/rhel7/10/Dockerfile.pgrestore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/10/Dockerfile.postgres-gis.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/10/Dockerfile.postgres.rhel7
+++ b/rhel7/10/Dockerfile.postgres.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="10" BACKREST_VERSION="2.18"
+ENV PGVERSION="10" BACKREST_VERSION="2.20"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf

--- a/rhel7/10/Dockerfile.postgres.rhel7
+++ b/rhel7/10/Dockerfile.postgres.rhel7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 10.11 (PGDG) on a RHEL7 base image" \
+	summary="PostgreSQL 10.12 (PGDG) on a RHEL7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         run="" \
         start="" \

--- a/rhel7/10/Dockerfile.upgrade.rhel7
+++ b/rhel7/10/Dockerfile.upgrade.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/upgrade" \
         vendor="crunchy data" \
 	PostgresVersion="10" \
-	PostgresFullVersion="10.11" \
+	PostgresFullVersion="10.12" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/11/Dockerfile.backrest-restore.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="11" BACKREST_VERSION="2.18"
+ENV PGVERSION="11" BACKREST_VERSION="2.20"
 
 # Crunchy Postgres repo
 ADD conf/RPM-GPG-KEY-crunchydata  /

--- a/rhel7/11/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/11/Dockerfile.backrest-restore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.backup.rhel7
+++ b/rhel7/11/Dockerfile.backup.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/backup" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.collect.rhel7
+++ b/rhel7/11/Dockerfile.collect.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/collect" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/11/Dockerfile.pgadmin4.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.pgbadger.rhel7
+++ b/rhel7/11/Dockerfile.pgbadger.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.pgbench.rhel7
+++ b/rhel7/11/Dockerfile.pgbench.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/11/Dockerfile.pgbouncer.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.pgdump.rhel7
+++ b/rhel7/11/Dockerfile.pgdump.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.pgpool.rhel7
+++ b/rhel7/11/Dockerfile.pgpool.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
   url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.pgrestore.rhel7
+++ b/rhel7/11/Dockerfile.pgrestore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/11/Dockerfile.postgres-gis.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/11/Dockerfile.postgres.rhel7
+++ b/rhel7/11/Dockerfile.postgres.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="11" BACKREST_VERSION="2.18"
+ENV PGVERSION="11" BACKREST_VERSION="2.20"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf

--- a/rhel7/11/Dockerfile.postgres.rhel7
+++ b/rhel7/11/Dockerfile.postgres.rhel7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 11.6 (PGDG) on a RHEL7 base image" \
+	summary="PostgreSQL 11.7 (PGDG) on a RHEL7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         run="" \
         start="" \

--- a/rhel7/11/Dockerfile.upgrade.rhel7
+++ b/rhel7/11/Dockerfile.upgrade.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/upgrade" \
         vendor="crunchy data" \
 	PostgresVersion="11" \
-	PostgresFullVersion="11.6" \
+	PostgresFullVersion="11.7" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/12/Dockerfile.backrest-restore.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="12" BACKREST_VERSION="2.18"
+ENV PGVERSION="12" BACKREST_VERSION="2.20"
 
 # Crunchy Postgres repo
 ADD conf/RPM-GPG-KEY-crunchydata  /

--- a/rhel7/12/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/12/Dockerfile.backrest-restore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.backup.rhel7
+++ b/rhel7/12/Dockerfile.backup.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/backup" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.collect.rhel7
+++ b/rhel7/12/Dockerfile.collect.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/collect" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/12/Dockerfile.pgadmin4.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.pgbadger.rhel7
+++ b/rhel7/12/Dockerfile.pgbadger.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.pgbench.rhel7
+++ b/rhel7/12/Dockerfile.pgbench.rhel7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \
-    	summary="pgBench 12.1 (PGDG) on a RHEL7 base image" \
+    	summary="pgBench 12.2 (PGDG) on a RHEL7 base image" \
         description="pgbench is a simple program for running benchmark tests on PostgreSQL. It runs the same sequence of SQL commands over and over, possibly in multiple concurrent database sessions, and then calculates the average transaction rate (transactions per second)." \
         run="" \
         start="" \

--- a/rhel7/12/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/12/Dockerfile.pgbouncer.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbouncer" \
         vendor="crunchy data" \
 		PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.pgdump.rhel7
+++ b/rhel7/12/Dockerfile.pgdump.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.pgpool.rhel7
+++ b/rhel7/12/Dockerfile.pgpool.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgpool" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.pgrestore.rhel7
+++ b/rhel7/12/Dockerfile.pgrestore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/12/Dockerfile.postgres-gis.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/12/Dockerfile.postgres.rhel7
+++ b/rhel7/12/Dockerfile.postgres.rhel7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \
-        summary="PostgreSQL 12.1 (PGDG) on a RHEL7 base image" \
+        summary="PostgreSQL 12.2 (PGDG) on a RHEL7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         run="" \
         start="" \

--- a/rhel7/12/Dockerfile.postgres.rhel7
+++ b/rhel7/12/Dockerfile.postgres.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="12" BACKREST_VERSION="2.18"
+ENV PGVERSION="12" BACKREST_VERSION="2.20"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf

--- a/rhel7/12/Dockerfile.upgrade.rhel7
+++ b/rhel7/12/Dockerfile.upgrade.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/upgrade" \
         vendor="crunchy data" \
         PostgresVersion="12" \
-        PostgresFullVersion="12.1" \
+        PostgresFullVersion="12.2" \
         Version="7.7" \
         Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.5/Dockerfile.backrest-restore.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="9.5" BACKREST_VERSION="2.18"
+ENV PGVERSION="9.5" BACKREST_VERSION="2.20"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /

--- a/rhel7/9.5/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.5/Dockerfile.backrest-restore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.backup.rhel7
+++ b/rhel7/9.5/Dockerfile.backup.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/backup" \
     vendor="crunchy data" \
     PostgresVersion="9.5" \
-  	PostgresFullVersion="9.5.20" \
+  	PostgresFullVersion="9.5.21" \
     Version="7.7" \
     Release="4.1.2" \
     url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.collect.rhel7
+++ b/rhel7/9.5/Dockerfile.collect.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/collect" \
 	vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
   url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/9.5/Dockerfile.pgadmin4.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbadger.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.pgbench.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbench.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/9.5/Dockerfile.pgbouncer.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.pgdump.rhel7
+++ b/rhel7/9.5/Dockerfile.pgdump.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.pgpool.rhel7
+++ b/rhel7/9.5/Dockerfile.pgpool.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
   url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.pgrestore.rhel7
+++ b/rhel7/9.5/Dockerfile.pgrestore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres-gis.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres-gis" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.5/Dockerfile.postgres.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres.rhel7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="9.5" \
-	PostgresFullVersion="9.5.20" \
+	PostgresFullVersion="9.5.21" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 9.5.20 (PGDG) on a RHEL7 base image" \
+	summary="PostgreSQL 9.5.21 (PGDG) on a RHEL7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         run="" \
         start="" \

--- a/rhel7/9.5/Dockerfile.postgres.rhel7
+++ b/rhel7/9.5/Dockerfile.postgres.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="9.5" BACKREST_VERSION="2.18"
+ENV PGVERSION="9.5" BACKREST_VERSION="2.20"
 
 # PGDG Postgres repo
 #RUN rpm -Uvh http://yum.postgresql.org/9.5/redhat/rhel-7-x86_64/pgdg-redhat95-9.5-3.noarch.rpm

--- a/rhel7/9.6/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.6/Dockerfile.backrest-restore.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="9.6" BACKREST_VERSION="2.18"
+ENV PGVERSION="9.6" BACKREST_VERSION="2.20"
 
 # Crunchy Postgres repo
 ADD conf/CRUNCHY-GPG-KEY.public  /

--- a/rhel7/9.6/Dockerfile.backrest-restore.rhel7
+++ b/rhel7/9.6/Dockerfile.backrest-restore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.backup.rhel7
+++ b/rhel7/9.6/Dockerfile.backup.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/backup" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.collect.rhel7
+++ b/rhel7/9.6/Dockerfile.collect.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/collect" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/9.6/Dockerfile.pgadmin4.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgadmin4" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.pgbadger.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbadger.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbadger" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.pgbench.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbench.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbench" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.pgbouncer.rhel7
+++ b/rhel7/9.6/Dockerfile.pgbouncer.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbouncer" \
 	vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.pgdump.rhel7
+++ b/rhel7/9.6/Dockerfile.pgdump.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgdump" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.pgpool.rhel7
+++ b/rhel7/9.6/Dockerfile.pgpool.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgpool" \
 	vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.pgrestore.rhel7
+++ b/rhel7/9.6/Dockerfile.pgrestore.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/restore" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.postgres-gis.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres-gis.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres-gis" \
 	vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/rhel7/9.6/Dockerfile.postgres.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres.rhel7
@@ -24,7 +24,7 @@ COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="9.6" BACKREST_VERSION="2.18"
+ENV PGVERSION="9.6" BACKREST_VERSION="2.20"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf

--- a/rhel7/9.6/Dockerfile.postgres.rhel7
+++ b/rhel7/9.6/Dockerfile.postgres.rhel7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \
-	summary="PostgreSQL 9.6.16 (PGDG) on a RHEL7 base image" \
+	summary="PostgreSQL 9.6.17 (PGDG) on a RHEL7 base image" \
         description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
         run="" \
         start="" \

--- a/rhel7/9.6/Dockerfile.upgrade.rhel7
+++ b/rhel7/9.6/Dockerfile.upgrade.rhel7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/upgrade" \
         vendor="crunchy data" \
 	PostgresVersion="9.6" \
-	PostgresFullVersion="9.6.16" \
+	PostgresFullVersion="9.6.17" \
 	Version="7.7" \
 	Release="4.1.2" \
         url="https://crunchydata.com" \

--- a/tools/test-harness/data/data_types_test.go
+++ b/tools/test-harness/data/data_types_test.go
@@ -4,7 +4,7 @@ import (
 	dockertest "gopkg.in/ory-am/dockertest.v3"
 )
 
-var tag = "centos7-11.6-4.1.2"
+var tag = "centos7-11.7-4.1.2"
 
 var primaryEnv = []string{
 	"TEMP_BUFFERS=9MB",

--- a/ubi7/11/Dockerfile.backrest-restore.ubi7
+++ b/ubi7/11/Dockerfile.backrest-restore.ubi7
@@ -24,7 +24,7 @@ COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="11" BACKREST_VERSION="2.18"
+ENV PGVERSION="11" BACKREST_VERSION="2.20"
 
 # Crunchy Postgres repo
 ADD conf/RPM-GPG-KEY-crunchydata  /

--- a/ubi7/11/Dockerfile.backrest-restore.ubi7
+++ b/ubi7/11/Dockerfile.backrest-restore.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/crunchy-backrest-restore" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.6" \
+      PostgresFullVersion="11.7" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.backup.ubi7
+++ b/ubi7/11/Dockerfile.backup.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/backup" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.6" \
+      PostgresFullVersion="11.7" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.collect.ubi7
+++ b/ubi7/11/Dockerfile.collect.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/collect" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.6" \
+      PostgresFullVersion="11.7" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.pgadmin4.ubi7
+++ b/ubi7/11/Dockerfile.pgadmin4.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgadmin4" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.6" \
+      PostgresFullVersion="11.7" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.pgbadger.ubi7
+++ b/ubi7/11/Dockerfile.pgbadger.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbadger" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.6" \
+      PostgresFullVersion="11.7" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.pgbench.ubi7
+++ b/ubi7/11/Dockerfile.pgbench.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbench" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.6" \
+      PostgresFullVersion="11.7" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.pgbouncer.ubi7
+++ b/ubi7/11/Dockerfile.pgbouncer.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbouncer" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.6" \
+      PostgresFullVersion="11.7" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.pgdump.ubi7
+++ b/ubi7/11/Dockerfile.pgdump.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgdump" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.6" \
+      PostgresFullVersion="11.7" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.pgpool.ubi7
+++ b/ubi7/11/Dockerfile.pgpool.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgpool" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.6" \
+      PostgresFullVersion="11.7" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.pgrestore.ubi7
+++ b/ubi7/11/Dockerfile.pgrestore.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/restore" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.6" \
+      PostgresFullVersion="11.7" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.postgres-appdev.ubi7
+++ b/ubi7/11/Dockerfile.postgres-appdev.ubi7
@@ -3,7 +3,7 @@ FROM ubi7
 LABEL name="crunchydata/postgres-appdev" \
       vendor="crunchydata" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.6" \
+      PostgresFullVersion="11.7" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.postgres-gis.ubi7
+++ b/ubi7/11/Dockerfile.postgres-gis.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres-gis" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.6" \
+      PostgresFullVersion="11.7" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/11/Dockerfile.postgres.ubi7
+++ b/ubi7/11/Dockerfile.postgres.ubi7
@@ -24,7 +24,7 @@ COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="11" BACKREST_VERSION="2.18"
+ENV PGVERSION="11" BACKREST_VERSION="2.20"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf

--- a/ubi7/11/Dockerfile.postgres.ubi7
+++ b/ubi7/11/Dockerfile.postgres.ubi7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.6" \
+      PostgresFullVersion="11.7" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \
-      summary="PostgreSQL 11.6 (PGDG) on a RHEL7 base image" \
+      summary="PostgreSQL 11.7 (PGDG) on a RHEL7 base image" \
       description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
       run="" \
       start="" \

--- a/ubi7/11/Dockerfile.upgrade.ubi7
+++ b/ubi7/11/Dockerfile.upgrade.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/upgrade" \
       vendor="crunchy data" \
       PostgresVersion="11" \
-      PostgresFullVersion="11.6" \
+      PostgresFullVersion="11.7" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.backrest-restore.ubi7
+++ b/ubi7/12/Dockerfile.backrest-restore.ubi7
@@ -24,7 +24,7 @@ COPY conf/atomic/backrestrestore/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="12" BACKREST_VERSION="2.18"
+ENV PGVERSION="12" BACKREST_VERSION="2.20"
 
 # Crunchy Postgres repo
 ADD conf/RPM-GPG-KEY-crunchydata  /

--- a/ubi7/12/Dockerfile.backrest-restore.ubi7
+++ b/ubi7/12/Dockerfile.backrest-restore.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/crunchy-backrest-restore" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.1" \
+      PostgresFullVersion="12.2" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.backup.ubi7
+++ b/ubi7/12/Dockerfile.backup.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/backup" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.1" \
+      PostgresFullVersion="12.2" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.collect.ubi7
+++ b/ubi7/12/Dockerfile.collect.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/collect" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.1" \
+      PostgresFullVersion="12.2" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.pgadmin4.ubi7
+++ b/ubi7/12/Dockerfile.pgadmin4.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgadmin4" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.1" \
+      PostgresFullVersion="12.2" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.pgbadger.ubi7
+++ b/ubi7/12/Dockerfile.pgbadger.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbadger" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.1" \
+      PostgresFullVersion="12.2" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.pgbench.ubi7
+++ b/ubi7/12/Dockerfile.pgbench.ubi7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbench" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.1" \
+      PostgresFullVersion="12.2" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \
-      summary="pgBench 12.1 (PGDG) on a RHEL7 base image" \
+      summary="pgBench 12.2 (PGDG) on a RHEL7 base image" \
       description="pgbench is a simple program for running benchmark tests on PostgreSQL. It runs the same sequence of SQL commands over and over, possibly in multiple concurrent database sessions, and then calculates the average transaction rate (transactions per second)." \
       run="" \
       start="" \

--- a/ubi7/12/Dockerfile.pgbouncer.ubi7
+++ b/ubi7/12/Dockerfile.pgbouncer.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgbouncer" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.1" \
+      PostgresFullVersion="12.2" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.pgdump.ubi7
+++ b/ubi7/12/Dockerfile.pgdump.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgdump" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.1" \
+      PostgresFullVersion="12.2" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.pgpool.ubi7
+++ b/ubi7/12/Dockerfile.pgpool.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/pgpool" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.1" \
+      PostgresFullVersion="12.2" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.pgrestore.ubi7
+++ b/ubi7/12/Dockerfile.pgrestore.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/restore" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.1" \
+      PostgresFullVersion="12.2" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.postgres-gis.ubi7
+++ b/ubi7/12/Dockerfile.postgres-gis.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres-gis" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.1" \
+      PostgresFullVersion="12.2" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \

--- a/ubi7/12/Dockerfile.postgres.ubi7
+++ b/ubi7/12/Dockerfile.postgres.ubi7
@@ -24,7 +24,7 @@ COPY conf/atomic/postgres/help.md /help.md
 COPY conf/licenses /licenses
 COPY licenses /licenses
 
-ENV PGVERSION="12" BACKREST_VERSION="2.18"
+ENV PGVERSION="12" BACKREST_VERSION="2.20"
 
 # if you ever need to install package docs inside the container, uncomment
 #RUN sed -i '/nodocs/d' /etc/yum.conf

--- a/ubi7/12/Dockerfile.postgres.ubi7
+++ b/ubi7/12/Dockerfile.postgres.ubi7
@@ -5,11 +5,11 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/postgres" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.1" \
+      PostgresFullVersion="12.2" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \
-      summary="PostgreSQL 12.1 (PGDG) on a RHEL7 base image" \
+      summary="PostgreSQL 12.2 (PGDG) on a RHEL7 base image" \
       description="Allows multiple deployment methods for PostgreSQL, including basic single primary, streaming replication with synchronous and asynchronous replicas, and stateful sets. Includes utilities for Auditing (pgaudit), statement tracking, and Backup / Restore (pgbackrest, pg_basebackup)." \
       run="" \
       start="" \

--- a/ubi7/12/Dockerfile.upgrade.ubi7
+++ b/ubi7/12/Dockerfile.upgrade.ubi7
@@ -5,7 +5,7 @@ MAINTAINER Crunchy Data <info@crunchydata.com>
 LABEL name="crunchydata/upgrade" \
       vendor="crunchy data" \
       PostgresVersion="12" \
-      PostgresFullVersion="12.1" \
+      PostgresFullVersion="12.2" \
       Version="7.7" \
       Release="4.1.2" \
       url="https://crunchydata.com" \


### PR DESCRIPTION
Updated for PostgreSQL 12.2, 11.7, 10.12, 9.6.17, 9.5.21