### PR TITLE
Move pg_dump to be built for each PostgreSQL version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ endif
 all: cc-pg-base-image pgimages pg-independent-images
 
 # Build images that either don't have a PG dependency or using the latest PG version is all that is needed
-pg-independent-images: backup pgadmin4 pgbadger pgbasebackuprestore pgbench pgbouncer pgdump pgpool grafana prometheus
+pg-independent-images: backup pgadmin4 pgbadger pgbasebackuprestore pgbench pgbouncer pgpool grafana prometheus
 
 # Build images that require a specific postgres version - ordered for potential concurrent benefits
-pgimages: postgres postgres-ha backrestrestore collect crunchyadm postgres-gis postgres-gis-ha pgrestore upgrade
+pgimages: postgres postgres-ha backrestrestore collect crunchyadm postgres-gis postgres-gis-ha pgdump pgrestore upgrade
 
 
 #===========================================


### PR DESCRIPTION
Per the PostgreSQL documentation, the pg_dump binary should be
aligned with the version of PostgreSQL that it is dumping from,
similar to the behavior of pg_restore.