### PR TITLE
Add Bootstrap Method for Existing PGDATA Directory

### DIFF
--- a/bin/postgres-ha/bootstrap/create-from-existing.sh
+++ b/bin/postgres-ha/bootstrap/create-from-existing.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright 2020 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /opt/cpm/bin/common/common_lib.sh
+enable_debugging
+
+source /opt/cpm/bin/common/pgha-common.sh
+export $(get_patroni_pgdata_dir)
+
+echo_info "Bootstrapping a new PostgreSQL cluster using an existing PGDATA directory"
+
+mv "${PATRONI_POSTGRESQL_DATA_DIR}_tmp" "${PATRONI_POSTGRESQL_DATA_DIR}"
+err_check "$?" "Initialize Existing PGDATA" "Could not initialize cluster using existing PGDATA directory"
+
+echo_info "Finished bootstrapping a new PostgreSQL cluster using an existing PGDATA directory"

--- a/conf/postgres-ha/postgres-ha-bootstrap.yaml
+++ b/conf/postgres-ha/postgres-ha-bootstrap.yaml
@@ -4,6 +4,9 @@ bootstrap:
   pgbackrest_init:
     command: '/opt/cpm/bin/pgbackrest/pgbackrest-create-replica.sh primary'
     keep_existing_recovery_conf: true
+  existing_init:
+    command: '/opt/cpm/bin/bootstrap/create-from-existing.sh'
+    keep_existing_recovery_conf: true
   dcs:
     postgresql:
       parameters:


### PR DESCRIPTION
This commit adds a new Patroni bootstrap method called `existing_init` that initializes a new PostgreSQL cluster using an existing `PGDATA` directory.  Now when the `PGHA_INIT` flag is `true` and the `crunchy-postgres-ha container` detects that the `PGDATA` directory for the cluster is not empty, the `existing_init` bootstrap method is executed.

This bootstrap method prevents Patroni from treating the initial start of the database as the recovery of a former cluster (as it typically would when the PGDATA directory isn't empty), but rather as the start of a brand new cluster.  This means the post initialization script is executed, the instance is started cleanly as a primary, and any new configuration settings specified when creating the cluster are applied (instead of restoring the configuration from a previous cluster).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

When an existing `PGDATA` directory is found and the `PGHA_INIT` flag is `true`, Patroni treats cluster initialization as the recovery of a former cluster.

**What is the new behavior (if this is a feature change)?**

When an existing `PGDATA` directory is found and the `PGHA_INIT` flag is `true`, Patroni treats cluster initialization as the creation of a brand new cluster.

**Other information**:

[ch8721]
[ch8719]