### PR TITLE
Remove gcc from container images

### DIFF
--- a/centos7/Dockerfile.pgadmin4.centos7
+++ b/centos7/Dockerfile.pgadmin4.centos7
@@ -21,7 +21,6 @@ RUN yum -y install \
 
 RUN yum -y install \
 		--setopt=skip_missing_names_on_install=False \
-		gcc \
 		mod_ssl \
 		mod_wsgi \
 		openssl \

--- a/centos7/Dockerfile.postgres-ha.centos7
+++ b/centos7/Dockerfile.postgres-ha.centos7
@@ -41,14 +41,13 @@ LABEL name="postgres-ha" \
 
 RUN yum -y install \
 	--setopt=skip_missing_names_on_install=False \
-	gcc \
-	python3-devel \
 	python3-pip \
+	python3-psutil \
 	python3-psycopg2 \
 	&& yum -y clean all
 
 # install patroni for Kube
-RUN pip3 install --upgrade setuptools python-dateutil \
+RUN pip3 install --upgrade python-dateutil \
  && pip3 install patroni[kubernetes]=="${PATRONI_VER}"
 
 RUN useradd crunchyadm -g 0 -u 17

--- a/rhel7/Dockerfile.pgadmin4.rhel7
+++ b/rhel7/Dockerfile.pgadmin4.rhel7
@@ -16,7 +16,6 @@ LABEL name="pgadmin4" \
 RUN yum -y install \
 		--setopt=skip_missing_names_on_install=False \
 		--enablerepo="epel,rhel-7-server-devtools-rpms,rhel-7-server-extras-rpms,rhel-7-server-optional-rpms" \
-		gcc \
 		mod_ssl \
 		mod_wsgi \
 		openssl \

--- a/rhel7/Dockerfile.postgres-ha.rhel7
+++ b/rhel7/Dockerfile.postgres-ha.rhel7
@@ -48,14 +48,13 @@ LABEL name="postgres-ha" \
 RUN yum -y install \
 	--enablerepo="epel,rhel-7-server-optional-rpms" \
 	--setopt=skip_missing_names_on_install=False \
-	gcc \
-	python3-devel \
 	python3-pip \
+	python3-psutil \
 	python3-psycopg2 \
 	&& yum -y clean all --enablerepo="epel,rhel-7-server-optional-rpms"
 
 # install patroni for Kube
-RUN pip3 install --upgrade setuptools python-dateutil \
+RUN pip3 install --upgrade python-dateutil \
 	&& pip3 install patroni[kubernetes]=="${PATRONI_VER}"
 
 RUN useradd crunchyadm -g 0 -u 17


### PR DESCRIPTION
This adds in a dependency that is used to install Patroni and
eliminates the need to include source files and gcc.