### PR TITLE
Update Approach for Saving pgBackRest Environment Variables

### DIFF
--- a/bin/postgres-ha/pgbackrest/pgbackrest-pre-bootstrap.sh
+++ b/bin/postgres-ha/pgbackrest/pgbackrest-pre-bootstrap.sh
@@ -66,7 +66,5 @@ set_pgbackrest_env_vars() {
 
 set_pgbackrest_env_vars
 
-env | grep "^PGBACKREST" | while read line ;
-do
-  echo "export ${line}" >> "/tmp/pgbackrest_env.sh"
-done
+# save pgbackrest env vars so they can be restored as needed to execute pgbackrest commands
+export -p | grep "^declare -x PGBACKREST" > "/tmp/pgbackrest_env.sh"


### PR DESCRIPTION
Implements a new approach for saving pgBackRest environment variables to file within the `crunchy-postgres-ha` container (as needed to ensure they can subsequently be restored in order to run various `pgbackrest` commands).  Specifically, the `export -p` command is now utilized, which ensures variables are properly quoted and escaped when stored (e.g. to ensure the proper handling of special characters), therefore ensuring the variables are accurately restored when subsequently needed to run various pgBackRest commands within the container.

Issue: [ch9718]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Special characters (such as an ampersand [`&`]) in `PGBACKREST` environment variables can lead to issues when saving and then restoring those environment variables within the `crunchy-postgres-ha` container.

https://github.com/CrunchyData/postgres-operator/issues/2024
[ch9718]

**What is the new behavior (if this is a feature change)?**

Special characters (such as an ampersand [`&`]) are properly handled when saved and restored within the `crunchy-postgres-ha` container.

**Other information**:

N/A