### PR TITLE
Upgrade + PostgreSQL Base Image Fixes

### DIFF
--- a/centos7/Dockerfile.pg-base.centos7
+++ b/centos7/Dockerfile.pg-base.centos7
@@ -20,5 +20,7 @@ RUN rpm --import RPM-GPG-KEY-crunchydata*
 
 RUN yum -y install \
 		--setopt=skip_missing_names_on_install=False \
+		--disablerepo=crunchypg* \
+		--enablerepo="crunchypg${PG_LBL}" \
 		postgresql${PG_LBL} \
 	&& yum -y clean all

--- a/centos7/Dockerfile.upgrade.centos7
+++ b/centos7/Dockerfile.upgrade.centos7
@@ -20,11 +20,11 @@ ADD conf/crunchypg*.repo /etc/yum.repos.d/
 RUN yum -y install \
 	--setopt=skip_missing_names_on_install=False \
 	--disablerepo=crunchypg* \
-	--enablerepo="crunchypg${PG_MAJOR}" \
-	"postgresql${PG_MAJOR}" \
-	"postgresql${PG_MAJOR}-contrib" \
-	"postgresql${PG_MAJOR}-server" \
-	"pgaudit${PG_MAJOR}*" \
+	--enablerepo="crunchypg${PG_MAJOR//.}" \
+	"postgresql${PG_MAJOR//.}" \
+	"postgresql${PG_MAJOR//.}-contrib" \
+	"postgresql${PG_MAJOR//.}-server" \
+	"pgaudit${PG_MAJOR//.}*" \
 	unzip \
 	&& yum -y clean all
 

--- a/rhel7/Dockerfile.pg-base.rhel7
+++ b/rhel7/Dockerfile.pg-base.rhel7
@@ -25,5 +25,7 @@ RUN rpm --import CRUNCHY-GPG-KEY.public
 
 RUN yum -y install \
 		--setopt=skip_missing_names_on_install=False \
+		--disablerepo=crunchypg* \
+		--enablerepo="crunchypg${PG_LBL}" \
 		postgresql${PG_LBL} \
 	&& yum -y clean all

--- a/rhel7/Dockerfile.upgrade.rhel7
+++ b/rhel7/Dockerfile.upgrade.rhel7
@@ -20,11 +20,11 @@ ADD conf/crunchypg*.repo /etc/yum.repos.d/
 RUN yum -y install \
 	--setopt=skip_missing_names_on_install=False \
 	--disablerepo=crunchypg* \
-	--enablerepo="crunchypg${PG_MAJOR}" \
-	"postgresql${PG_MAJOR}" \
-	"postgresql${PG_MAJOR}-contrib" \
-	"postgresql${PG_MAJOR}-server" \
-	"pgaudit${PG_MAJOR}*" \
+	--enablerepo="crunchypg${PG_MAJOR//.}" \
+	"postgresql${PG_MAJOR//.}" \
+	"postgresql${PG_MAJOR//.}-contrib" \
+	"postgresql${PG_MAJOR//.}-server" \
+	"pgaudit${PG_MAJOR//.}*" \
 	unzip \
 	&& yum -y clean all
 


### PR DESCRIPTION
## Ensure upgrade consolidation works for PostgreSQL 9.6

The build argument PG_MAJOR container a "." in it, which did not
mesh correctly with the repo file. This subs out the "."

## Set proper repository enablement in PostgreSQL base container

This ensures that only the appropriate base PostgreSQL files are
installed in a given environment.