### PR TITLE
Restart Primary Database Following Manual DB Start

### DIFF
--- a/bin/postgres-ha/bootstrap-postgres-ha.sh
+++ b/bin/postgres-ha/bootstrap-postgres-ha.sh
@@ -84,6 +84,14 @@ initialization_monitor() {
                 sleep 1
             done
 
+            if [[ "${manual_start}" == "true" ]]
+            then
+                echo_info "Executing Patroni restart to restart database and update configuration"
+                curl -X POST --silent "127.0.0.1:${PGHA_PATRONI_PORT}/restart"
+                test_server "postgres" "${PGHOST}" "${PGPORT}" "postgres"
+                echo_info "The database has been restarted"
+            fi
+
             # if the bootstrap method is not "initdb", we assume we're running an init job and now
             # proceed with shutting down Patroni and the database
             if [[ "${PGHA_BOOTSTRAP_METHOD}" == "initdb" ]]


### PR DESCRIPTION
This commit reintroduces a Patroni restart to the initialization process for primary databases that were started manually, e.g. for a point-in-time restore.  This ensures all PostgreSQL settings on the primary are properly applied prior to continuing the cluster initialization process.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The primary isn't automatically restarted via a `patronictl restart` following a manual database start (i.e. as used for a PITR), which prevents certain settings needed to support proper cluster behavior (e.g. proper replication from replicas) from being applied until a restart is executed.

**What is the new behavior (if this is a feature change)?**

The primary is automatically restarted via a `patronictl restart` following a manual database start (i.e. as used for a PITR), which ensures all settings needed to support proper cluster behavior (e.g. proper replication from replicas) are properly applied.

**Other information**:

N/A