### PR TITLE
Proper Primary Health Endpoint for Standby Leader

### DIFF
--- a/bin/postgres-ha/bootstrap-postgres-ha.sh
+++ b/bin/postgres-ha/bootstrap-postgres-ha.sh
@@ -61,14 +61,22 @@ initialization_monitor() {
 
         if [[ "${PGHA_INIT}" == "true" ]]
         then
+
+            if [[ "${PGHA_STANDBY}" != "true" ]]
+            then
+                primary_endpoint="master"
+            else
+                primary_endpoint="standby_leader"
+            fi
+
             echo_info "PGHA_INIT is '${PGHA_INIT}', waiting to initialize as primary"
             # Wait until the master endpoint returns 200 indicating the local node is running as the current primary
-            status_code=$(curl -o /dev/stderr -w "%{http_code}" "127.0.0.1:${PGHA_PATRONI_PORT}/master" 2> /dev/null)
+            status_code=$(curl -o /dev/stderr -w "%{http_code}" "127.0.0.1:${PGHA_PATRONI_PORT}/${primary_endpoint}" 2> /dev/null)
             until [[ "${status_code}" == "200" ]]
             do
                 sleep 1
                 echo "Not yet running as primary, retrying" >> "/tmp/patroni_initialize_check.log"
-                status_code=$(curl -o /dev/stderr -w "%{http_code}" "127.0.0.1:${PGHA_PATRONI_PORT}/master" 2> /dev/null)
+                status_code=$(curl -o /dev/stderr -w "%{http_code}" "127.0.0.1:${PGHA_PATRONI_PORT}/${primary_endpoint}" 2> /dev/null)
             done
         fi
 


### PR DESCRIPTION
When initializing a standby cluster, the `standby_leader` REST endpoint (as Provided by Patroni) is now utilized to determine if the local instance has initialized as the leader of a standby cluster.  When initializing a non-standby cluster, the `master` REST endpoint is still utilized for this purpose.

This ensures proper leader detection for standby and non-standby clusters, specifically due to a change in behavior (listed as a
bug fix) in Patroni 2.0.0 in which the `master` endpoint can no longer be utilized to detect whether or not the local instance is running as a standby leader.

_This change should be backpatched, even though the issue described should currently only impact v4.5+ (which has Patroni 2.0.0+)._

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Using the `master` endpoint to detect whether the local instance is running as the leader of a standby cluster fails.

https://github.com/CrunchyData/postgres-operator/issues/1959
[ch9581]

**What is the new behavior (if this is a feature change)?**

The `standby_leader` endpoint is utilized to properly detect whether the local instance is running as the leader of a standby cluster.

**Other information**:

N/A