### PR TITLE
Reduce the number of arguments to build images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,6 @@ CCP_POSTGIS_VERSION ?= 2.5
 IMGBUILDER ?= buildah
 IMGCMDSTEM=sudo --preserve-env buildah bud --layers $(SQUASH)
 DFSET=$(CCP_BASEOS)
-# This gets set with the name of the PostgreSQL LLVM package to use, but unset
-# if it is unsupported
-CCP_LIBLLVM="postgresql$(CCP_PGVERSION)-llvmjit"
 
 # Allows simplification of IMGBUILDER switching
 ifeq ("$(IMGBUILDER)","docker")
@@ -27,16 +24,6 @@ endif
 # Allows consolidation of ubi/rhel Dockerfile sets
 ifeq ("$(CCP_BASEOS)", "ubi7")
 	DFSET=rhel7
-endif
-
-# Allows for selectively installing libllvm to support JIT in versions of
-# PostgreSQL 11 or greater
-ifeq ("$(CCP_PGVERSION)", "10")
-	CCP_LIBLLVM=""
-else ifeq ("$(CCP_PGVERSION)", "9.6")
-	CCP_LIBLLVM=""
-else ifeq ("$(CCP_PGVERSION)", "9.5")
-	CCP_LIBLLVM=""
 endif
 
 
@@ -150,7 +137,6 @@ postgres-pgimg-build: cc-pg-base-image commands $(CCPROOT)/$(DFSET)/Dockerfile.p
 		--build-arg PG_MAJOR=$(CCP_PGVERSION) \
 		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
 		--build-arg BACKREST_VER=$(CCP_BACKREST_VERSION) \
-		--build-arg LIBLLVM=$(CCP_LIBLLVM) \
 		$(CCPROOT)
 
 postgres-pgimg-buildah: postgres-pgimg-build
@@ -170,7 +156,6 @@ postgres-gis-pgimg-build: postgres commands $(CCPROOT)/$(DFSET)/Dockerfile.postg
 		--build-arg PG_MAJOR=$(CCP_PGVERSION) \
 		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
 		--build-arg POSTGIS_LBL=$(subst .,,$(CCP_POSTGIS_VERSION)) \
-		--build-arg LIBLLVM=$(CCP_LIBLLVM) \
 		$(CCPROOT)
 
 postgres-gis-pgimg-buildah: postgres-gis-pgimg-build
@@ -191,7 +176,6 @@ postgres-ha-pgimg-build: cc-pg-base-image commands $(CCPROOT)/$(DFSET)/Dockerfil
 		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
 		--build-arg BACKREST_VER=$(CCP_BACKREST_VERSION) \
 		--build-arg PATRONI_VER=$(CCP_PATRONI_VERSION) \
-		--build-arg LIBLLVM=$(CCP_LIBLLVM) \
 		$(CCPROOT)
 
 postgres-ha-pgimg-buildah: postgres-ha-pgimg-build
@@ -211,7 +195,6 @@ postgres-gis-ha-pgimg-build: postgres-ha commands $(CCPROOT)/$(DFSET)/Dockerfile
 		--build-arg PG_MAJOR=$(CCP_PGVERSION) \
 		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
 		--build-arg POSTGIS_LBL=$(subst .,,$(CCP_POSTGIS_VERSION)) \
-		--build-arg LIBLLVM=$(CCP_LIBLLVM) \
 		$(CCPROOT)
 
 postgres-gis-ha-pgimg-buildah: postgres-gis-ha-pgimg-build

--- a/centos7/Dockerfile.postgres-ha.centos7
+++ b/centos7/Dockerfile.postgres-ha.centos7
@@ -2,7 +2,6 @@ ARG BASEOS
 ARG BASEVER
 ARG PG_FULL
 ARG PREFIX
-ARG LIBLLVM
 FROM ${PREFIX}/crunchy-pg-base:${BASEOS}-${PG_FULL}-${BASEVER}
 
 # ===== Early lines ordered for leveraging cache, reorder carefully =====
@@ -24,7 +23,7 @@ RUN yum -y install \
 	postgresql${PG_MAJOR//.}-server \
 	postgresql${PG_MAJOR//.}-plpython \
 	postgresql${PG_MAJOR//.}-plpython3 \
-	${LIBLLVM} \
+	$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
 	psmisc \
 	rsync \
 	less \

--- a/centos7/Dockerfile.postgres.centos7
+++ b/centos7/Dockerfile.postgres.centos7
@@ -2,7 +2,6 @@ ARG BASEOS
 ARG BASEVER
 ARG PG_FULL
 ARG PREFIX
-ARG LIBLLVM
 FROM ${PREFIX}/crunchy-pg-base:${BASEOS}-${PG_FULL}-${BASEVER}
 
 # ===== Early lines ordered for leveraging cache, reorder carefully =====
@@ -24,7 +23,7 @@ RUN yum -y install \
 	postgresql${PG_MAJOR//.}-server \
 	postgresql${PG_MAJOR//.}-plpython \
 	postgresql${PG_MAJOR//.}-plpython3 \
-	${LIBLLVM} \
+	$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
 	psmisc \
 	rsync \
 	&& yum -y clean all

--- a/rhel7/Dockerfile.postgres-ha.rhel7
+++ b/rhel7/Dockerfile.postgres-ha.rhel7
@@ -2,7 +2,6 @@ ARG BASEOS
 ARG BASEVER
 ARG PG_FULL
 ARG PREFIX
-ARG LIBLLVM
 FROM ${PREFIX}/crunchy-pg-base:${BASEOS}-${PG_FULL}-${BASEVER}
 
 # ===== Early lines ordered for leveraging cache, reorder carefully =====
@@ -28,7 +27,7 @@ RUN yum -y install \
 		postgresql${PG_MAJOR//.}-server \
 		postgresql${PG_MAJOR//.}-plpython \
 		postgresql${PG_MAJOR//.}-plpython3 \
-		${LIBLLVM} \
+		$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
 		psmisc \
 		rsync \
 		less \

--- a/rhel7/Dockerfile.postgres.rhel7
+++ b/rhel7/Dockerfile.postgres.rhel7
@@ -2,7 +2,6 @@ ARG BASEOS
 ARG BASEVER
 ARG PG_FULL
 ARG PREFIX
-ARG LIBLLVM
 FROM ${PREFIX}/crunchy-pg-base:${BASEOS}-${PG_FULL}-${BASEVER}
 
 # ===== Early lines ordered for leveraging cache, reorder carefully =====
@@ -28,7 +27,7 @@ RUN yum -y install \
 		postgresql${PG_MAJOR//.}-server \
 		postgresql${PG_MAJOR//.}-plpython \
 		postgresql${PG_MAJOR//.}-plpython3 \
-		${LIBLLVM} \
+		$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
 		psmisc \
 		rsync \
 	&& yum -y install \


### PR DESCRIPTION
With a bit of shell, the PG_MAJOR argument is sufficient to choose when to include the postgresql*-llvmjit package: PostgreSQL 11 or greater.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the new behavior (if this is a feature change)?**

One fewer make variables and image build arguments.