### PR TITLE
Updates for PostgreSQL Operator Enhanced Cluster Configuration

### DIFF
--- a/bin/install-deps.sh
+++ b/bin/install-deps.sh
@@ -20,7 +20,7 @@ POSTGRES_EXPORTER_VERSION=0.7.0
 PGMONITOR_COMMIT='v3.2'
 OPENSHIFT_CLIENT='https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz'
 CERTSTRAP_VERSION=1.1.1
-YQ_VERSION=2.4.0
+YQ_VERSION=3.3.0
 
 sudo yum -y install net-tools bind-utils wget unzip git
 

--- a/bin/postgres-ha/bootstrap/pre-bootstrap.sh
+++ b/bin/postgres-ha/bootstrap/pre-bootstrap.sh
@@ -270,12 +270,6 @@ build_bootstrap_config_file() {
     pghba_file="/tmp/postgres-ha-pghba.yaml"
     cat "/opt/cpm/conf/postgres-ha-pghba-bootstrap.yaml" >> "${pghba_file}"
 
-    if [[ -f "/pgconf/postgresql.conf" ]]
-    then
-        echo_info "Setting custom 'postgresql.conf' as base config using 'custom_conf'"
-        /opt/cpm/bin/yq m -i -x "${bootstrap_file}" "/opt/cpm/conf/postgres-ha-custom-pgconf.yaml"
-    fi
-
     if [[ "${PGHA_BASE_BOOTSTRAP_CONFIG}" == "true" ]]
     then
         echo_info "Applying base bootstrap config to postgres-ha configuration"

--- a/bin/postgres-ha/common/pgha-reload-local.sh
+++ b/bin/postgres-ha/common/pgha-reload-local.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Copyright 2020 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /opt/cpm/bin/common/common_lib.sh
+
+bootstrap_file="/tmp/postgres-ha-bootstrap.yaml"
+bootstrap_file_bak="${bootstrap_file}.bak"
+
+lock_file="${bootstrap_file}.lock"
+
+# the first parameter passed in is the configMap content for the local server that will
+# be merged into the local configuration file
+conf_content="${1?}"
+
+# a temporary file used to store the conf that needs to be merged into the current local 
+# configuration
+merge_file="${bootstrap_file}.merge"
+
+patroni_port="${2?}"
+
+# cleans up any resources and releases the file lock
+cleanup() {
+    rm -f "${lock_file}" 
+}
+
+# reverts any changes to the local config file, then handles the error and exits
+# accordingly
+handle_error_and_revert() {
+    if [[ ${1?} != 0 ]]
+    then
+        mv "${bootstrap_file_bak}" "${bootstrap_file}" 2>/dev/null
+        cleanup
+        echo_err "Error reloading local config: ${2?}"
+        exit "${1?}"
+    fi
+}
+
+# if the lock file already exists, then exit
+if [[ -f "${lock_file}" ]]
+then
+    echo_err "Unable to reload configuration, lock already taken"
+    exit 1
+fi
+
+# grab the lock file
+touch "${lock_file}"
+
+# if no diff's detected when comparing the server's configMap content to it's current local
+# config, then just exit.  Otherwise proceed with updating and reloading the config.
+if echo "${conf_content}" | /opt/cpm/bin/yq x --tojson - "${bootstrap_file}" postgresql
+then
+    cleanup
+    exit 0
+fi
+
+echo_info "Reload Config: Detected config change, reloading local configuration"
+
+# backup the current patroni config file for the local node
+cp "${bootstrap_file}" "${bootstrap_file_bak}"
+handle_error_and_revert "$?" "Unable backup configuration"
+
+# now merge the files conf_file
+echo "${conf_content}" > "${merge_file}"
+/opt/cpm/bin/yq d -i "${bootstrap_file}" postgresql && \
+    /opt/cpm/bin/yq m -i "${bootstrap_file}" "${merge_file}"
+handle_error_and_revert "$?" "Unable to merge files"
+
+# Now issue a patroni reload
+curl -s -XPOST "http://localhost:${patroni_port}/reload"
+handle_error_and_revert "$?" "Unable to reload local configuration"
+
+echo_info "Reload Config: Successfully scheduled config reload"
+
+cleanup

--- a/conf/postgres-ha/postgres-ha-custom-pgconf.yaml
+++ b/conf/postgres-ha/postgres-ha-custom-pgconf.yaml
@@ -1,3 +1,0 @@
----
-postgresql:
-  custom_conf: /pgconf/postgresql.conf


### PR DESCRIPTION
This PR includes updates to support enhanced cluster configuration within the PostgreSQL Operator.  Specifically, a script is now included for reloading the local configuration for a specific database node within a PG cluster.  This script is responsible for merging new/modified  configuration settings into the node's local configuration file, and then issuing a Patroni `reload` in order to apply those changes to the local node.

Additionally (and due to the new configMap-based approach for configuring a PG cluster included in the PostgreSQL Operator), support for the Patroni `custom_conf` setting has been removed.  Instead, all configuration will be applied via Patroni configuration, allowing PG settings to be easily added, modified, and/or deleted throughout a cluster's lifetime.

Please note that this PR also bumps the version of `yq` included in the `crunchy-postgres-ha` container to `v3.3.0`.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Modifying and reloading a node's local config must be done manually.

[ch7646]

**What is the new behavior (if this is a feature change)?**

A script exists that can be utilized to modify and reload a local node's config.

**Other information**:

N/A