### PR TITLE
Reduce Use of Manual Database Starts

### DIFF
--- a/bin/postgres-ha/bootstrap/post-bootstrap.sh
+++ b/bin/postgres-ha/bootstrap/post-bootstrap.sh
@@ -45,12 +45,4 @@ then
     psql < "/pgconf/audit.sql"
 fi
 
-# Apply enhancement modules
-echo_info "Applying enahncement modules"
-for module in /opt/cpm/bin/modules/*.sh
-do
-    echo_info "Applying module ${module}"
-    source "${module}"
-done
-
 echo_info "postgres-ha post-bootstrap complete"

--- a/bin/postgres-ha/callbacks/pgha-on-role-change.sh
+++ b/bin/postgres-ha/callbacks/pgha-on-role-change.sh
@@ -42,7 +42,7 @@ source /opt/cpm/bin/pgbackrest/pgbackrest-set-env.sh
 # is being utilized (e.g. with the PostgreSQL Operator), then this process will be handled
 # externally (e.g. within the PostgreSQL Operator when the repo host is updated following the
 # promotion of a replica to primary)
-if [[ "${role}" ==  "master" && "${PGHA_PGBACKREST}" == "true" ]]
+if [[ -f "/crunchyadm/pgha_initialized" && "${role}" ==  "master" && "${PGHA_PGBACKREST}" == "true" ]]
 then
     curl -s -XPATCH -d '{"tags":{"primary_on_role_change":"true"}}' "localhost:${PGHA_PATRONI_PORT}/config"
     if [[ ! -v PGBACKREST_REPO1_HOST && ! -v PGBACKREST_REPO_HOST ]]

--- a/bin/postgres-ha/modules/crunchyadm.sh
+++ b/bin/postgres-ha/modules/crunchyadm.sh
@@ -17,8 +17,8 @@ username="crunchyadm"
 
 # Create the crunchyadm user if it doesn't already exist
 if [[ "${PGHA_CRUNCHYADM}" == "true" ]] &&
-    ! psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='${username}'" | grep -q 1
+    [[ $(psql -v "username=${username}" -tA -f - <<< "SELECT 1 FROM pg_roles WHERE rolname=:'username'") != 1 ]]
 then
     echo_info "Creating user ${username}"
-    psql -c "CREATE USER ${username} LOGIN;"
+    psql -v "username=${username}" -tA -f - <<< "CREATE ROLE :username LOGIN"
 fi

--- a/bin/postgres-ha/modules/crunchyadm.sh
+++ b/bin/postgres-ha/modules/crunchyadm.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2020 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+username="crunchyadm"
+
+# Create the crunchyadm user if it doesn't already exist
+if [[ "${PGHA_CRUNCHYADM}" == "true" ]] &&
+    ! psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='${username}'" | grep -q 1
+then
+    echo_info "Creating user ${username}"
+    psql -c "CREATE USER ${username} LOGIN;"
+fi

--- a/bin/postgres-ha/modules/crunchyadm.sh
+++ b/bin/postgres-ha/modules/crunchyadm.sh
@@ -20,5 +20,5 @@ if [[ "${PGHA_CRUNCHYADM}" == "true" ]] &&
     [[ $(psql -v "username=${username}" -tA -f - <<< "SELECT 1 FROM pg_roles WHERE rolname=:'username'") != 1 ]]
 then
     echo_info "Creating user ${username}"
-    psql -v "username=${username}" -tA -f - <<< "CREATE ROLE :username LOGIN"
+    psql -v "username=${username}" -tA -f - <<< 'CREATE ROLE :"username" LOGIN'
 fi

--- a/bin/postgres-ha/modules/pgmonitor.sh
+++ b/bin/postgres-ha/modules/pgmonitor.sh
@@ -51,7 +51,7 @@ then
             < "/tmp/setup_pg.sql" > /tmp/pgmonitor-setup.stdout 2> /tmp/pgmonitor-setup.stderr
 
         psql -U postgres --port="${PG_PRIMARY_PORT}" -d postgres \
-            -c "ALTER ROLE ccp_monitoring PASSWORD '${PGMONITOR_PASSWORD?}'" \
+            -c "SET log_statement TO 'none'; ALTER ROLE ccp_monitoring PASSWORD '${PGMONITOR_PASSWORD?}'" \
             > /tmp/pgmonitor-alter-role.stdout 2> /tmp/pgmonitor-alter-role.stderr
     fi
 fi

--- a/bin/postgres-ha/modules/pgmonitor.sh
+++ b/bin/postgres-ha/modules/pgmonitor.sh
@@ -15,43 +15,39 @@
 
 if [[ -v PGMONITOR_PASSWORD ]]
 then
-    if [[ ${PGHA_INIT?} == "true" ]]
+    echo_info "PGMONITOR_PASSWORD detected.  Enabling pgMonitor support."
+
+    source /opt/cpm/bin/common/common_lib.sh
+    export PGHOST="/tmp"
+
+    test_server "postgres" "${PGHOST?}" "${PGHA_PG_PORT}" "postgres"
+    VERSION=$(psql --port="${PG_PRIMARY_PORT}" -d postgres -qtAX -c "SELECT current_setting('server_version_num')")
+
+    if (( ${VERSION?} >= 90500 )) && (( ${VERSION?} < 90600 ))
     then
-
-        echo_info "PGMONITOR_PASSWORD detected.  Enabling pgMonitor support."
-
-        source /opt/cpm/bin/common/common_lib.sh
-        export PGHOST="/tmp"
-
-        test_server "postgres" "${PGHOST?}" "${PGHA_PG_PORT}" "postgres"
-        VERSION=$(psql --port="${PG_PRIMARY_PORT}" -d postgres -qtAX -c "SELECT current_setting('server_version_num')")
-
-        if (( ${VERSION?} >= 90500 )) && (( ${VERSION?} < 90600 ))
-        then
-            function_file='/opt/cpm/bin/modules/pgexporter/setup_pg95.sql'
-        elif (( ${VERSION?} >= 90600 )) && (( ${VERSION?} < 100000 ))
-        then
-            function_file='/opt/cpm/bin/modules/pgexporter/setup_pg96.sql'
-        elif (( ${VERSION?} >= 100000 )) && (( ${VERSION?} < 110000 ))
-        then
-            function_file='/opt/cpm/bin/modules/pgexporter/setup_pg10.sql'
-        elif (( ${VERSION?} >= 110000 ))
-        then
-            function_file='/opt/cpm/bin/modules/pgexporter/setup_pg11.sql'
-        else
-            echo_err "Unknown or unsupported version of PostgreSQL.  Exiting.."
-            exit 1
-        fi
-
-        echo_info "Using setup file '${function_file}' for pgMonitor"
-        cp "${function_file}" "/tmp/setup_pg.sql"
-        sed -i "s/\/usr\/bin\/pgbackrest-info.sh/\/opt\/cpm\/bin\/pgbackrest\/pgbackrest_info.sh/g" "/tmp/setup_pg.sql"
-
-        psql -U postgres --port="${PG_PRIMARY_PORT}" -d postgres \
-            < "/tmp/setup_pg.sql" > /tmp/pgmonitor-setup.stdout 2> /tmp/pgmonitor-setup.stderr
-
-        psql -U postgres --port="${PG_PRIMARY_PORT}" -d postgres \
-            -c "SET log_statement TO 'none'; ALTER ROLE ccp_monitoring PASSWORD '${PGMONITOR_PASSWORD?}'" \
-            > /tmp/pgmonitor-alter-role.stdout 2> /tmp/pgmonitor-alter-role.stderr
+        function_file='/opt/cpm/bin/modules/pgexporter/setup_pg95.sql'
+    elif (( ${VERSION?} >= 90600 )) && (( ${VERSION?} < 100000 ))
+    then
+        function_file='/opt/cpm/bin/modules/pgexporter/setup_pg96.sql'
+    elif (( ${VERSION?} >= 100000 )) && (( ${VERSION?} < 110000 ))
+    then
+        function_file='/opt/cpm/bin/modules/pgexporter/setup_pg10.sql'
+    elif (( ${VERSION?} >= 110000 ))
+    then
+        function_file='/opt/cpm/bin/modules/pgexporter/setup_pg11.sql'
+    else
+        echo_err "Unknown or unsupported version of PostgreSQL.  Exiting.."
+        exit 1
     fi
+
+    echo_info "Using setup file '${function_file}' for pgMonitor"
+    cp "${function_file}" "/tmp/setup_pg.sql"
+    sed -i "s/\/usr\/bin\/pgbackrest-info.sh/\/opt\/cpm\/bin\/pgbackrest\/pgbackrest_info.sh/g" "/tmp/setup_pg.sql"
+
+    psql -U postgres --port="${PG_PRIMARY_PORT}" -d postgres \
+        < "/tmp/setup_pg.sql" > /tmp/pgmonitor-setup.stdout 2> /tmp/pgmonitor-setup.stderr
+
+    psql -U postgres --port="${PG_PRIMARY_PORT}" -d postgres \
+        -c "SET log_statement TO 'none'; ALTER ROLE ccp_monitoring PASSWORD '${PGMONITOR_PASSWORD?}'" \
+        > /tmp/pgmonitor-alter-role.stdout 2> /tmp/pgmonitor-alter-role.stderr
 fi

--- a/bin/postgres-ha/modules/pgmonitor.sh
+++ b/bin/postgres-ha/modules/pgmonitor.sh
@@ -47,18 +47,11 @@ then
         cp "${function_file}" "/tmp/setup_pg.sql"
         sed -i "s/\/usr\/bin\/pgbackrest-info.sh/\/opt\/cpm\/bin\/pgbackrest\/pgbackrest_info.sh/g" "/tmp/setup_pg.sql"
 
-        # TODO Add ON_ERROR_STOP and single transaction when
-        # upstream pgmonitor changes setup SQL to check if the
-        # role exists prior to creating it.
         psql -U postgres --port="${PG_PRIMARY_PORT}" -d postgres \
             < "/tmp/setup_pg.sql" > /tmp/pgmonitor-setup.stdout 2> /tmp/pgmonitor-setup.stderr
-
-        #err_check "$?" "pgMonitor Setup" "Could not load pgMonitor functions: \n$(cat /tmp/pgmonitor.stderr)"
 
         psql -U postgres --port="${PG_PRIMARY_PORT}" -d postgres \
             -c "ALTER ROLE ccp_monitoring PASSWORD '${PGMONITOR_PASSWORD?}'" \
             > /tmp/pgmonitor-alter-role.stdout 2> /tmp/pgmonitor-alter-role.stderr
-
-        #err_check "$?" "pgMonitor User Setup" "Could not alter ccp_monitor user's password: \n$(cat /tmp/pgmonitor.stderr)"
     fi
 fi


### PR DESCRIPTION
With this change, the database will only be manually started under the following conditions:

- A PITR is detected
- A non-Patroni standalone database is being converted to a Patroni cluster

Otherwise, in all other scenarios Patroni start the database, handling any recovery procedures as needed.

To auto-detect whether or a PITR is being performed, the bootstrap script for the HA container now checks to see if a `recovery.signal` (PG v12 and above) or a `recovery.conf` (PG v11 and below) is present, along with whether not any `recovery_target` settings are configured for the restore.  To detect if a non-Patroni standalone database is being converted to a Patroni cluster, the bootstrap script checks to see if there is an existing `PGDATA` directory which does not contain a `patroni.dynamic.json`.  If this file is present, an existing Patroni cluster is assumed and Patroni will handle the recovery.

Additionally, `post-existing-init.sql` is now only run when converting a standalone database to a Patroni cluster, and the `pgha-on-role-change.sh` now exits immediately (and gracefully) if the cluster has not yet been initialized.  A check is also now in place to see if the `crunchyadm` user already exists prior to attempting to create it.  And finally, all enhancement modules (pgMonitor, pgAudit Analyze, etc.) are now always run (if enabled) when initializing a primary, regardless of whether that primary is being initialized as part of a brand new database, or if it is being initialized as part of a clone or restore workflow.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The database is started manually prior to handing over to Patroni in all "init" scenarios, such as when performing a restore of any type, when cloning, etc.

**What is the new behavior (if this is a feature change)?**

The database is only started manually when performing a PITR (or when a non-Patroni standalone database is being converted to a Patroni cluster).  When performing a full restore or when cloning Patroni handles the restore.

**Other information**:

N/A