### PR TITLE
Add LLVM support for PostgreSQL 11+ containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ CCP_POSTGIS_VERSION ?= 2.5
 IMGBUILDER ?= buildah
 IMGCMDSTEM=sudo --preserve-env buildah bud --layers $(SQUASH)
 DFSET=$(CCP_BASEOS)
+# This gets set with the name of the PostgreSQL LLVM package to use, but unset
+# if it is unsupported
+CCP_LIBLLVM="postgresql$(CCP_PG_VERSION)-llvmjit"
 
 # Allows simplification of IMGBUILDER switching
 ifeq ("$(IMGBUILDER)","docker")
@@ -25,6 +28,17 @@ endif
 ifeq ("$(CCP_BASEOS)", "ubi7")
 	DFSET=rhel7
 endif
+
+# Allows for selectively installing libllvm to support JIT in versions of
+# PostgreSQL 11 or greater
+ifeq ("$(CCP_PG_VERSION)", "10")
+	CCP_LIBLLVM=""
+else ifeq ("$(CCP_PG_VERSION)", "9.6")
+	CCP_LIBLLVM=""
+else ifeq ("$(CCP_PG_VERSION)", "9.5")
+	CCP_LIBLLVM=""
+endif
+
 
 .PHONY:	all pg-independent-images pgimages
 
@@ -136,6 +150,7 @@ postgres-pgimg-build: cc-pg-base-image commands $(CCPROOT)/$(DFSET)/Dockerfile.p
 		--build-arg PG_MAJOR=$(CCP_PGVERSION) \
 		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
 		--build-arg BACKREST_VER=$(CCP_BACKREST_VERSION) \
+		--build-arg LIBLLVM=$(CCP_LIBLLVM) \
 		$(CCPROOT)
 
 postgres-pgimg-buildah: postgres-pgimg-build
@@ -155,6 +170,7 @@ postgres-gis-pgimg-build: postgres commands $(CCPROOT)/$(DFSET)/Dockerfile.postg
 		--build-arg PG_MAJOR=$(CCP_PGVERSION) \
 		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
 		--build-arg POSTGIS_LBL=$(subst .,,$(CCP_POSTGIS_VERSION)) \
+		--build-arg LIBLLVM=$(CCP_LIBLLVM) \
 		$(CCPROOT)
 
 postgres-gis-pgimg-buildah: postgres-gis-pgimg-build
@@ -174,7 +190,8 @@ postgres-ha-pgimg-build: cc-pg-base-image commands $(CCPROOT)/$(DFSET)/Dockerfil
 		--build-arg PG_MAJOR=$(CCP_PGVERSION) \
 		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
 		--build-arg BACKREST_VER=$(CCP_BACKREST_VERSION) \
-	    --build-arg PATRONI_VER=$(CCP_PATRONI_VERSION) \
+		--build-arg PATRONI_VER=$(CCP_PATRONI_VERSION) \
+		--build-arg LIBLLVM=$(CCP_LIBLLVM) \
 		$(CCPROOT)
 
 postgres-ha-pgimg-buildah: postgres-ha-pgimg-build
@@ -194,6 +211,7 @@ postgres-gis-ha-pgimg-build: postgres-ha commands $(CCPROOT)/$(DFSET)/Dockerfile
 		--build-arg PG_MAJOR=$(CCP_PGVERSION) \
 		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
 		--build-arg POSTGIS_LBL=$(subst .,,$(CCP_POSTGIS_VERSION)) \
+		--build-arg LIBLLVM=$(CCP_LIBLLVM) \
 		$(CCPROOT)
 
 postgres-gis-ha-pgimg-buildah: postgres-gis-ha-pgimg-build

--- a/centos7/Dockerfile.postgres-ha.centos7
+++ b/centos7/Dockerfile.postgres-ha.centos7
@@ -2,6 +2,7 @@ ARG BASEOS
 ARG BASEVER
 ARG PG_FULL
 ARG PREFIX
+ARG LIBLLVM
 FROM ${PREFIX}/crunchy-pg-base:${BASEOS}-${PG_FULL}-${BASEVER}
 
 # ===== Early lines ordered for leveraging cache, reorder carefully =====
@@ -23,6 +24,7 @@ RUN yum -y install \
 	postgresql${PG_MAJOR//.}-server \
 	postgresql${PG_MAJOR//.}-plpython \
 	postgresql${PG_MAJOR//.}-plpython3 \
+	${LIBLLVM} \
 	psmisc \
 	rsync \
 	less \

--- a/centos7/Dockerfile.postgres.centos7
+++ b/centos7/Dockerfile.postgres.centos7
@@ -2,6 +2,7 @@ ARG BASEOS
 ARG BASEVER
 ARG PG_FULL
 ARG PREFIX
+ARG LIBLLVM
 FROM ${PREFIX}/crunchy-pg-base:${BASEOS}-${PG_FULL}-${BASEVER}
 
 # ===== Early lines ordered for leveraging cache, reorder carefully =====
@@ -17,12 +18,13 @@ RUN yum -y install \
 	--setopt=skip_missing_names_on_install=False \
 	openssh-clients \
 	openssh-server \
-        pgaudit${PG_MAJOR//.} \
+	pgaudit${PG_MAJOR//.} \
 	crunchy-backrest-${BACKREST_VER} \
 	postgresql${PG_MAJOR//.}-contrib \
 	postgresql${PG_MAJOR//.}-server \
 	postgresql${PG_MAJOR//.}-plpython \
 	postgresql${PG_MAJOR//.}-plpython3 \
+	${LIBLLVM} \
 	psmisc \
 	rsync \
 	&& yum -y clean all

--- a/rhel7/Dockerfile.postgres-ha.rhel7
+++ b/rhel7/Dockerfile.postgres-ha.rhel7
@@ -2,6 +2,7 @@ ARG BASEOS
 ARG BASEVER
 ARG PG_FULL
 ARG PREFIX
+ARG LIBLLVM
 FROM ${PREFIX}/crunchy-pg-base:${BASEOS}-${PG_FULL}-${BASEVER}
 
 # ===== Early lines ordered for leveraging cache, reorder carefully =====
@@ -27,6 +28,7 @@ RUN yum -y install \
 		postgresql${PG_MAJOR//.}-server \
 		postgresql${PG_MAJOR//.}-plpython \
 		postgresql${PG_MAJOR//.}-plpython3 \
+		${LIBLLVM} \
 		psmisc \
 		rsync \
 		less \

--- a/rhel7/Dockerfile.postgres.rhel7
+++ b/rhel7/Dockerfile.postgres.rhel7
@@ -2,6 +2,7 @@ ARG BASEOS
 ARG BASEVER
 ARG PG_FULL
 ARG PREFIX
+ARG LIBLLVM
 FROM ${PREFIX}/crunchy-pg-base:${BASEOS}-${PG_FULL}-${BASEVER}
 
 # ===== Early lines ordered for leveraging cache, reorder carefully =====
@@ -27,6 +28,7 @@ RUN yum -y install \
 		postgresql${PG_MAJOR//.}-server \
 		postgresql${PG_MAJOR//.}-plpython \
 		postgresql${PG_MAJOR//.}-plpython3 \
+		${LIBLLVM} \
 		psmisc \
 		rsync \
 	&& yum -y install \


### PR DESCRIPTION
This requires installing both libllvm and the package that enables
it for PostgreSQL versions after 11.

Per upsream PostgreSQL, JIT compilation, which uses libllvm, is
off by default in PostgreSQL 11, but enabled in PostgreSQL 12 and
beyond.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the new behavior (if this is a feature change)?**

Add support for libllvm in the PostgreSQL containers, which in turn allows JIT compilation.