### PR TITLE
Initialization Job Support for the 'crunchy-postgres-ha' Container

### DIFF
--- a/bin/postgres-ha/sql/post-existing-init.sql
+++ b/bin/postgres-ha/sql/post-existing-init.sql
@@ -13,5 +13,9 @@
  * limitations under the License.
  */
 
-CREATE USER ${PATRONI_SUPERUSER_USERNAME} WITH SUPERUSER PASSWORD $$${PATRONI_SUPERUSER_PASSWORD}$$;
-CREATE USER ${PATRONI_REPLICATION_USERNAME} WITH REPLICATION PASSWORD $$${PATRONI_REPLICATION_PASSWORD}$$;
+/**
+ * Create the PGHA user and then alter its password.  This ensures the password is updated
+ * in the event the user already exists.
+ */
+CREATE ROLE "${PGHA_USER}" WITH LOGIN PASSWORD $$${PGHA_USER_PASSWORD}$$;
+ALTER ROLE "${PGHA_USER}" WITH PASSWORD $$${PGHA_USER_PASSWORD}$$;

--- a/conf/postgres-ha/postgres-ha-bootstrap.yaml
+++ b/conf/postgres-ha/postgres-ha-bootstrap.yaml
@@ -1,5 +1,9 @@
 ---
 bootstrap:
+  method: PGHA_BOOTSTRAP_METHOD
+  pgbackrest_init:
+    command: '/opt/cpm/bin/pgbackrest/pgbackrest-create-replica.sh primary'
+    keep_existing_recovery_conf: true
   dcs:
     postgresql:
       parameters:

--- a/conf/postgres-ha/postgres-ha-pgconf.yaml
+++ b/conf/postgres-ha/postgres-ha-pgconf.yaml
@@ -6,11 +6,11 @@ postgresql:
     - pgbackrest
     - basebackup
   pgbackrest:
-    command: '/opt/cpm/bin/pgbackrest/pgbackrest-create-replica.sh'
+    command: '/opt/cpm/bin/pgbackrest/pgbackrest-create-replica.sh replica'
     keep_data: true
     no_params: true
   pgbackrest_standby:
-    command: '/opt/cpm/bin/pgbackrest/pgbackrest-create-replica.sh'
+    command: '/opt/cpm/bin/pgbackrest/pgbackrest-create-replica.sh standby'
     keep_data: true
     no_params: true
     no_master: 1


### PR DESCRIPTION
This commit adds support to allow the `crunchy-postgres-ha` container to be run as an initialization Job.  This can be used to initialize a new PostgreSQL database using an existing data source (e.g. a pgBackRest backup), and then cleanly shut the database down once initialization is complete (e.g. a pgBackRest restore has finished successfully and recovery has completed) so that it can then be cleanly started again when needed.  This specifically allows the PostgreSQL Operator to initially run batch Job to populate the `PGDATA` volume for a new cluster, and then subsequently mount and use that same volume to bring a new PostgreSQL cluster online.

In support of running the container as an initialization Job, a new custom bootstrap method called `pgbackrest_init` has been created.  When this bootstrap method is configured, a `pgbackrest restore` is performed when initializing a new PostgreSQL cluster (instead of running `initdb` to initialize from scratch).  A `RESTORE_OPTS` environment variable is also provided that allows for further customization of the `pgbackrest restore` command (e.g. specifying a `--type` and `--target` to use a PITR to initialize the cluster).

Also, the `post-existing-init.sql` script is now executed from the post-restore script following the following the initialization of a cluster using the 'pgbackrest_init' bootstrap method.  This creates and/or updates the credentials for the standard user created with all new PostgreSQL clusters, and can be further customized to run additional SQL upon bootstrap completion when using this bootstrap method.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The `crunchy-postgres-ha` container is not designed to run as an init Job.

**What is the new behavior (if this is a feature change)?**

The `crunchy-postgres-ha` container can now be run as an init Job.

**Other information**:

N/A