### PR TITLE
Allow for rootless builds of containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,13 @@ IMGBUILDER ?= buildah
 # Determines whether or not images should be pushed to the local docker daemon when building with
 # a tool other than docker (e.g. when building with buildah)
 IMG_PUSH_TO_DOCKER_DAEMON ?= true
-IMGCMDSTEM=sudo --preserve-env buildah bud --layers $(SQUASH)
+# Defines the sudo command that should be prepended to various build commands when rootless builds are
+# not enabled
+IMGCMDSUDO=
+ifneq ("$(IMG_ROOTLESS_BUILD)", "true")
+	IMGCMDSUDO=sudo --preserve-env
+endif
+IMGCMDSTEM=$(IMGCMDSUDO) buildah bud --layers $(SQUASH)
 DFSET=$(CCP_BASEOS)
 DOCKERBASEREGISTRY=registry.access.redhat.com/
 


### PR DESCRIPTION
This adds the `IMG_ROOTLESS_BUILD` environmental variable
to instruct the Makefile to build the various containers
without root privileges.