### PR TITLE
Enable Delta Restores When Using the 'pgbackrest_init' Bootstrap Method

### DIFF
--- a/bin/postgres-ha/bootstrap/pre-bootstrap.sh
+++ b/bin/postgres-ha/bootstrap/pre-bootstrap.sh
@@ -451,13 +451,15 @@ validate_env
 # Create the Patroni bootstrap configuration file
 build_bootstrap_config_file
 
-# If the PGHA_INIT flag is 'true' and we're initializing from an existing PGDATA directory, then
-# proceed with preparing the PGDATA directory for the 'existing_init' bootstrap method.
-# Specifically, temporarily rename the existing PGDATA directory so that the true PGDATA 
-# directory remains empty.  This will cause Patroni to call the 'existing_init' bootstrap method,
-# which will undo the directory name change and allow initialization to proceed using the data 
-# contained within the existing PGDATA directory.
-if [[ "${PGHA_INIT}" == "true" ]] && [[ "${PGHA_BOOTSTRAP_METHOD}" == "existing_init" ]]
+# If the PGHA_INIT flag is 'true' and data exists within the PGDATA directory, then proceed with
+# preparing the PGDATA directory for cluster bootstrap.  Specifically, assume we are using a
+# bootstrap method that is able to leverage an existing PGDATA directory (for instance, if starting
+# the database that already exists within the PGDATA directory, or if performing a pgBackRest delta
+# restore), and temporarily rename the existing PGDATA directory so that the true PGDATA directory
+# remains empty.  This will cause Patroni to bootstrap a new PostgreSQL cluster from scratch, while
+# still allowing the configured bootstrap method to leverage any existing data within the PGDATA
+# directory as needed.
+if [[ "${PGHA_INIT}" == "true" ]] && [[ -n "$(ls -A "${PATRONI_POSTGRESQL_DATA_DIR}")" ]]
 then
     echo_info "Detected cluster initialization using an existing PGDATA directory"
     mv "${PATRONI_POSTGRESQL_DATA_DIR}" "${PATRONI_POSTGRESQL_DATA_DIR}_tmp"

--- a/bin/postgres-ha/bootstrap/pre-bootstrap.sh
+++ b/bin/postgres-ha/bootstrap/pre-bootstrap.sh
@@ -232,7 +232,7 @@ set_pg_user_credentials() {
 set_bootstrap_method() {
     if [[ ! -v PGHA_BOOTSTRAP_METHOD ]]
     then
-        if [[ -n "$(ls -A "${PATRONI_POSTGRESQL_DATA_DIR}")" ]]
+        if [[ -d "${PATRONI_POSTGRESQL_DATA_DIR}" && -n "$(ls -A "${PATRONI_POSTGRESQL_DATA_DIR}")" ]]
         then
             export PGHA_BOOTSTRAP_METHOD="existing_init"
         else
@@ -459,7 +459,8 @@ build_bootstrap_config_file
 # remains empty.  This will cause Patroni to bootstrap a new PostgreSQL cluster from scratch, while
 # still allowing the configured bootstrap method to leverage any existing data within the PGDATA
 # directory as needed.
-if [[ "${PGHA_INIT}" == "true" ]] && [[ -n "$(ls -A "${PATRONI_POSTGRESQL_DATA_DIR}")" ]]
+if [[ "${PGHA_INIT}" == "true" ]] && 
+    [[ -d "${PATRONI_POSTGRESQL_DATA_DIR}" && -n "$(ls -A "${PATRONI_POSTGRESQL_DATA_DIR}")" ]]
 then
     echo_info "Detected cluster initialization using an existing PGDATA directory"
     mv "${PATRONI_POSTGRESQL_DATA_DIR}" "${PATRONI_POSTGRESQL_DATA_DIR}_tmp"


### PR DESCRIPTION
If a pgBackRest restore has been requested when bootstrapping a new PostgreSQL cluster (i.e. the `PGHA_BOOTSTRAP_METHOD` environment variable is set to `pgbackrest_init`), and the `PGDATA` directory contains an existing PostgreSQL database, then a pgBackRest delta restore will be attempted.  This allows users to leverage existing `PGDATA` directories when restoring from an existing pgBackRest backup during cluster initialization, specifically by leveraging pgBackRest's delta restore capability to cleanly and efficiently populate the `PGDATA` directory.

It should be noted that as of this commit, an existing `PGATA` directory will only be loaded if the `PGHA_BOOTSTRAP_METHOD` is set to `existing_init` (as will automatically occur if `PGHA_BOOTSTRAP_METHOD` is not explicitly set and an existing PostgreSQL database is detected).  Therefore, if a user requests to restore from an existing or former PostgreSQL cluster when bootstrapping a new cluster, but also has an existing database within the `PGDATA` directory, the restore will now now always take precedence (specifically in the form of a pgBackRest delta restore), overwriting any contents of the `PGDATA` directory as needed to complete the delta restore.  This is a change from previous behavior, in which loading an existing PostgreSQL database (if detected within the `PGDATA` directory) would always take precedence over performing a restore, even if a restore was explicitly requested.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

If data is detected in the `PGDATA` directory when initializing the `crunchy-postgres-ha` container, and the user has also requested the use of a pgBackRest restore to bootstrap a new PostgreSQL cluster (specifically by setting the `PGHA_BOOTSTRAP_METHOD` environment variable is set to `pgbackrest_init`), then an attempt is made to start the existing database within the `PGDATA` directory, and a restore is not performed.

[ch9814]

**What is the new behavior (if this is a feature change)?**

If data is detected in the `PGDATA` directory when initializing the `crunchy-postgres-ha` container, and the user has also requested the use of a pgBackRest restore to bootstrap a new PostgreSQL cluster (specifically by setting the `PGHA_BOOTSTRAP_METHOD` environment variable is set to `pgbackrest_init`), then a pgBackRest delta restore will automatically be attempted.

**Other information**:

N/A