### PR TITLE
Proper Directory Permissions for Existing PGDATA Directory Bootstrap

### DIFF
--- a/bin/postgres-ha/bootstrap/create-from-existing.sh
+++ b/bin/postgres-ha/bootstrap/create-from-existing.sh
@@ -24,4 +24,7 @@ echo_info "Bootstrapping a new PostgreSQL cluster using an existing PGDATA direc
 mv "${PATRONI_POSTGRESQL_DATA_DIR}_tmp" "${PATRONI_POSTGRESQL_DATA_DIR}"
 err_check "$?" "Initialize Existing PGDATA" "Could not initialize cluster using existing PGDATA directory"
 
+# ensure the PGDATA directory has the proper permissions
+chmod u+rwx,go-rwx "${PATRONI_POSTGRESQL_DATA_DIR}"
+
 echo_info "Finished bootstrapping a new PostgreSQL cluster using an existing PGDATA directory"


### PR DESCRIPTION
When bootstrapping a new PostgreSQL cluster using an existing/pre-populated `PGDATA` directory, the directory file permissions are now explicitly set to 0700.  This is to ensure any additional file permissions added to the volume (e.g. when Kubernetes applies fsGroups) are removed as needed to ensure the database can be properly started.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The file permissions for an existing `PGDATA` directory are not explicitly set.

[ch9156]

**What is the new behavior (if this is a feature change)?**

The file permissions for an existing `PGDATA` directory are explicitly set.

**Other information**:

N/A