### PR TITLE
Escape password values stored in PostgreSQL password file

### DIFF
--- a/bin/backup/start-backupjob.sh
+++ b/bin/backup/start-backupjob.sh
@@ -40,7 +40,11 @@ env_check_info "BACKUP_LABEL" "BACKUP_LABEL is set to ${BACKUP_LABEL}."
 env_check_info "BACKUP_PATH" "BACKUP_PATH is set to ${BACKUP_PATH}."
 env_check_info "BACKUP_OPTS" "BACKUP_OPTS is set to ${BACKUP_OPTS}."
 
-echo "*:*:*:"${BACKUP_USER?}":"${BACKUP_PASS?} >> ${PGPASSFILE?}
+# escape any instances of ':' or '\' with '\' in the provided password
+# before storing the value in the password file
+ESCAPED_PASSWORD=$(sed <<< "${BACKUP_PASS?}" 's/[:\\]/\\&/g')
+
+echo "*:*:*:${BACKUP_USER?}:${ESCAPED_PASSWORD?}" >> ${PGPASSFILE?}
 chmod 600 ${PGPASSFILE?}
 
 pg_basebackup --label=${BACKUP_LABEL?} -X fetch \

--- a/bin/pgbench/start.sh
+++ b/bin/pgbench/start.sh
@@ -42,8 +42,13 @@ fi
 
 function create_pgpass() {
     cd /tmp
+
+# escape any instances of ':' or '\' with '\' in the provided password
+# before storing the value in the password file
+ESCAPED_PASSWORD=$(sed <<< "${PG_PASSWORD?}" 's/[:\\]/\\&/g')
+
 cat >> ".pgpass" <<-EOF
-*:*:*:${PG_USERNAME?}:${PG_PASSWORD?}
+*:*:*:${PG_USERNAME?}:${ESCAPED_PASSWORD?}
 EOF
     chmod 0600 .pgpass
 }

--- a/bin/pgdump/start.sh
+++ b/bin/pgdump/start.sh
@@ -32,8 +32,12 @@ env_check_err "PGDUMP_USER"
 # Todo: Add SSL support
 conn_opts="-h ${PGDUMP_HOST?} -p ${PGDUMP_PORT?} -U ${PGDUMP_USER?}"
 
+# escape any instances of ':' or '\' with '\' in the provided password
+# before storing the value in the password file
+ESCAPED_PASSWORD=$(sed <<< "${PGDUMP_PASS?}" 's/[:\\]/\\&/g')
+
 cat >> "${PGPASSFILE?}" <<-EOF
-*:*:*:${PGDUMP_USER?}:${PGDUMP_PASS?}
+*:*:*:${PGDUMP_USER?}:${ESCAPED_PASSWORD?}
 EOF
 
 chmod 600 ${PGPASSFILE?}

--- a/bin/pgrestore/start.sh
+++ b/bin/pgrestore/start.sh
@@ -34,8 +34,12 @@ PGDUMP_BACKUP_HOST="${PGDUMP_BACKUP_HOST:-${PGRESTORE_HOST?}}"
 # Todo: Add SSL support
 conn_opts="-h ${PGRESTORE_HOST?} -p ${PGRESTORE_PORT?} -U ${PGRESTORE_USER?} -d ${PGRESTORE_DB?}"
 
+# escape any instances of ':' or '\' with '\' in the provided password
+# before storing the value in the password file
+ESCAPED_PASSWORD=$(sed <<< "${PGRESTORE_PASS?}" 's/[:\\]/\\&/g')
+
 cat >> "${PGPASSFILE?}" <<-EOF
-*:*:*:${PGRESTORE_USER?}:${PGRESTORE_PASS?}
+*:*:*:${PGRESTORE_USER?}:${ESCAPED_PASSWORD?}
 EOF
 
 chmod 600 ${PGPASSFILE?}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently, PostgreSQL passwords stored in the .pgpass file
are not properly escaped.
As documented here:
https://www.postgresql.org/docs/current/libpq-pgpass.html
"If an entry needs to contain : or \, escape this character with \"

**What is the new behavior (if this is a feature change)?**
This update adds that functionality to the passwords stored in
the .pgpass files used by the pgdump, pgbench, pgbackup and
pgrestore container scripts.


**Other information**:
