### PR TITLE
Update Documentation for UBI (master)

### DIFF
--- a/hugo/content/container-specifications/crunchy-backrest-restore.md
+++ b/hugo/content/container-specifications/crunchy-backrest-restore.md
@@ -21,7 +21,7 @@ The crunchy-backrest-restore Docker image contains the following packages (versi
 * PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgBackRest](https://pgbackrest.org/) (2.20)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Environment Variables
 

--- a/hugo/content/container-specifications/crunchy-backup.md
+++ b/hugo/content/container-specifications/crunchy-backup.md
@@ -21,7 +21,7 @@ The crunchy-backup Docker image contains the following packages (versions vary d
 
 * PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Environment Variables
 

--- a/hugo/content/container-specifications/crunchy-collect.md
+++ b/hugo/content/container-specifications/crunchy-collect.md
@@ -25,7 +25,7 @@ The crunchy-collect Docker image contains the following packages (versions vary 
 
 * PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 * [PostgreSQL Exporter](https://github.com/wrouesnel/postgres_exporter)
 
 ## Environment Variables

--- a/hugo/content/container-specifications/crunchy-grafana.md
+++ b/hugo/content/container-specifications/crunchy-grafana.md
@@ -35,7 +35,7 @@ The crunchy-grafana Docker image contains the following packages:
 
 * [Grafana](https://grafana.com/)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Environment Variables
 

--- a/hugo/content/container-specifications/crunchy-pgadmin4.md
+++ b/hugo/content/container-specifications/crunchy-pgadmin4.md
@@ -31,7 +31,7 @@ The crunchy-pgadmin4 Docker image contains the following packages (versions vary
 * PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgAdmin4](https://www.pgadmin.org/)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Environment Variables
 

--- a/hugo/content/container-specifications/crunchy-pgbadger.md
+++ b/hugo/content/container-specifications/crunchy-pgbadger.md
@@ -23,7 +23,7 @@ The crunchy-badger Docker image contains the following packages:
 
 * [pgBadger](http://dalibo.github.io/pgbadger)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Environment Variables
 

--- a/hugo/content/container-specifications/crunchy-pgbasebackup-restore.md
+++ b/hugo/content/container-specifications/crunchy-pgbasebackup-restore.md
@@ -16,7 +16,7 @@ The crunchy-pgbasebackup-restore Docker image contains the following packages:
 
 * rsync
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Environment Variables
 

--- a/hugo/content/container-specifications/crunchy-pgbench.md
+++ b/hugo/content/container-specifications/crunchy-pgbench.md
@@ -21,7 +21,7 @@ The crunchy-pgbench Docker image contains the following packages (versions vary 
 
 * pgBench (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Environment Variables
 

--- a/hugo/content/container-specifications/crunchy-pgbouncer.md
+++ b/hugo/content/container-specifications/crunchy-pgbouncer.md
@@ -24,7 +24,7 @@ The crunchy-pgbouncer Docker image contains the following packages (versions var
 * PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgBouncer](https://pgbouncer.github.io/)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Restrictions
 

--- a/hugo/content/container-specifications/crunchy-pgdump.md
+++ b/hugo/content/container-specifications/crunchy-pgdump.md
@@ -14,7 +14,7 @@ The crunchy-pgdump Docker image contains the following packages (versions vary d
 
 * PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Environment Variables
 

--- a/hugo/content/container-specifications/crunchy-pgpool.md
+++ b/hugo/content/container-specifications/crunchy-pgpool.md
@@ -30,7 +30,7 @@ The crunchy-pgpool Docker image contains the following packages (versions vary d
 * PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgPool II](http://www.pgpool.net/mediawiki/index.php/Main_Page)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Environment Variables
 

--- a/hugo/content/container-specifications/crunchy-pgrestore.md
+++ b/hugo/content/container-specifications/crunchy-pgrestore.md
@@ -15,7 +15,7 @@ The crunchy-pgrestore Docker image contains the following packages (versions var
 
 * PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Environment Variables
 

--- a/hugo/content/container-specifications/crunchy-postgres-gis.md
+++ b/hugo/content/container-specifications/crunchy-postgres-gis.md
@@ -25,7 +25,7 @@ The crunchy-postgres-gis Docker image contains the following packages (versions 
 * PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgBackRest](https://pgbackrest.org/) (2.20)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Environment Variables
 

--- a/hugo/content/container-specifications/crunchy-postgres.md
+++ b/hugo/content/container-specifications/crunchy-postgres.md
@@ -23,7 +23,7 @@ The crunchy-postgres Docker image contains the following packages (versions vary
 * PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * [pgBackRest](https://pgbackrest.org/) (2.20)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Environment Variables
 

--- a/hugo/content/container-specifications/crunchy-prometheus.md
+++ b/hugo/content/container-specifications/crunchy-prometheus.md
@@ -32,7 +32,7 @@ The crunchy-prometheus Docker image contains the following packages:
 
 * [Prometheus](https://prometheus.io)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Environment Variables
 

--- a/hugo/content/container-specifications/crunchy-upgrade.md
+++ b/hugo/content/container-specifications/crunchy-upgrade.md
@@ -37,7 +37,7 @@ The crunchy-upgrade Docker image contains the following packages (versions vary 
 
 * PostgreSQL (12.2, 11.7, 10.12, 9.6.17 and 9.5.21)
 * CentOS7 - publicly available
-* RHEL7 - customers only
+* UBI7 - customers only
 
 ## Environment Variables
 

--- a/hugo/content/installation-guide/installation-guide.md
+++ b/hugo/content/installation-guide/installation-guide.md
@@ -94,7 +94,7 @@ line starting with #:
     export GOPATH=$HOME/cdev        # set path to your new Go workspace
     export GOBIN=$GOPATH/bin        # set bin path
     export PATH=$PATH:$GOBIN        # add Go bin path to your overall path
-    export CCP_BASEOS=centos7       # centos7 for Centos, rhel7 for Redhat
+    export CCP_BASEOS=centos7       # centos7 for Centos, ubi7 for Red Hat Universal Base Image
     export CCP_PGVERSION=10         # The PostgreSQL major version
     export CCP_PG_FULLVERSION=10.11
     export CCP_VERSION=4.3.0
@@ -112,10 +112,10 @@ effect.
 
 At this point we have almost all the prequesites required to build the Crunchy Container Suite.
 
-# Building RHEL Containers With Supported Crunchy Enterprise Software
+# Building UBI Containers With Supported Crunchy Enterprise Software
 
-Before you can build supported containers on RHEL and Crunchy Supported Software, you need
-to add the Crunchy repositories to your approved Yum repositories. Crunchy Enterprise Customer running on RHEL
+Before you can build supported containers on UBI and Crunchy Supported Software, you need
+to add the Crunchy repositories to your approved Yum repositories. Crunchy Enterprise Customer running on UBI
 can login and download the Crunchy repository key and yum repository from <https://access.crunchydata.com/>
 on the downloads page. Once the files are downloaded please place them into the `$CCPROOT/conf` directory (defined
 above in the environment variable section).

--- a/hugo/content/overview/overview.md
+++ b/hugo/content/overview/overview.md
@@ -9,16 +9,19 @@ weight: 2
 
 The following provides a high level overview of each of the container images.
 
-## CentOS vs RHEL Images
+## CentOS vs Red Hat UBI Images
 
-The Crunchy Container suite provides two different OS images: `centos7` and `rhel7`.
-These images are indentical except for the packages used by `yum` to install the
-software.
+The Crunchy Container suite provides two different OS images: `centos7` and `ubi7`.  Both images
+utilize Crunchy Ceritifed RPM's for the installation of PostgreSQL, and outside of the base images
+utilized to build the containers and any packages included within them (either CentOS or UBI), both
+are effectively the same.  The `ubi7` images are available to active Crunchy Data Customers only,
+and are built using the Red Hat Universal Base Image (UBI).
 
-The `centos7` images, `yum` is configured to use PostgreSQL RPM Building Project.
+Please note that as of version 4.2.2 of the Crunchy Containers Suite, the `ubi7` images have
+replaced the `rhel7` images included in previous versions of the container suite.  For more
+information on Red Hat UBI, please see the following link:
 
-The `rhel7` images use Crunchy Certified RPMs and are only available to active
-Crunchy Data customers.
+https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image
 
 ## Database Images
 


### PR DESCRIPTION
Now that the RHEL images have been replaced by UBI as of version 4.2.2 of the Crunchy Container Suite, this commit replaces all applicable references to 'RHEL' in the Crunchy Container Suite documentation with 'UBI'.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

RHEL 7 is referenced in the Crunchy Container Suite documentation.

**What is the new behavior (if this is a feature change)?**

UBI 7 is referenced in the Crunchy Container Suite documentation where applicable.

**Other information:**

N/A