### PR TITLE
Ensure pgBackRest Settings Work When Local & S3 Storage is Enabled

### DIFF
--- a/bin/postgres-ha/pgbackrest/pgbackrest-archive-push-local-s3.sh
+++ b/bin/postgres-ha/pgbackrest/pgbackrest-archive-push-local-s3.sh
@@ -30,8 +30,18 @@ source /opt/cpm/bin/pgbackrest/pgbackrest-set-env.sh
 pgbackrest archive-push $1
 local_exit=$?
 
+# set the repo type flag
+archive_push_cmd_args=("--repo1-type=s3")
+
+# if TLS verification is disabled, pass in the appropriate flag
+# otherwise, leave the default behavior and verify TLS
+if [[ $PGHA_PGBACKREST_S3_VERIFY_TLS == "false" ]]
+then
+    archive_push_cmd_args+=("--no-repo1-s3-verify-tls")
+fi
+
 # then try S3
-pgbackrest archive-push --repo-type=s3 $1
+pgbackrest archive-push ${archive_push_cmd_args[*]} $1
 s3_exit=$?
 
 # check each exit code. If one of them fail, exit with their nonzero exit code

--- a/bin/postgres-ha/pgbackrest/pgbackrest-set-env.sh
+++ b/bin/postgres-ha/pgbackrest/pgbackrest-set-env.sh
@@ -23,6 +23,13 @@ then
     replica_bootstrap_repo_type="$(cat /pgconf/replica-bootstrap-repo-type)"
     if [[ "${replica_bootstrap_repo_type}" != "" ]]
     then
-        export PGBACKREST_REPO_TYPE=${replica_bootstrap_repo_type}
+        export PGBACKREST_REPO1_TYPE=${replica_bootstrap_repo_type}
     fi
+fi
+
+# for an S3 repo, if TLS verification is disabled, pass in the appropriate flag
+# otherwise, leave the default behavior and verify the S3 server certificate
+if [[ $PGBACKREST_REPO_TYPE == "s3" && $PGHA_PGBACKREST_S3_VERIFY_TLS == "false" ]]
+then
+    export PGBACKREST_REPO1_S3_VERIFY_TLS="n"
 fi


### PR DESCRIPTION


**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently, pgBackRest backups initiated by the Postgres Operator
that utilize the 'local,s3' setting do not work as expected with the 
's3-verify-tls' & 's3-uri-style' configuration settings.


**What is the new behavior (if this is a feature change)?**
This update is the companion update to the Postgres Operator PR which
ensures that the 's3-verify-tls' & 's3-uri-style' settings work as expected
when both local & S3 storage are enabled for pgBackRest when creating a
pgcluster. Currently, when a new cluster is created using Local and AWS S3
storage (e.g. by specifiying --pgbackrest-storage-type=local,s3 with the
pgo create command), stanza creation fails and the cluster is not initialized.

Since this is failing because the 'non S3' pgBackRest command runs when
the repo1-s3-verify-tls flag is detected in the environment. This fix updates
the pgBackRest flag implementation so that the repo1-s3-verify-tls setting
is applied only for the second pgbackrest command only, i.e. the command using
--repo-type-s3, and not apply it when running the first pgbackrest command for
the local repository. This is done by using the --no-repo1-s3-verify-tls
command flag rather than the relevant environment variable or the
related configuration file setting. This method allows both commands to
execute as expected.


**Other information**:
[ch8634]