### PR TITLE
Containers Compaction: pgBouncer pgBadger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ crunchyadm: admin-pgimg-$(IMGBUILDER)
 pgadmin4: pgadmin4-pgimg-$(IMGBUILDER)
 pgbackrest: pgbackrest-pgimg-$(IMGBUILDER)
 pgbackrest-repo: pgbackrest-repo-pgimg-$(IMGBUILDER)
-pgbadger: pgbadger-pgimg-$(IMGBUILDER)
-pgbouncer: pgbouncer-pgimg-$(IMGBUILDER)
+pgbadger: pgbadger-img-$(IMGBUILDER)
+pgbouncer: pgbouncer-img-$(IMGBUILDER)
 pgpool: pgpool-pgimg-$(IMGBUILDER)
 postgres: postgres-pgimg-$(IMGBUILDER)
 postgres-ha: postgres-ha-pgimg-$(IMGBUILDER)
@@ -336,6 +336,7 @@ pgbackrest-repo-pgimg-docker: pgbackrest-repo-pgimg-build
 		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
 		--build-arg DFSET=$(DFSET) \
 		--build-arg PACKAGER=$(PACKAGER) \
+		--build-arg PG_LBL=${subst .,,$(CCP_PGVERSION)} \
 		$(CCPROOT)
 
 %-pgimg-buildah: %-pgimg-build ;
@@ -358,6 +359,7 @@ endif
 		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
 		--build-arg DFSET=$(DFSET) \
 		--build-arg PACKAGER=$(PACKAGER) \
+		--build-arg PG_LBL=${subst .,,$(CCP_PGVERSION)} \
 		$(CCPROOT)
 
 %-img-buildah: %-img-build ;

--- a/bin/pgbadger/badger-generate.sh
+++ b/bin/pgbadger/badger-generate.sh
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source /opt/cpm/bin/common_lib.sh
+CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+source "${CRUNCHY_DIR}/bin/common_lib.sh"
 enable_debugging
 export BADGER_CUSTOM_OPTS=${BADGER_CUSTOM_OPTS:-}
 

--- a/bin/pgbadger/start-pgbadger.sh
+++ b/bin/pgbadger/start-pgbadger.sh
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source /opt/cpm/bin/common_lib.sh
+CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+source "${CRUNCHY_DIR}/bin/common_lib.sh"
 enable_debugging
 
-export PATH=$PATH:/opt/cpm/bin
+export PATH="${PATH}:${CRUNCHY_DIR}/bin"
 export PIDFILE=/tmp/badgerserver.pid
 
 function trap_sigterm() {
@@ -30,7 +31,7 @@ trap 'trap_sigterm' SIGINT SIGTERM
 env_check_info "BADGER_TARGET" "Overriding BADGER_TARGET environment variable and setting to ${BADGER_TARGET}."
 
 echo_info "Starting pgBadger server.."
-/opt/cpm/bin/badgerserver &
+"${CRUNCHY_DIR}/bin/badgerserver" &
 echo $! > $PIDFILE
 
 wait

--- a/bin/pgbouncer/start.sh
+++ b/bin/pgbouncer/start.sh
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source /opt/cpm/bin/common_lib.sh
+CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+source "${CRUNCHY_DIR}/bin/common_lib.sh"
 enable_debugging
 
 
@@ -39,7 +40,7 @@ then
     echo_info "Custom users.txt file detected.."
 else
     echo_info "No custom users.txt detected.  Apply default config.."
-    cp /opt/cpm/conf/users.txt ${CONF_DIR?}/users.txt
+    cp "${CRUNCHY_DIR}/conf/users.txt" "${CONF_DIR?}/users.txt"
     env_check_err "PGBOUNCER_PASSWORD"
     sed -i "s/PGBOUNCER_PASSWORD/${PGBOUNCER_PASSWORD?}/g" ${CONF_DIR?}/users.txt
 fi
@@ -49,7 +50,7 @@ then
     echo_info "Custom pgbouncer.ini file detected.."
 else
     echo_info "No custom pgbouncer.ini detected.  Applying default config.."
-    cp /opt/cpm/conf/pgbouncer.ini ${CONF_DIR?}/pgbouncer.ini
+    cp "${CRUNCHY_DIR}/conf/pgbouncer.ini" "${CONF_DIR?}/pgbouncer.ini"
 
     env_check_err "PG_SERVICE"
 

--- a/build/pgbadger/Dockerfile
+++ b/build/pgbadger/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /go/src/github.com/crunchydata/crunchy-containers
 ADD ./badger ./badger
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o badgerserver ./badger
 
-FROM ${PREFIX}/crunchy-pg-base:${BASEOS}-${PG_FULL}-${BASEVER}
+FROM ${PREFIX}/crunchy-base:${BASEOS}-${PG_FULL}-${BASEVER}
 
 # For RHEL8 all arguments used in main code has to be specified after FROM
 ARG BASEOS
@@ -15,6 +15,8 @@ ARG DFSET
 ARG PACKAGER
 
 ARG PG_MAJOR
+# Needed due to lack of environment substitution trick on ADD
+ARG PG_LBL
 
 LABEL name="pgbadger" \
 	summary="HTTP wrapper around the PGBadger PostgreSQL utility" \
@@ -22,6 +24,26 @@ LABEL name="pgbadger" \
 	io.k8s.description="pgBadger" \
 	io.k8s.display-name="pgBadger" \
 	io.openshift.tags="postgresql,postgres,monitoring,pgbadger,database,crunchy"
+
+# Crunchy Postgres repo GPG Keys
+# Both keys are added to support building all PG versions
+# of this container. PG 11+ requires RPM-GPG-KEY-crunchydata
+# PG 9.5, 9.6 and 10 require CRUNCHY-GPG-KEY.public on RHEL machines
+ADD conf/*KEY* /
+
+# Add any available Crunchy PG repo files
+ADD conf/crunchypg${PG_LBL}.repo /etc/yum.repos.d/
+# Import both keys to support all required repos
+RUN rpm --import RPM-GPG-KEY-crunchydata*
+RUN if [ "$DFSET" = "rhel" ] ; then rpm --import CRUNCHY-GPG-KEY.public ; fi
+
+RUN if [ "$BASEOS" = "centos8" ] ; then \
+	${PACKAGER} -qy module disable postgresql ; \
+fi
+
+RUN if [ "$BASEOS" = "ubi8" ] ; then \
+	${PACKAGER} -qy module disable postgresql ; \
+fi
 
 RUN if [ "$DFSET" = "centos" ] ; then \
        ${PACKAGER} -y install \
@@ -60,17 +82,17 @@ ENV PGVERSION="${PGMAJOR}"
 
 RUN groupadd -g 26 postgres && useradd -g 26 -u 26 postgres
 
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /report
+RUN mkdir -p /opt/crunchy/bin /opt/crunchy/conf /report
 
 COPY --from=badgerserver-build \
 	/go/src/github.com/crunchydata/crunchy-containers/badgerserver \
-	/opt/cpm/bin
-ADD conf/pgbadger /opt/cpm/conf
-ADD bin/common /opt/cpm/bin
-ADD bin/pgbadger /opt/cpm/bin
+	/opt/crunchy/bin
+ADD conf/pgbadger /opt/crunchy/conf
+ADD bin/common /opt/crunchy/bin
+ADD bin/pgbadger /opt/crunchy/bin
 
-RUN chown -R postgres:postgres /opt/cpm /report /bin && \
-	chmod -R g=u /opt/cpm /report /bin
+RUN chown -R postgres:postgres /opt/crunchy /report /bin && \
+	chmod -R g=u /opt/crunchy /report /bin
 
 # pgbadger port
 EXPOSE 10000
@@ -82,8 +104,8 @@ RUN chmod g=u /etc/passwd && \
 # volume permissions are applied when building the image
 VOLUME ["/pgdata", "/report"]
 
-ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
+ENTRYPOINT ["opt/crunchy/bin/uid_postgres.sh"]
 
 USER 26
 
-CMD ["/opt/cpm/bin/start-pgbadger.sh"]
+CMD ["/opt/crunchy/bin/start-pgbadger.sh"]

--- a/build/pgbouncer/Dockerfile
+++ b/build/pgbouncer/Dockerfile
@@ -2,13 +2,15 @@ ARG BASEOS
 ARG BASEVER
 ARG PG_FULL
 ARG PREFIX
-FROM ${PREFIX}/crunchy-pg-base:${BASEOS}-${PG_FULL}-${BASEVER}
+FROM ${PREFIX}/crunchy-base:${BASEOS}-${PG_FULL}-${BASEVER}
 
 # For RHEL8 all arguments used in main code has to be specified after FROM
 ARG DFSET
 ARG PACKAGER
 
 ARG PG_MAJOR
+# Needed due to lack of environment substitution trick on ADD
+ARG PG_LBL
 
 LABEL name="pgbouncer" \
 	summary="Lightweight connection pooler for crunchy-postgres" \
@@ -17,7 +19,28 @@ LABEL name="pgbouncer" \
 	io.k8s.display-name="pgBouncer" \
 	io.openshift.tags="postgresql,postgres,pooling,pgbouncer,database,crunchy"
 
+# Crunchy Postgres repo GPG Keys
+# Both keys are added to support building all PG versions
+# of this container. PG 11+ requires RPM-GPG-KEY-crunchydata
+# PG 9.5, 9.6 and 10 require CRUNCHY-GPG-KEY.public on RHEL machines
+ADD conf/*KEY* /
+
+# Add any available Crunchy PG repo files
+ADD conf/crunchypg${PG_LBL}.repo /etc/yum.repos.d/
+# Import both keys to support all required repos
+RUN rpm --import RPM-GPG-KEY-crunchydata*
+RUN if [ "$DFSET" = "rhel" ] ; then rpm --import CRUNCHY-GPG-KEY.public ; fi
+
+RUN if [ "$BASEOS" = "centos8" ] ; then \
+	${PACKAGER} -qy module disable postgresql ; \
+fi
+
+RUN if [ "$BASEOS" = "ubi8" ] ; then \
+	${PACKAGER} -qy module disable postgresql ; \
+fi
+
 RUN ${PACKAGER} -y install \
+	--disablerepo="epel" \
 	--setopt=skip_missing_names_on_install=False \
 	pgbouncer \
 	&& ${PACKAGER} -y clean all
@@ -25,14 +48,14 @@ RUN ${PACKAGER} -y install \
 # Preserving PGVERSION out of paranoia
 ENV PGVERSION="${PG_MAJOR}"
 
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgconf
+RUN mkdir -p /opt/crunchy/bin /opt/crunchy/conf /pgconf
 
-ADD bin/pgbouncer /opt/cpm/bin
-ADD bin/common /opt/cpm/bin
-ADD conf/pgbouncer /opt/cpm/conf
+ADD bin/pgbouncer /opt/crunchy/bin
+ADD bin/common /opt/crunchy/bin
+ADD conf/pgbouncer /opt/crunchy/conf
 
-RUN chown -R 2:0 /opt/cpm /pgconf && \
-	chmod -R g=u /opt/cpm /pgconf
+RUN chown -R 2:0 /opt/crunchy /pgconf && \
+	chmod -R g=u /opt/crunchy /pgconf
 
 EXPOSE 6432
 
@@ -42,8 +65,8 @@ RUN chmod g=u /etc/passwd
 # volume permissions are applied when building the image
 VOLUME ["/pgconf"]
 
-ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
+ENTRYPOINT ["opt/crunchy/bin/uid_daemon.sh"]
 
 USER 2
 
-CMD ["/opt/cpm/bin/start.sh"]
+CMD ["/opt/crunchy/bin/start.sh"]


### PR DESCRIPTION
In an effort to remove the crunchy-pg-base image the crunchy-pgbouncer and
crunchy-pgbadger iamges are now built based on the crunchy-base image. Since
neither pgBouncer or pgBadger depend on having PostgreSQL installed, using the
crunchy-pg-base image was making the images larger than they needed to be. This
also removes two more dependencies on the crunchy-pg-base image.

The scripts for crunchy-pgbouncer and crunchy-pgbadger have been updated with
the new `/opt/crunchy` (previously `/opt/cpm`) path when adding binary and
config files. The dockerfiles for these two images now include steps to setup
the required repository files and packager settings based on the baseos. These
steps were previously done in the crunchy-pg-base image.

The pgBouncer dockerfile was modified to not installed the EPEL version of
pgBouncer.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
