### PR TITLE
Modify PL/Python install directive

### DIFF
--- a/build/postgres-appdev/Dockerfile
+++ b/build/postgres-appdev/Dockerfile
@@ -25,8 +25,7 @@ RUN ${PACKAGER} -y install \
 	postgis25_${PG_MAJOR//.} \
 	postgis25_${PG_MAJOR//.}-client \
 	postgresql${PG_MAJOR//.}-contrib \
-	postgresql${PG_MAJOR//.}-plpython \
-	postgresql${PG_MAJOR//.}-plpython3 \
+	postgresql${PG_MAJOR//.}-plpython* \
 	postgresql${PG_MAJOR//.}-server \
 	R-core \
 	rsync \

--- a/build/postgres-ha/Dockerfile
+++ b/build/postgres-ha/Dockerfile
@@ -27,8 +27,7 @@ RUN if [ "$DFSET" = "centos" ] ; then \
         	crunchy-backrest-${BACKREST_VER} \
         	postgresql${PG_MAJOR//.}-contrib \
         	postgresql${PG_MAJOR//.}-server \
-        	postgresql${PG_MAJOR//.}-plpython \
-        	postgresql${PG_MAJOR//.}-plpython3 \
+        	postgresql${PG_MAJOR//.}-plpython* \
         	pgnodemx${PG_MAJOR//.} \
         	$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
         	psmisc \
@@ -47,8 +46,7 @@ else \
 		crunchy-backrest-${BACKREST_VER} \
 		postgresql${PG_MAJOR//.}-contrib \
 		postgresql${PG_MAJOR//.}-server \
-		postgresql${PG_MAJOR//.}-plpython \
-		postgresql${PG_MAJOR//.}-plpython3 \
+		postgresql${PG_MAJOR//.}-plpython* \
 		pgnodemx${PG_MAJOR//.} \
 		$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
 		psmisc \

--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -27,8 +27,7 @@ RUN if [ "$DFSET" = "centos" ] ; then \
         	crunchy-backrest-${BACKREST_VER} \
         	postgresql${PG_MAJOR//.}-contrib \
         	postgresql${PG_MAJOR//.}-server \
-        	postgresql${PG_MAJOR//.}-plpython \
-        	postgresql${PG_MAJOR//.}-plpython3 \
+        	postgresql${PG_MAJOR//.}-plpython* \
         	pgnodemx${PG_MAJOR//.} \
         	$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
         	psmisc \
@@ -46,8 +45,7 @@ else \
 		crunchy-backrest-${BACKREST_VER} \
 		postgresql${PG_MAJOR//.}-contrib \
 		postgresql${PG_MAJOR//.}-server \
-		postgresql${PG_MAJOR//.}-plpython \
-		postgresql${PG_MAJOR//.}-plpython3 \
+		postgresql${PG_MAJOR//.}-plpython* \
 		pgnodemx${PG_MAJOR//.} \
 		$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
 		psmisc \


### PR DESCRIPTION
As the PostgreSQL 13 builds drop support for Python 2, we need
to modify the install directive so we can include Python 2 on
older installs as well as Python 3 everywhere.