### PR TITLE
Update ssh support for CentOS/UBI 8 compatibility

### DIFF
--- a/build/postgres-ha/Dockerfile
+++ b/build/postgres-ha/Dockerfile
@@ -142,7 +142,7 @@ RUN chmod +x /opt/cpm/bin/yq
 RUN chmod g=u /etc/passwd \
  && chmod g=u /etc/group
 
-RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh && rm -f /run/nologin
 
 # The VOLUME directive must appear after all RUN directives to ensure the proper
 # volume permissions are applied when building the image

--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -94,7 +94,7 @@ ADD tools/pgmonitor/exporter/postgres /opt/cpm/bin/modules/pgexporter
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
 
-RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh && rm -f /run/nologin
 
 # add volumes to allow override of pg_hba.conf and postgresql.conf
 # add volumes to offer a restore feature


### PR DESCRIPTION
The fix removes a file that should be removed at container boot that
prevents non-root sessions from logging in (which is essential for
the pgBackRest functionality).