### PR TITLE
Set /tablespaces directory to same permissions as all the others

### DIFF
--- a/centos7/Dockerfile.postgres-ha.centos7
+++ b/centos7/Dockerfile.postgres-ha.centos7
@@ -64,8 +64,7 @@ RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backrestrepo \
 RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
 	/pgdata /pgwal /pgconf /backrestrepo /crunchyadm /tablespaces &&  \
 	chmod -R g=u /opt/cpm /var/lib/pgsql \
-	/pgdata /pgwal /pgconf /backrestrepo /crunchyadm && \
-	chmod -R u=rwx,go= /tablespaces
+	/pgdata /pgwal /pgconf /backrestrepo /crunchyadm /tablespaces
 
 # open up the postgres port
 EXPOSE 5432

--- a/rhel7/Dockerfile.postgres-ha.rhel7
+++ b/rhel7/Dockerfile.postgres-ha.rhel7
@@ -71,8 +71,7 @@ RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backrestrepo \
 RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
 	/pgdata /pgwal /pgconf /backrestrepo /crunchyadm /tablespaces &&  \
 	chmod -R g=u /opt/cpm /var/lib/pgsql \
-	/pgdata /pgwal /pgconf /backrestrepo /crunchyadm && \
-	chmod -R u=rwx,go= /tablespaces
+	/pgdata /pgwal /pgconf /backrestrepo /crunchyadm /tablespaces
 
 # open up the postgres port
 EXPOSE 5432


### PR DESCRIPTION
Locking it down to "pgdata" permissions (0700) caused this to break
in certain environments, so this ensures the group is able to access
the directory.

Co-authored-by: Andrew L'Ecuyer <andrew.lecuyer@crunchydata.com>
Issue: [ch8068]