### PR TITLE
Support multiple PostGIS versions per PostgreSQL version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CCP_PG_FULLVERSION ?= 12.3
 CCP_PATRONI_VERSION ?= 1.6.5
 CCP_BACKREST_VERSION ?= 2.25
 CCP_VERSION ?= 4.3.2
-CCP_POSTGIS_VERSION ?= 2.5
+CCP_POSTGIS_VERSION ?= 3.0
 
 # Valid values: buildah (default), docker
 IMGBUILDER ?= buildah
@@ -149,7 +149,7 @@ postgres-pgimg-docker: postgres-pgimg-build
 postgres-gis-pgimg-build: postgres commands $(CCPROOT)/$(DFSET)/Dockerfile.postgres-gis.$(DFSET)
 	$(IMGCMDSTEM) \
 		-f $(CCPROOT)/$(DFSET)/Dockerfile.postgres-gis.$(DFSET) \
-		-t $(CCP_IMAGE_PREFIX)/crunchy-postgres-gis:$(CCP_IMAGE_TAG) \
+		-t $(CCP_IMAGE_PREFIX)/crunchy-postgres-gis:$(CCP_POSTGIS_IMAGE_TAG) \
 		--build-arg BASEOS=$(CCP_BASEOS) \
 		--build-arg BASEVER=$(CCP_VERSION) \
 		--build-arg PG_FULL=$(CCP_PG_FULLVERSION) \
@@ -159,7 +159,7 @@ postgres-gis-pgimg-build: postgres commands $(CCPROOT)/$(DFSET)/Dockerfile.postg
 		$(CCPROOT)
 
 postgres-gis-pgimg-buildah: postgres-gis-pgimg-build
-	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-postgres-gis:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-postgres-gis:$(CCP_IMAGE_TAG)
+	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-postgres-gis:$(CCP_POSTGIS_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-postgres-gis:$(CCP_POSTGIS_IMAGE_TAG)
 
 postgres-gis-pgimg-docker: postgres-gis-pgimg-build
 
@@ -188,7 +188,7 @@ postgres-ha-pgimg-docker: postgres-ha-pgimg-build
 postgres-gis-ha-pgimg-build: postgres-ha commands $(CCPROOT)/$(DFSET)/Dockerfile.postgres-gis-ha.$(DFSET)
 	$(IMGCMDSTEM) \
 		-f $(CCPROOT)/$(DFSET)/Dockerfile.postgres-gis-ha.$(DFSET) \
-		-t $(CCP_IMAGE_PREFIX)/crunchy-postgres-gis-ha:$(CCP_IMAGE_TAG) \
+		-t $(CCP_IMAGE_PREFIX)/crunchy-postgres-gis-ha:$(CCP_POSTGIS_IMAGE_TAG) \
 		--build-arg BASEOS=$(CCP_BASEOS) \
 		--build-arg BASEVER=$(CCP_VERSION) \
 		--build-arg PG_FULL=$(CCP_PG_FULLVERSION) \
@@ -198,7 +198,7 @@ postgres-gis-ha-pgimg-build: postgres-ha commands $(CCPROOT)/$(DFSET)/Dockerfile
 		$(CCPROOT)
 
 postgres-gis-ha-pgimg-buildah: postgres-gis-ha-pgimg-build
-	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-postgres-gis-ha:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-postgres-gis-ha:$(CCP_IMAGE_TAG)
+	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-postgres-gis-ha:$(CCP_POSTGIS_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-postgres-gis-ha:$(CCP_POSTGIS_IMAGE_TAG)
 
 postgres-gis-ha-pgimg-docker: postgres-gis-ha-pgimg-build
 
@@ -207,7 +207,7 @@ postgres-gis-ha-pgimg-docker: postgres-gis-ha-pgimg-build
 backrest-restore-pgimg-build: cc-pg-base-image $(CCPROOT)/$(DFSET)/Dockerfile.backrest-restore.$(DFSET)
 	$(IMGCMDSTEM) \
 		-f $(CCPROOT)/$(DFSET)/Dockerfile.backrest-restore.$(DFSET) \
-		-t $(CCP_IMAGE_PREFIX)/crunchy-backrest-restore:$(CCP_IMAGE_TAG) \
+		-t $(CCP_IMAGE_PREFIX)/crunchy-backrest-restore:$(CCP_POSTGIS_IMAGE_TAG) \
 		--build-arg BASEOS=$(CCP_BASEOS) \
 		--build-arg BASEVER=$(CCP_VERSION) \
 		--build-arg PG_FULL=$(CCP_PG_FULLVERSION) \

--- a/bin/pull-from-crunchy.sh
+++ b/bin/pull-from-crunchy.sh
@@ -13,9 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 REG_CCP_IMAGE_PREFIX=registry.crunchydata.com/crunchydata
-for CONTAINER in crunchy-prometheus crunchy-upgrade crunchy-grafana crunchy-collect crunchy-pgbadger crunchy-pgpool crunchy-backup crunchy-postgres crunchy-postgres-gis crunchy-pgbouncer crunchy-pgadmin4 crunchy-pgdump crunchy-pgrestore crunchy-backrest-restore crunchy-pgbench crunchy-pgbasebackup-restore crunchy-postgres-ha crunchy-postgres-gis-ha
+for CONTAINER in crunchy-prometheus crunchy-upgrade crunchy-grafana crunchy-collect crunchy-pgbadger crunchy-pgpool crunchy-backup crunchy-postgres crunchy-pgbouncer crunchy-pgadmin4 crunchy-pgdump crunchy-pgrestore crunchy-backrest-restore crunchy-pgbench crunchy-pgbasebackup-restore crunchy-postgres-ha
 do
 	echo $CONTAINER is the container
 	docker pull $REG_CCP_IMAGE_PREFIX/$CONTAINER:$CCP_IMAGE_TAG
 	docker tag $REG_CCP_IMAGE_PREFIX/$CONTAINER:$CCP_IMAGE_TAG $CCP_IMAGE_PREFIX/$CONTAINER:$CCP_IMAGE_TAG
+done
+
+# Now pull the PostGIS containers, which are tagged to include their PostGIS version
+for GIS_CONTAINER in crunchy-postgres-gis crunchy-postgres-gis-ha
+do
+	echo $GIS_CONTAINER is the container
+	docker pull $REG_CCP_IMAGE_PREFIX/$CONTAINER:$CCP_POSTGIS_IMAGE_TAG
+	docker tag $REG_CCP_IMAGE_PREFIX/$CONTAINER:$CCP_POSTGIS_IMAGE_TAG $CCP_IMAGE_PREFIX/$CONTAINER:$CCP_POSTGIS_IMAGE_TAG
 done

--- a/bin/pull-from-dockerhub.sh
+++ b/bin/pull-from-dockerhub.sh
@@ -32,7 +32,7 @@ docker pull $CCP_IMAGE_PREFIX/crunchy-pgbadger:$CCP_IMAGE_TAG
 docker pull $CCP_IMAGE_PREFIX/crunchy-pgpool:$CCP_IMAGE_TAG
 docker pull $CCP_IMAGE_PREFIX/crunchy-backup:$CCP_IMAGE_TAG
 docker pull $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
-docker pull $CCP_IMAGE_PREFIX/crunchy-postgres-gis:$CCP_IMAGE_TAG
+docker pull $CCP_IMAGE_PREFIX/crunchy-postgres-gis:$CCP_POSTGIS_IMAGE_TAG
 docker pull $CCP_IMAGE_PREFIX/crunchy-pgbouncer:$CCP_IMAGE_TAG
 docker pull $CCP_IMAGE_PREFIX/crunchy-pgadmin4:$CCP_IMAGE_TAG
 docker pull $CCP_IMAGE_PREFIX/crunchy-pgdump:$CCP_IMAGE_TAG
@@ -41,4 +41,4 @@ docker pull $CCP_IMAGE_PREFIX/crunchy-upgrade:$CCP_IMAGE_TAG
 docker pull $CCP_IMAGE_PREFIX/crunchy-pgbench:$CCP_IMAGE_TAG
 docker pull $CCP_IMAGE_PREFIX/crunchy-pgbasebackup-restore:$CCP_IMAGE_TAG
 docker pull $CCP_IMAGE_PREFIX/crunchy-postgres-ha:$CCP_IMAGE_TAG
-docker pull $CCP_IMAGE_PREFIX/crunchy-postgres-gis-ha:$CCP_IMAGE_TAG
+docker pull $CCP_IMAGE_PREFIX/crunchy-postgres-gis-ha:$CCP_POSTGIS_IMAGE_TAG

--- a/bin/pull-from-gcr.sh
+++ b/bin/pull-from-gcr.sh
@@ -4,6 +4,7 @@ set -e -u
 
 REGISTRY='us.gcr.io/container-suite'
 VERSION=${CCP_IMAGE_TAG?}
+GIS_VERSION=${CCP_POSTGIS_IMAGE_TAG?}
 IMAGES=(
     crunchy-backrest-restore
     crunchy-backup
@@ -17,13 +18,16 @@ IMAGES=(
     crunchy-pgpool
     crunchy-pgrestore
     crunchy-postgres
-    crunchy-postgres-gis
     crunchy-prometheus
     crunchy-upgrade
     crunchy-pgbasebackup-restore
     crunchy-postgres-ha
-    crunchy-postgres-gis-ha
     crunchy-admin
+)
+
+GIS_IMAGES=(
+    crunchy-postgres-gis
+    crunchy-postgres-gis-ha
 )
 
 function echo_green() {
@@ -41,6 +45,13 @@ do
     echo_green "=> Pulling ${REGISTRY?}/${image?}:${VERSION?}.."
     docker pull ${REGISTRY?}/${image?}:${VERSION?}
     docker tag ${REGISTRY?}/${image?}:${VERSION?} crunchydata/${image?}:${VERSION?}
+done
+
+for gis_image in "${GIS_IMAGES[@]}"
+do
+    echo_green "=> Pulling ${REGISTRY?}/${gis_image?}:${GIS_VERSION?}.."
+    docker pull ${REGISTRY?}/${gis_image?}:${GIS_VERSION?}
+    docker tag ${REGISTRY?}/${gis_image?}:${GIS_VERSION?} crunchydata/${gis_image?}:${GIS_VERSION?}
 done
 
 echo_green "=> Done!"

--- a/bin/push-to-dockerhub.sh
+++ b/bin/push-to-dockerhub.sh
@@ -21,12 +21,12 @@ docker push  $CCP_IMAGE_PREFIX/crunchy-pgbadger:$CCP_IMAGE_TAG
 docker push  $CCP_IMAGE_PREFIX/crunchy-pgpool:$CCP_IMAGE_TAG
 docker push  $CCP_IMAGE_PREFIX/crunchy-backup:$CCP_IMAGE_TAG
 docker push  $CCP_IMAGE_PREFIX/crunchy-postgres:$CCP_IMAGE_TAG
-docker push  $CCP_IMAGE_PREFIX/crunchy-postgres-gis:$CCP_IMAGE_TAG
+docker push  $CCP_IMAGE_PREFIX/crunchy-postgres-gis:$CCP_POSTGIS_IMAGE_TAG
 docker push  $CCP_IMAGE_PREFIX/crunchy-pgbouncer:$CCP_IMAGE_TAG
 docker push  $CCP_IMAGE_PREFIX/crunchy-pgadmin4:$CCP_IMAGE_TAG
 docker push $CCP_IMAGE_PREFIX/crunchy-upgrade:$CCP_IMAGE_TAG
 docker push $CCP_IMAGE_PREFIX/crunchy-pgbench:$CCP_IMAGE_TAG
 docker push $CCP_IMAGE_PREFIX/crunchy-pgbasebackup-restore:$CCP_IMAGE_TAG
 docker push  $CCP_IMAGE_PREFIX/crunchy-postgres-ha:$CCP_IMAGE_TAG
-docker push  $CCP_IMAGE_PREFIX/crunchy-postgres-gis-ha:$CCP_IMAGE_TAG
+docker push  $CCP_IMAGE_PREFIX/crunchy-postgres-gis-ha:$CCP_POSTGIS_IMAGE_TAG
 docker push  $CCP_IMAGE_PREFIX/crunchy-admin:$CCP_IMAGE_TAG

--- a/bin/push-to-local.sh
+++ b/bin/push-to-local.sh
@@ -4,25 +4,30 @@ set -e -u
 
 REGISTRY=192.168.0.117:5000
 VERSION=${CCP_IMAGE_TAG?}
+GIS_VERSION=${CCP_POSTGIS_IMAGE_TAG?}
 IMAGES=(
-    crunchy-postgres
+    crunchy-backrest-restore
     crunchy-backup
-    crunchy-pgpool
-    crunchy-pgbouncer
-    crunchy-pgdump
-    crunchy-pgbench
     crunchy-collect
-    crunchy-pgbadger
     crunchy-grafana
     crunchy-pgadmin4
+    crunchy-pgbadger
+    crunchy-pgbench
+    crunchy-pgbouncer
+    crunchy-pgdump
+    crunchy-pgpool
     crunchy-pgrestore
-    crunchy-postgres-gis
+    crunchy-postgres
     crunchy-prometheus
     crunchy-upgrade
-    crunchy-backrest-restore
+    crunchy-pgbasebackup-restore
     crunchy-postgres-ha
-    crunchy-postgres-gis-ha
     crunchy-admin
+)
+
+GIS_IMAGES=(
+    crunchy-postgres-gis
+    crunchy-postgres-gis-ha
 )
 
 function echo_green() {
@@ -36,6 +41,13 @@ do
     echo_green "=> Pushing ${REGISTRY?}/$CCP_IMAGE_PREFIX/${image?}:${VERSION?}.."
     docker tag $CCP_IMAGE_PREFIX/${image?}:${VERSION?} ${REGISTRY?}/$CCP_IMAGE_PREFIX/${image?}:${VERSION?}
     docker push ${REGISTRY?}/$CCP_IMAGE_PREFIX/${image?}:${VERSION?}
+done
+
+for gis_image in "${IMAGES[@]}"
+do
+    echo_green "=> Pushing ${REGISTRY?}/$CCP_IMAGE_PREFIX/${gis_image?}:${GIS_VERSION?}.."
+    docker tag $CCP_IMAGE_PREFIX/${image?}:${GIS_VERSION?} ${REGISTRY?}/$CCP_IMAGE_PREFIX/${gis_image?}:${GIS_VERSION?}
+    docker push ${REGISTRY?}/$CCP_IMAGE_PREFIX/${gis_image?}:${GIS_VERSION?}
 done
 
 echo_green "=> Done!"

--- a/bin/remove-all-images.sh
+++ b/bin/remove-all-images.sh
@@ -22,4 +22,12 @@ do
 	docker rmi -f  crunchy-$i
 #	docker rmi -f  registry.crunchydata.openshift.com/jeff-project/crunchy-$i:$CCP_IMAGE_TAG
 done
+
+for i in \
+postgres-gis postgres-gis-ha
+do
+	docker rmi -f  $CCP_IMAGE_PREFIX/crunchy-$i:$CCP_POSTGIS_IMAGE_TAG
+	docker rmi -f  crunchy-$i
+done
+
 exit

--- a/docs/content/contributing/building.md
+++ b/docs/content/contributing/building.md
@@ -51,9 +51,11 @@ export PATH=$PATH:$GOBIN        # add Go bin path to your overall path
 export CCP_BASEOS=centos7       # centos7 for Centos, ubi7 for Red Hat Universal Base Image
 export CCP_PGVERSION=12        # The PostgreSQL major version
 export CCP_PG_FULLVERSION=12.3
+export CCP_POSTGIS_VERSION=3.0
 export CCP_VERSION=4.3.2
 export CCP_IMAGE_PREFIX=crunchydata # Prefix to put before all the container image names
 export CCP_IMAGE_TAG=$CCP_BASEOS-$CCP_PG_FULLVERSION-$CCP_VERSION   # Used to tag the images
+export CCP_POSTGIS_IMAGE_TAG=$CCP_BASEOS-$CCP_PG_FULLVERSION-$CCP_POSTGIS_VERSION-$CCPVERSION # Used to tag images that include PostGIS
 export CCPROOT=$GOPATH/src/github.com/crunchydata/crunchy-containers    # The base of the clone github repo
 ```
 
@@ -68,9 +70,11 @@ export PATH=$PATH:$GOBIN
 export CCP_BASEOS=centos7
 export CCP_PGVERSION=12
 export CCP_PG_FULLVERSION=12.3
+export CCP_POSTGIS_VERSION=3.0
 export CCP_VERSION=4.3.2
 export CCP_IMAGE_PREFIX=crunchydata
 export CCP_IMAGE_TAG=$CCP_BASEOS-$CCP_PG_FULLVERSION-$CCP_VERSION
+export CCP_POSTGIS_IMAGE_TAG=$CCP_BASEOS-$CCP_PG_FULLVERSION-$CCP_POSTGIS_VERSION-$CCPVERSION
 export CCPROOT=$GOPATH/src/github.com/crunchydata/crunchy-containers
 EOF
 ```

--- a/docs/content/installation-guide/installation-guide.md
+++ b/docs/content/installation-guide/installation-guide.md
@@ -92,9 +92,11 @@ line starting with #:
     export CCP_BASEOS=centos7       # centos7 for Centos, ubi7 for Red Hat Universal Base Image
     export CCP_PGVERSION=12         # The PostgreSQL major version
     export CCP_PG_FULLVERSION=12.3
+    export CCP_POSTGIS_VERSION=3.0  # The PostGIS version
     export CCP_VERSION=4.3.2
     export CCP_IMAGE_PREFIX=crunchydata # Prefix to put before all the container image names
     export CCP_IMAGE_TAG=$CCP_BASEOS-$CCP_PG_FULLVERSION-$CCP_VERSION   # Used to tag the images
+    export CCP_POSTGIS_IMAGE_TAG=$CCP_BASEOS-$CCP_PG_FULLVERSION-$CCP_POSTGIS_VERSION-$CCP_VERSION # Used to tag images that include PostGIS
     export CCPROOT=$GOPATH/src/github.com/crunchydata/crunchy-containers    # The base of the clone github repo
     export CCP_SECURITY_CONTEXT=""
     export CCP_CLI=kubectl          # kubectl for K8s, oc for OpenShift

--- a/examples/docker/postgres-gis/run.sh
+++ b/examples/docker/postgres-gis/run.sh
@@ -48,4 +48,4 @@ docker run \
 	-e PG_DATABASE=userdb \
 	--name=$CONTAINER_NAME \
 	--hostname=$CONTAINER_NAME \
-	-d $CCP_IMAGE_PREFIX/crunchy-postgres-gis:$CCP_IMAGE_TAG
+	-d $CCP_IMAGE_PREFIX/crunchy-postgres-gis:$CCP_POSTGIS_IMAGE_TAG

--- a/examples/kube/postgres-gis-ha/postgres-gis-ha.json
+++ b/examples/kube/postgres-gis-ha/postgres-gis-ha.json
@@ -93,7 +93,7 @@
                 "containers": [
                     {
                         "name": "postgres",
-                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres-gis-ha:$CCP_IMAGE_TAG",
+                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres-gis-ha:$CCP_POSTGIS_IMAGE_TAG",
                         "securityContext": {
                             "runAsUser": 26
                         },
@@ -362,7 +362,7 @@
                 "containers": [
                     {
                         "name": "postgres",
-                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres-gis-ha:$CCP_IMAGE_TAG",
+                        "image": "$CCP_IMAGE_PREFIX/crunchy-postgres-gis-ha:$CCP_POSTGIS_IMAGE_TAG",
                         "securityContext": {
                             "runAsUser": 26
                         },

--- a/examples/kube/postgres-gis/postgres-gis.json
+++ b/examples/kube/postgres-gis/postgres-gis.json
@@ -43,7 +43,7 @@
         "containers": [
             {
                 "name": "postgres-gis",
-                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres-gis:$CCP_IMAGE_TAG",
+                "image": "$CCP_IMAGE_PREFIX/crunchy-postgres-gis:$CCP_POSTGIS_IMAGE_TAG",
                 "ports": [
                     {
                         "containerPort": 5432,

--- a/tools/test-harness/setup_test.go
+++ b/tools/test-harness/setup_test.go
@@ -42,8 +42,8 @@ func setup(t *testing.T, timeout time.Duration, cleanup bool) *harness {
 
 	t.Log("Running Initialization Checks...")
 	envs := []string{
-		"CCPROOT", "CCP_BASEOS", "CCP_PGVERSION",
-		"CCP_IMAGE_PREFIX", "CCP_IMAGE_TAG",
+		"CCPROOT", "CCP_BASEOS", "CCP_PGVERSION", "CCP_POSTGIS_VERSION",
+		"CCP_IMAGE_PREFIX", "CCP_IMAGE_TAG", "CCP_POSTGIS_IMAGE_TAG",
 		"CCP_STORAGE_MODE", "CCP_STORAGE_CAPACITY", "CCP_CLI"}
 
 	if err := runner.GetEnv(envs); err != nil {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Currently, the container Makefile does not have a convenient
way to handle multiple PostGIS versions with a particular PostgreSQL
release. 

**What is the new behavior (if this is a feature change)?**

To better accommodate this, two new environment variables
are introduced, CCP_POSTGIS_VERSION and CCP_POSTGIS_IMAGE_TAG. These
variables are then used when by the relevant project scripts when building,
pulling or pushing the postgres-gis or postgres-gis-ha container images.
Finally, the relevant documentation and examples were updated to
use the new tag values as well.




**Other information**:
[ch8489]
[ch8490]