### PR TITLE
Add support for adding tablespaces to existing clusters

### DIFF
--- a/bin/postgres-ha/bootstrap/post-bootstrap.sh
+++ b/bin/postgres-ha/bootstrap/post-bootstrap.sh
@@ -38,21 +38,10 @@ sed -i "s/PGHA_DATABASE/$PGHA_DATABASE/g" "/tmp/setup.sql"
 echo_info "Running setup.sql file"
 psql < "/tmp/setup.sql"
 
-# If there are any tablespaces, create them as a convenience to the user
-IFS=',' read -r -a TABLESPACES <<< "${PGHA_TABLESPACES}"
-# Iterate through the list and both create the tablespace in the PostgreSQL
-# instance, and ensure the PGHA_USER is able to utilize them
-for TABLESPACE in "${TABLESPACES[@]}"
-do
-  TABLESPACE_PATH="/tablespaces/${TABLESPACE}/${TABLESPACE}"
-  echo_info "Adding \"${TABLESPACE}\" at location \"${TABLESPACE_PATH}\" to PostgreSQL"
-
-  TABLESESPACE_SQL="CREATE TABLESPACE \"${TABLESPACE}\" LOCATION '${TABLESPACE_PATH}';"
-  psql -c "${TABLESESPACE_SQL}"
-
-  TABLESPACE_GRANT_SQL="GRANT CREATE ON TABLESPACE \"${TABLESPACE}\" TO \"${PGHA_USER}\";"
-  psql -c "${TABLESPACE_GRANT_SQL}"
-done
+# If there are any tablespaces, create them as a convenience to the user, both
+# the directories and the PostgreSQL objects
+source /opt/cpm/bin/common/pgha-tablespaces.sh
+tablespaces_create_postgresql_objects "${PGHA_USER}"
 
 # Run audit.sql file if exists
 if [[ -f "/pgconf/audit.sql" ]]

--- a/bin/postgres-ha/bootstrap/pre-bootstrap.sh
+++ b/bin/postgres-ha/bootstrap/pre-bootstrap.sh
@@ -412,22 +412,9 @@ build_bootstrap_config_file
 mkdir -p "${PATRONI_POSTGRESQL_DATA_DIR}"
 chmod 0700 "${PATRONI_POSTGRESQL_DATA_DIR}"
 
-# If a list of tablespaces has been passed in, create these names in the
-#tablespace directory, which are in the format:
-#
-# tablespace1,tablespace2
-IFS=',' read -r -a TABLESPACES <<< "${PGHA_TABLESPACES}"
-# Next, iterate through the list, especially if any tablespaces were found
-for TABLESPACE in "${TABLESPACES[@]}"
-do
-  TABLESPACE_PATH="/tablespaces/${TABLESPACE}/${TABLESPACE}"
-  echo_info "create directory for tablespace \"${TABLESPACE}\" on mount point \"${TABLESPACE_PATH}\""
-  # create the folder that the tablespace will be mounted to as well as set its
-  # permissions correctly. This has to go "two deep" in order to account for
-  # the direcory structure of the mounted file system
-  mkdir -p "${TABLESPACE_PATH}"
-  chmod 0700 "${TABLESPACE_PATH}"
-done
+# create any tablespace directories, if they have not been created yet
+source /opt/cpm/bin/common/pgha-tablespaces.sh
+tablespaces_create_directory
 
 echo_info "postgres-ha pre-bootstrap complete!  The following configuration will be utilized to initialize " \
 "this postgres-ha node:"

--- a/bin/postgres-ha/common/pgha-tablespaces.sh
+++ b/bin/postgres-ha/common/pgha-tablespaces.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Copyright 2020 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These functions determine if any tablespaces should be created. this involves
+# ensuring that the directory is created on the disk
+
+# *****************************************************************************
+# The list of tablespaces is available in the PGHA_TABLESPACES variable in the
+# format:
+#
+# "tablespace1,tablespace2"
+#
+# This needs to be parsed out
+# *****************************************************************************
+
+# tablespaces_path returns the path used for a tablespace
+# accept an argument of a tablespace name
+function tablespaces_path() {
+  tablespace=$1
+
+  echo "/tablespaces/${tablespace}/${tablespace}"
+}
+
+# tablespaces_create_directory creates any directories on the mount for  all
+# of the tablespaces that are available, if the directory  has not already been
+# created
+function tablespaces_create_directory() {
+  IFS=',' read -r -a TABLESPACES <<< "${PGHA_TABLESPACES}"
+
+  # iterate through the list of tablespaces if any are found
+  for TABLESPACE in "${TABLESPACES[@]}"
+  do
+    TABLESPACE_PATH=$(tablespaces_path "${TABLESPACE}")
+
+    # only create the tablespace if the directory does not exist
+    if [[ ! -d "${TABLESPACE_PATH}" ]]
+    then
+      echo_info "create directory for tablespace \"${TABLESPACE}\" on mount point \"${TABLESPACE_PATH}\""
+
+      # create the folder that the tablespace will be mounted to as well as set its
+      # permissions correctly. This has to go "two deep" in order to account for
+      # the direcory structure of the mounted file system
+      mkdir -p "${TABLESPACE_PATH}"
+      chmod 0700 "${TABLESPACE_PATH}"
+    fi
+  done
+}
+
+# tablespaces_create_postgresql_objects updates PostgreSQL to set up all of the
+# tablespace objects within the database, if the object does not exist
+#
+# takes one argument: PGHA_USER or a user to create a grant on the tablespace
+# for
+function tablespaces_create_postgresql_objects() {
+  user=$1
+  IFS=',' read -r -a TABLESPACES <<< "${PGHA_TABLESPACES}"
+
+  # iterate through the list of tablespaces if any are found and try to create
+  for TABLESPACE in "${TABLESPACES[@]}"
+  do
+    sql="SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_tablespace WHERE spcname = '${TABLESPACE}')"
+    tablespace_exists=$(psql -At -c "${sql}")
+
+    # only try to create the tablespace if it does not already exist
+    if [[ "${tablespace_exists}" == "f" ]]
+    then
+      TABLESPACE_PATH=$(tablespaces_path "${TABLESPACE}")
+
+      echo_info "Adding \"${TABLESPACE}\" at location \"${TABLESPACE_PATH}\" to PostgreSQL"
+
+      # first, create the tablespace
+      sql="CREATE TABLESPACE \"${TABLESPACE}\" LOCATION '${TABLESPACE_PATH}';"
+      psql -c "${sql}"
+
+      # then, ensure the default user is able to create objects on the
+      # tablespace
+      sql="GRANT CREATE ON TABLESPACE \"${TABLESPACE}\" TO \"${user}\";"
+      psql -c "${sql}"
+    fi
+  done
+}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the new behavior (if this is a feature change)?**

All of the PostgreSQL instances in a cluster need to create
the directory in the mounted volume where the new tablespace
will exist, as well as create the tablespace object in the
PostgreSQL cluster.

This includes a few refactors for tablespace support that was
introduced in 3dc9c8e

**Other information**:

Issue: [ch7232]
CrunchyData/postgres-operator#1357