### PR TITLE
pgAdmin 4 Updates

### DIFF
--- a/bin/pgadmin4/start-pgadmin4.sh
+++ b/bin/pgadmin4/start-pgadmin4.sh
@@ -17,7 +17,7 @@ source /opt/cpm/bin/common_lib.sh
 enable_debugging
 
 export PATH=$PATH:/usr/pgsql-*/bin
-PGADMIN_DIR='/usr/lib/python2.7/site-packages/pgadmin4-web'
+PGADMIN_DIR=/usr/lib/python3.6/site-packages/pgadmin4-web
 APACHE_PIDFILE='/tmp/httpd.pid'
 
 function trap_sigterm() {
@@ -62,7 +62,7 @@ cd ${PGADMIN_DIR?}
 if [[ ! -f /var/lib/pgadmin/pgadmin4.db ]]
 then
     echo_info "Setting up pgAdmin4 database.."
-    python setup.py > /tmp/pgadmin4.stdout 2> /tmp/pgadmin4.stderr
+    python3 setup.py > /tmp/pgadmin4.stdout 2> /tmp/pgadmin4.stderr
     err_check "$?" "pgAdmin4 Database Setup" "Could not create pgAdmin4 database: \n$(cat /tmp/pgadmin4.stderr)"
 fi
 

--- a/build/pgadmin4/Dockerfile
+++ b/build/pgadmin4/Dockerfile
@@ -27,7 +27,8 @@ RUN if [ "$BASEOS" = "centos7" ] ; then \
                 mod_ssl \
                 mod_wsgi \
                 openssl \
-                --setopt=obsoletes=0 pgadmin4-web-4.18 \
+                pgadmin4-web-4.20 \
+                --setopt=obsoletes=0 \
                 postgresql${PG_MAJOR//.}-server \
         && ${PACKAGER} -y clean all  \
         && chown -R 2:0 /usr/lib/python2.7/site-packages/pgadmin4-web \
@@ -46,7 +47,8 @@ RUN if [ "$BASEOS" = "centos8" ] ; then \
                 mod_ssl \
                 python3-mod_wsgi \
                 openssl \
-                --setopt=obsoletes=0 pgadmin4-web-4.20 \
+                pgadmin4-web-4.20 \
+                --setopt=obsoletes=0 \
                 postgresql${PG_MAJOR//.}-server \
         && ${PACKAGER} -y clean all \
         && chown -R 2:0 /usr/lib/python3.6/site-packages/pgadmin4-web \
@@ -58,25 +60,6 @@ RUN if [ "$BASEOS" = "centos8" ] ; then \
         && ln -sf /var/lib/pgadmin/pgadmin.conf /etc/httpd/conf.d/pgadmin.conf ; \
 fi
 
-RUN if [ "$BASEOS" = "rhel7" ] ; then \
-        ${PACKAGER} -y install \
-                --setopt=skip_missing_names_on_install=False \
-                --enablerepo="epel,rhel-7-server-extras-rpms" \
-                mod_ssl \
-                mod_wsgi \
-                openssl \
-                --setopt=obsoletes=0 pgadmin4-web-4.18 \
-                postgresql${PG_MAJOR//.}-server \
-        && ${PACKAGER} -y clean all --enablerepo="epel,rhel-7-server-extras-rpms" \
-        && chown -R 2:0 /usr/lib/python2.7/site-packages/pgadmin4-web \
-                /var/lib/pgadmin /var/log/pgadmin /certs /etc/httpd /run/httpd \
-                /var/log/httpd \
-        && chmod -R g=u /usr/lib/python2.7/site-packages/pgadmin4-web \
-                /var/lib/pgadmin /var/log/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd \
-        && ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python2.7/site-packages/pgadmin4-web/config_local.py \
-        && ln -sf /var/lib/pgadmin/pgadmin.conf /etc/httpd/conf.d/pgadmin.conf ; \
-fi
-
 RUN if [ "$BASEOS" = "ubi7" ] ; then \
         ${PACKAGER} -y install \
                 --setopt=skip_missing_names_on_install=False \
@@ -84,7 +67,8 @@ RUN if [ "$BASEOS" = "ubi7" ] ; then \
                 mod_ssl \
                 mod_wsgi \
                 openssl \
-                --setopt=obsoletes=0 pgadmin4-web-4.18 \
+                pgadmin4-web-4.20 \
+                --setopt=obsoletes=0 \
                 postgresql${PG_MAJOR//.}-server \
         && ${PACKAGER} -y clean all --enablerepo="epel,rhel-7-server-extras-rpms" \
         && chown -R 2:0 /usr/lib/python2.7/site-packages/pgadmin4-web \
@@ -103,7 +87,8 @@ RUN if [ "$BASEOS" = "ubi8" ] ; then \
                 mod_ssl \
                 python3-mod_wsgi \
                 openssl \
-                --setopt=obsoletes=0 pgadmin4-web-4.20 \
+                pgadmin4-web-4.20 \
+                --setopt=obsoletes=0 \
                 postgresql${PG_MAJOR//.}-server \
         && ${PACKAGER} -y clean all --enablerepo="epel" \
         && chown -R 2:0 /usr/lib/python3.6/site-packages/pgadmin4-web \

--- a/build/pgadmin4/Dockerfile
+++ b/build/pgadmin4/Dockerfile
@@ -23,32 +23,28 @@ RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /var/lib/pgadmin /var/log/pgadmin \
 RUN if [ "$BASEOS" = "centos7" ] ; then \
         ${PACKAGER} -y install \
                 --setopt=skip_missing_names_on_install=False \
-                gcc \
                 mod_ssl \
                 mod_wsgi \
                 openssl \
-                pgadmin4-web-4.20 \
-                --setopt=obsoletes=0 \
+                --setopt=obsoletes=0 pgadmin4 \
                 postgresql${PG_MAJOR//.}-server \
         && ${PACKAGER} -y clean all  \
-        && chown -R 2:0 /usr/lib/python2.7/site-packages/pgadmin4-web \
+        && chown -R 2:0 /usr/lib/python3.6/site-packages/pgadmin4-web \
                 /var/lib/pgadmin /var/log/pgadmin /certs /etc/httpd /run/httpd \
                 /var/log/httpd \
-        && chmod -R g=u /usr/lib/python2.7/site-packages/pgadmin4-web \
+        && chmod -R g=u /usr/lib/python3.6/site-packages/pgadmin4-web \
                 /var/lib/pgadmin /var/log/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd \
-        && ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python2.7/site-packages/pgadmin4-web/config_local.py \
+        && ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python3.6/site-packages/pgadmin4-web/config_local.py \
         && ln -sf /var/lib/pgadmin/pgadmin.conf /etc/httpd/conf.d/pgadmin.conf ; \
 fi
 
 RUN if [ "$BASEOS" = "centos8" ] ; then \
         ${PACKAGER} -y install \
                 --setopt=skip_missing_names_on_install=False \
-                gcc \
                 mod_ssl \
                 python3-mod_wsgi \
                 openssl \
-                pgadmin4-web-4.20 \
-                --setopt=obsoletes=0 \
+                --setopt=obsoletes=0 pgadmin4 \
                 postgresql${PG_MAJOR//.}-server \
         && ${PACKAGER} -y clean all \
         && chown -R 2:0 /usr/lib/python3.6/site-packages/pgadmin4-web \
@@ -67,16 +63,15 @@ RUN if [ "$BASEOS" = "ubi7" ] ; then \
                 mod_ssl \
                 mod_wsgi \
                 openssl \
-                pgadmin4-web-4.20 \
-                --setopt=obsoletes=0 \
+                --setopt=obsoletes=0 pgadmin4 \
                 postgresql${PG_MAJOR//.}-server \
         && ${PACKAGER} -y clean all --enablerepo="epel,rhel-7-server-extras-rpms" \
-        && chown -R 2:0 /usr/lib/python2.7/site-packages/pgadmin4-web \
+        && chown -R 2:0 /usr/lib/python3.6/site-packages/pgadmin4-web \
                 /var/lib/pgadmin /var/log/pgadmin /certs /etc/httpd /run/httpd \
                 /var/log/httpd \
-        && chmod -R g=u /usr/lib/python2.7/site-packages/pgadmin4-web \
+        && chmod -R g=u /usr/lib/python3.6/site-packages/pgadmin4-web \
                 /var/lib/pgadmin /var/log/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd \
-        && ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python2.7/site-packages/pgadmin4-web/config_local.py \
+        && ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python3.6/site-packages/pgadmin4-web/config_local.py \
         && ln -sf /var/lib/pgadmin/pgadmin.conf /etc/httpd/conf.d/pgadmin.conf ; \
 fi
 
@@ -87,8 +82,7 @@ RUN if [ "$BASEOS" = "ubi8" ] ; then \
                 mod_ssl \
                 python3-mod_wsgi \
                 openssl \
-                pgadmin4-web-4.20 \
-                --setopt=obsoletes=0 \
+                --setopt=obsoletes=0 pgadmin4 \
                 postgresql${PG_MAJOR//.}-server \
         && ${PACKAGER} -y clean all --enablerepo="epel" \
         && chown -R 2:0 /usr/lib/python3.6/site-packages/pgadmin4-web \

--- a/conf/pgadmin4/pgadmin-http.conf
+++ b/conf/pgadmin4/pgadmin-http.conf
@@ -1,9 +1,9 @@
 <VirtualHost *:SERVER_PORT>
 	LoadModule wsgi_module modules/mod_wsgi.so
 	WSGIDaemonProcess pgadmin processes=1 threads=25
-	WSGIScriptAlias SERVER_PATH /usr/lib/python2.7/site-packages/pgadmin4-web/pgAdmin4.wsgi
+	WSGIScriptAlias SERVER_PATH /usr/lib/python3.6/site-packages/pgadmin4-web/pgAdmin4.wsgi
 
-	<Directory /usr/lib/python2.7/site-packages/pgadmin4-web/>
+	<Directory /usr/lib/python3.6/site-packages/pgadmin4-web/>
 		WSGIProcessGroup pgadmin
 		WSGIApplicationGroup %{GLOBAL}
 		<IfModule mod_authz_core.c>

--- a/conf/pgadmin4/pgadmin-https.conf
+++ b/conf/pgadmin4/pgadmin-https.conf
@@ -2,7 +2,7 @@
 
     LoadModule ssl_module modules/mod_ssl.so
 	LoadModule wsgi_module modules/mod_wsgi.so
-    
+
     SSLEngine on
     SSLCipherSuite HIGH:!aNULL:!MD5
     SSLProtocol +TLSv1.2
@@ -10,9 +10,9 @@
     SSLCertificateKeyFile "/certs/server.key"
 
 	WSGIDaemonProcess pgadmin processes=1 threads=25
-	WSGIScriptAlias SERVER_PATH /usr/lib/python2.7/site-packages/pgadmin4-web/pgAdmin4.wsgi
+	WSGIScriptAlias SERVER_PATH /usr/lib/python3.6/site-packages/pgadmin4-web/pgAdmin4.wsgi
 
-	<Directory /usr/lib/python2.7/site-packages/pgadmin4-web/>
+	<Directory /usr/lib/python3.6/site-packages/pgadmin4-web/>
 		WSGIProcessGroup pgadmin
 		WSGIApplicationGroup %{GLOBAL}
 		<IfModule mod_authz_core.c>


### PR DESCRIPTION
- Remove RHEL 7 references
- Remove gcc from the packages
- Ensure pgAdmin 4 4.20 is the latest and greatest everywhere
- Ensure pgAdmin 4 runs on EL8

[ch9207]