### PR TITLE
Pgnodemx integration

### DIFF
--- a/bin/install-deps.sh
+++ b/bin/install-deps.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Dependency Versions
-PGMONITOR_COMMIT='v4.2'
+PGMONITOR_COMMIT='v4.4-RC2'
 OPENSHIFT_CLIENT='https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz'
 CERTSTRAP_VERSION=1.1.1
 YQ_VERSION=3.3.0

--- a/bin/postgres-ha/modules/pgmonitor.sh
+++ b/bin/postgres-ha/modules/pgmonitor.sh
@@ -53,4 +53,7 @@ then
     psql -U postgres --port="${PG_PRIMARY_PORT}" -d postgres \
         -c "SET log_statement TO 'none'; ALTER ROLE ccp_monitoring PASSWORD '${PGMONITOR_PASSWORD?}'" \
         > /tmp/pgmonitor-alter-role.stdout 2> /tmp/pgmonitor-alter-role.stderr
+
+    psql -U postgres --port="${PG_PRIMARY_PORT}" -d postgres \
+        -c "CREATE EXTENSION IF NOT EXISTS pgnodemx WITH SCHEMA monitor;" > /tmp/pgmonitor-setup.stdout 2> /tmp/pgmonitor-setup.stderr
 fi

--- a/build/postgres-ha/Dockerfile
+++ b/build/postgres-ha/Dockerfile
@@ -29,6 +29,7 @@ RUN if [ "$DFSET" = "centos" ] ; then \
         	postgresql${PG_MAJOR//.}-server \
         	postgresql${PG_MAJOR//.}-plpython \
         	postgresql${PG_MAJOR//.}-plpython3 \
+        	pgnodemx${PG_MAJOR//.} \
         	$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
         	psmisc \
         	rsync \
@@ -47,6 +48,7 @@ else \
 		postgresql${PG_MAJOR//.}-server \
 		postgresql${PG_MAJOR//.}-plpython \
 		postgresql${PG_MAJOR//.}-plpython3 \
+		pgnodemx${PG_MAJOR//.} \
 		$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
 		psmisc \
 		rsync \

--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -29,6 +29,7 @@ RUN if [ "$DFSET" = "centos" ] ; then \
         	postgresql${PG_MAJOR//.}-server \
         	postgresql${PG_MAJOR//.}-plpython \
         	postgresql${PG_MAJOR//.}-plpython3 \
+        	pgnodemx${PG_MAJOR//.} \
         	$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
         	psmisc \
         	rsync \
@@ -46,6 +47,7 @@ else \
 		postgresql${PG_MAJOR//.}-server \
 		postgresql${PG_MAJOR//.}-plpython \
 		postgresql${PG_MAJOR//.}-plpython3 \
+		pgnodemx${PG_MAJOR//.} \
 		$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
 		psmisc \
 		rsync \

--- a/conf/postgres-ha/postgres-ha-initdb.yaml
+++ b/conf/postgres-ha/postgres-ha-initdb.yaml
@@ -12,7 +12,7 @@ bootstrap:
         log_statement: none
         work_mem: 4MB
         max_wal_senders: 6
-        shared_preload_libraries: pgaudit.so,pg_stat_statements.so
+        shared_preload_libraries: pgaudit.so,pg_stat_statements.so,pgnodemx.so
   initdb:
   - encoding: UTF8
   - data-checksums

--- a/conf/postgres/postgresql.conf.template
+++ b/conf/postgres/postgresql.conf.template
@@ -141,7 +141,7 @@ dynamic_shared_memory_type = posix	# the default is the first option
 
 #max_files_per_process = 1000		# min 25
 					# (change requires restart)
-shared_preload_libraries = 'pgaudit.so,pg_stat_statements.so'		# (change requires restart)
+shared_preload_libraries = 'pgaudit.so,pg_stat_statements.so,pgnodemx.so'		# (change requires restart)
 
 # - Cost-Based Vacuum Delay -
 

--- a/conf/postgres/postgresql.conf.template.nopgaudit
+++ b/conf/postgres/postgresql.conf.template.nopgaudit
@@ -141,7 +141,7 @@ dynamic_shared_memory_type = posix	# the default is the first option
 
 #max_files_per_process = 1000		# min 25
 					# (change requires restart)
-shared_preload_libraries = 'pg_stat_statements.so'		# (change requires restart)
+shared_preload_libraries = 'pg_stat_statements.so,pgnodemx.so'		# (change requires restart)
 
 # - Cost-Based Vacuum Delay -
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Pgnodemx is not installed in either the Crunchy Postgres HA or
Crunchy Postgres containers.


**What is the new behavior (if this is a feature change)?**
This update integrates the pgnodemx extension to the crunchy-postgres-ha
container for use with the Crunchy Postgres Exporter in the Crunchy PostgreSQL 
Operator project. It updates the pgMonitor version to be used, installs the pgnodemx 
RPM and enables the PostgreSQL extension.

This update also installs the pgnodemx RPM in the postgres
container. While it is available for use, it is not auto-enabled,
and that will need to be done by creating the pgnodemx extension.
 

**Other information**:
[ch8768]
[ch9010]