### PR TITLE
Allow for simpler configuration of TLS-enabled PostgreSQL clusters

### DIFF
--- a/conf/postgres-ha/postgres-ha-pgconf-tls.yaml
+++ b/conf/postgres-ha/postgres-ha-pgconf-tls.yaml
@@ -1,0 +1,9 @@
+---
+bootstrap:
+  dcs:
+    postgresql:
+      parameters:
+        ssl: "on"
+        ssl_cert_file: "/pgconf/tls/tls.crt"
+        ssl_key_file: "/pgconf/tls/tls.key"
+        ssl_ca_file: "/pgconf/tls/ca.crt"

--- a/conf/postgres-ha/postgres-ha-pgconf.yaml
+++ b/conf/postgres-ha/postgres-ha-pgconf.yaml
@@ -1,11 +1,5 @@
 ---
 postgresql:
-  pg_hba:
-    - local all postgres peer
-    - local all crunchyadm peer
-    - host replication PATRONI_REPLICATION_USERNAME 0.0.0.0/0 md5
-    - host all PATRONI_REPLICATION_USERNAME 0.0.0.0/0 reject
-    - host all all 0.0.0.0/0 md5
   use_unix_socket: true
   pgpass: /tmp/.pgpass
   create_replica_methods:

--- a/conf/postgres-ha/postgres-ha-pghba-bootstrap.yaml
+++ b/conf/postgres-ha/postgres-ha-pghba-bootstrap.yaml
@@ -1,0 +1,5 @@
+---
+postgresql:
+  pg_hba:
+    - local all postgres peer
+    - local all crunchyadm peer

--- a/conf/postgres-ha/postgres-ha-pghba-notls.yaml
+++ b/conf/postgres-ha/postgres-ha-pghba-notls.yaml
@@ -1,0 +1,6 @@
+---
+postgresql:
+  pg_hba:
+    - host replication PATRONI_REPLICATION_USERNAME 0.0.0.0/0 md5
+    - host all PATRONI_REPLICATION_USERNAME 0.0.0.0/0 reject
+    - host all all 0.0.0.0/0 md5

--- a/conf/postgres-ha/postgres-ha-pghba-tls.yaml
+++ b/conf/postgres-ha/postgres-ha-pghba-tls.yaml
@@ -1,0 +1,6 @@
+---
+postgresql:
+  pg_hba:
+    - hostssl replication PATRONI_REPLICATION_USERNAME 0.0.0.0/0 md5
+    - hostssl all PATRONI_REPLICATION_USERNAME 0.0.0.0/0 reject
+    - hostssl all all 0.0.0.0/0 md5


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Though there were ways to configured TLS-enabled PostgreSQL clusters in
the crunchy-postgres-ha and derived containers, it was a lot of work.

**What is the new behavior (if this is a feature change)?**

Given this is a fairly typical requirement, this commit does the
following:

- Break out the pg_hba.conf settings into their own files, and stagger
between the system ones and the connection ones
- Add the `PGHA_TLS_ENABLED` environmental variable to enable the
"hostssl" configuration settings
- Add the `PGHA_TLS_ONLY` environmental variale to force TLS only
connections
- Add the required PostgreSQL GUCs for enabling TLS in a cluster

**Other information**:

Issue: [ch7493]
Issue: CrunchyData/postgres-operator#1287