### PR TITLE
Enable replication connections to use certificate-based authentication

### DIFF
--- a/conf/postgres-ha/postgres-ha-pghba-tls-auth.yaml
+++ b/conf/postgres-ha/postgres-ha-pghba-tls-auth.yaml
@@ -1,0 +1,6 @@
+---
+postgresql:
+  pg_hba:
+    - hostssl replication PATRONI_REPLICATION_USERNAME 0.0.0.0/0 cert
+    - hostssl all PATRONI_REPLICATION_USERNAME 0.0.0.0/0 reject
+    - hostssl all all 0.0.0.0/0 md5


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the new behavior (if this is a feature change)?**

[Certificate-based authentication](https://www.postgresql.org/docs/current/auth-cert.html) is a powerful PostgreSQL feature
that allows for a PostgreSQL client to authenticate using a TLS
certificate. While there are a variety of permutations for this can be
set up, we can at least create a standardized way for enabling the
replication connection to authenticate with a certificate, as we do have
a known certificate authority.

This introduces support for certificate-based authentication for the
replication user, presuming that the CN on the certificate is that of
`PATRONI_REPLICATION_USERNAME` (default is "primaryuser"). If the CN
on the certificate is different, one must include a "pg_ident"
customization as part of their configuration.

If TLS is enabled on the container and a Secret that contains the
replication user's TLS credentials is mounted to the container, then
certificate-based authentication for this user is automatically set up.
As the CA must be appropriately mounted for this to work, we are able
to set PGSSLMODE to use "verify-ca" by default, to include a stronger
guarnatee of validity between the instances (though not as strong as
"verify-full", but we cannot make that level of assumption about the
environment).

Issue: [ch8387]