### PR TITLE
Add wal2json to the PostgreSQL containers

### DIFF
--- a/build/postgres-ha/Dockerfile
+++ b/build/postgres-ha/Dockerfile
@@ -34,6 +34,7 @@ RUN if [ "$DFSET" = "centos" ] ; then \
         	psmisc \
         	rsync \
         	less \
+        	wal2json${PG_MAJOR//.} \
         && ${PACKAGER} -y clean all ; \
 else \
        ${PACKAGER} -y install \
@@ -53,6 +54,7 @@ else \
 		psmisc \
 		rsync \
 		less \
+		wal2json${PG_MAJOR//.} \
 	&& ${PACKAGER} -y install \
 		--setopt=tsflags='' \
 		--enablerepo="epel" \

--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -33,6 +33,7 @@ RUN if [ "$DFSET" = "centos" ] ; then \
         	$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
         	psmisc \
         	rsync \
+        	wal2json${PG_MAJOR//.} \
         && ${PACKAGER} -y clean all ; \
 else \
         ${PACKAGER} -y install \
@@ -51,6 +52,7 @@ else \
 		$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
 		psmisc \
 		rsync \
+		wal2json${PG_MAJOR//.} \
 	&& ${PACKAGER} -y install \
 		--setopt=tsflags='' \
 		--enablerepo="epel" \


### PR DESCRIPTION
wal2json is great for applications that want to leverage
logical decoding in an output format that is easy to understand,
let alone parse. The committer of the patch has even used it
himself in the past. So, let's bring it into the containers.

Issue: [ch9125]
fixes CrunchyData/postgres-operator#1816
fixes CrunchyData/postgres-operator#1841