### PR TITLE
Mark PostgreSQL's data volume to detect failed initialization

### DIFF
--- a/bin/postgres-ha/bootstrap/pre-bootstrap.sh
+++ b/bin/postgres-ha/bootstrap/pre-bootstrap.sh
@@ -299,8 +299,6 @@ build_bootstrap_config_file() {
 
     if [[ "${PGHA_INIT}" == "true" ]]
     then
-        echo_info "PGDATA directory is empty on node identifed as Primary"
-        echo_info "initdb configuration will be applied to intitilize a new database"
         /opt/cpm/bin/yq m -i -x "${bootstrap_file}" "/opt/cpm/conf/postgres-ha-initdb.yaml"
 
         if [[ -n "${PGHA_WALDIR}" ]]
@@ -455,7 +453,7 @@ build_bootstrap_config_file
 # If the PGHA_INIT flag is 'true' and we're initializing from an existing PGDATA directory, then
 # proceed with preparing the PGDATA directory for the 'existing_init' bootstrap method.
 # Specifically, temporarily rename the existing PGDATA directory so that the true PGDATA 
-# directory remains empty.  This will allow the 'existing_init' bootstrap method to be called,
+# directory remains empty.  This will cause Patroni to call the 'existing_init' bootstrap method,
 # which will undo the directory name change and allow initialization to proceed using the data 
 # contained within the existing PGDATA directory.
 if [[ "${PGHA_INIT}" == "true" ]] && [[ "${PGHA_BOOTSTRAP_METHOD}" == "existing_init" ]]


### PR DESCRIPTION






**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

When bootstrap fails, Patroni renames the data directory and exits. The next time the container starts, the "missing" data directory triggers a successful `initdb` bootstrap, and the cluster comes online empty. When initializing from an existing data directory, being online like this can lead to future data loss.

**What is the new behavior (if this is a feature change)?**

To detect bootstrap failures across restarts, we place a file next to the PostgreSQL data directory and remove it when bootstrap succeeds. If we detect this file during startup, we pause the process (logging in a loop) and do not proceed.

Some human intervention is now required whenever bootstrap fails. This could be relaxed in the future to allow for some automated retry.

**Other information**:

Issue: [ch9711]