### PR TITLE
Change PGBACKREST_REPO_TYPE to PGBACKREST_REPO1_TYPE in 'crunchy-postgres-ha' Container

### DIFF
--- a/bin/postgres-ha/pgbackrest/pgbackrest-post-bootstrap.sh
+++ b/bin/postgres-ha/pgbackrest/pgbackrest-post-bootstrap.sh
@@ -6,7 +6,7 @@ source /opt/cpm/bin/common/common_lib.sh
 create_pgbackrest_dirs() {
 
     # only create repo dir if using local storage (not if using a central repo or 's3')
-    if [[ ! -v PGBACKREST_REPO1_HOST && "${PGBACKREST_REPO_TYPE}" != "s3" ]]
+    if [[ ! -v PGBACKREST_REPO1_HOST && "${PGBACKREST_REPO1_TYPE}" != "s3" ]]
     then
         if [[ -v PGBACKREST_REPO_PATH ]]
         then

--- a/bin/postgres-ha/pgbackrest/pgbackrest-set-env.sh
+++ b/bin/postgres-ha/pgbackrest/pgbackrest-set-env.sh
@@ -7,7 +7,7 @@ source /tmp/pgbackrest_env.sh
 # Now override any pgBackRest environment variables as needed
 
 # If a bootstrap repo type is specified in the 'replica-bootstrap-repo-type' file (assuming it
-# exists), then use the value within it to override the PGBACKREST_REPO_TYPE env var setting
+# exists), then use the value within it to override the PGBACKREST_REPO1_TYPE env var setting
 # currently set within the environment.  This is needed in scenarios where it is necessary to 
 # override the repo type for specific pgBackRest commands but want to leave the env var set as
 # is within the environment.  
@@ -15,8 +15,8 @@ source /tmp/pgbackrest_env.sh
 # For instance, when bootstrapping and fetching archives for a standby cluster, it is necessary
 # to ensure only "s3" is utilized for pgBackRest 'restore' and 'archive-get' commands.  However, 
 # when the cluster is no longer a standby, this override setting can be removed, and the original
-# value for PGBACKREST_REPO_TYPE can be used instead.  This effectively allows this setting to be
-# changed dynamically without requiring a container restart to update the PGBACKREST_REPO_TYPE env
+# value for PGBACKREST_REPO1_TYPE can be used instead.  This effectively allows this setting to be
+# changed dynamically without requiring a container restart to update the PGBACKREST_REPO1_TYPE env
 # var.
 if [[ -f /pgconf/replica-bootstrap-repo-type ]]
 then
@@ -29,7 +29,7 @@ fi
 
 # for an S3 repo, if TLS verification is disabled, pass in the appropriate flag
 # otherwise, leave the default behavior and verify the S3 server certificate
-if [[ $PGBACKREST_REPO_TYPE == "s3" && $PGHA_PGBACKREST_S3_VERIFY_TLS == "false" ]]
+if [[ $PGBACKREST_REPO1_TYPE == "s3" && $PGHA_PGBACKREST_S3_VERIFY_TLS == "false" ]]
 then
     export PGBACKREST_REPO1_S3_VERIFY_TLS="n"
 fi


### PR DESCRIPTION
Changes `PGBACKREST_REPO_TYPE` to `PGBACKREST_REPO1_TYPE` in the `crunchy-postgres-ha` container. 
 Specifically, since the PostgreSQL Operator now utilizes and set `PGBACKREST_REPO1_TYPE` (and no longer `PGBACKREST_REPO_TYPE`), and since the `pgbackrest-set-env.sh` script utilized to set the proper pgBackRest environment when running `pgbackrest` commands already utilizes `PGBACKREST_REPO1_TYPE` when a replica bootstrap repo type is detected, this change ensures is `PGBACKREST_REPO1_TYPE` is consistently utilized throughout the `crunchy-postgres-ha` container, fully replacing any/all use of `PGBACKREST_REPO_TYPE`.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The `crunchy-postgres-ha` container references both `PGBACKREST_REPO_TYPE` and `PGBACKREST_REPO1_TYPE`.

Issue: https://github.com/CrunchyData/postgres-operator/issues/1953

**What is the new behavior (if this is a feature change)?**

The `crunchy-postgres-ha` container _only_ references `PGBACKREST_REPO1_TYPE`, ensuring consistent configuration of the repo type within the container.

**Other information**:

N/A