### PR TITLE
Fix the config.toml for doc generation

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -26,11 +26,8 @@ disableHomeIcon = true # default is false
 disableSearch = false # default is false
 disableNavChevron = false # set true to hide next/prev chevron, default is false
 highlightClientSide = false # set true to use highlight.pack.js instead of the default hugo chroma highlighter
-menushortcutsnewtab = false # set true to open shortcuts links to a new tab/window
+menushortcutsnewtab = true # set true to open shortcuts links to a new tab/window
 enableGitInfo = true
-
-[blackfriday]
-hrefTargetBlank = true
 
 [outputs]
 home = [ "HTML", "RSS", "JSON"]
@@ -51,7 +48,12 @@ name = "<i class='fas fa-file-contract'></i> <label>License</label>"
 url = "https://github.com/CrunchyData/crunchy-containers/blob/master/LICENSE.md"
 weight = 30
 
-#[[menu.downloads]]
-#name = "<i class='fas fa-file-pdf'></i> <label>PDF</label>"
-#url = "/pdf/backrest.pdf"
-#weight = 20
+[[menu.downloads]]
+name = "<i class='fas fa-file-pdf'></i> <label>PDF</label>"
+url = "/pdf/crunchy_containers.pdf"
+weight = 20
+
+[[menu.downloads]]
+name = "<i class='fas fa-book'></i> <label>EPUB</label>"
+url = "/epub/crunchy_containers.epub"
+weight = 30


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently the config.toml is being overriden during document generation.


**What is the new behavior (if this is a feature change)?**
With these changes we are able to remove the replacement of the config.toml and allow us to pick up the latest version of this file to fix broken documents.


**Other information**:
  This will need to be backported to at least the 4.2 line.  Please make sure it is backported to any line where documentation will need to be generated again.