### PR TITLE
Updates to the pgBadger container

### DIFF
--- a/build/pgbadger/Dockerfile
+++ b/build/pgbadger/Dockerfile
@@ -2,9 +2,9 @@ ARG BASEOS
 ARG BASEVER
 ARG PG_FULL
 ARG PREFIX
-FROM golang:1.15.4 as badgerserver-build
+FROM golang:1.15.5 as badgerserver-build
 WORKDIR /go/src/github.com/crunchydata/crunchy-containers
-ADD . .
+ADD ./badger ./badger
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o badgerserver ./badger
 
 FROM ${PREFIX}/crunchy-pg-base:${BASEOS}-${PG_FULL}-${BASEVER}


### PR DESCRIPTION
This updates the version of Go to 1.15.5 and limits the number
of files that are included in the build portion of the
pgBadger contianer.