### PR TITLE
Only Run Manual Starts When PGHA_INIT is 'true'

### DIFF
--- a/bin/postgres-ha/bootstrap-postgres-ha.sh
+++ b/bin/postgres-ha/bootstrap-postgres-ha.sh
@@ -205,7 +205,7 @@ fi
 # Determine if the database is configured for a PITR.  If so, the database will be started
 # manually to ensure the propery recovery target is achieved.  Otherwise, if not perorming
 # a PITR, Patroni will handle any recovery and start the database.
-if is_pg_in_pitr_recovery || is_pg_in_pitr_recovery_legacy
+if [[ "${PGHA_INIT}" == "true" ]] && (is_pg_in_pitr_recovery || is_pg_in_pitr_recovery_legacy)
 then
     echo_info "Detected PITR recovery, will start database manually prior to starting Patroni"
     manual_start=true


### PR DESCRIPTION
With this commit, the database will only ever be manually started when the `PGHA_INIT` flag is `true`.  This ensures that there is never an attempt to manually start replicas.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

A manual start is executed anytime a `recovery_target_*` setting is detected, even if the database being started isn't a primary.

**What is the new behavior (if this is a feature change)?**

A manual start is executed only when `PGHA_INIT` is `true`.

**Other information**:

N/A
