### PR TITLE
Remove references to crunchy-backrest-restore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,29 +244,6 @@ endif
 
 postgres-gis-ha-pgimg-docker: postgres-gis-ha-pgimg-build
 
-# ----- Special case pg-based image (backrest-restore) -----
-# Special case args: BACKREST_VER
-backrest-restore-pgimg-build: cc-pg-base-image $(CCPROOT)/build/backrest-restore/Dockerfile
-	$(IMGCMDSTEM) \
-		-f $(CCPROOT)/build/backrest-restore/Dockerfile \
-		-t $(CCP_IMAGE_PREFIX)/crunchy-backrest-restore:$(CCP_IMAGE_TAG) \
-		--build-arg BASEOS=$(CCP_BASEOS) \
-		--build-arg BASEVER=$(CCP_VERSION) \
-		--build-arg PG_FULL=$(CCP_PG_FULLVERSION) \
-		--build-arg PG_MAJOR=$(CCP_PGVERSION) \
-		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
-		--build-arg BACKREST_VER=$(CCP_BACKREST_VERSION) \
-		--build-arg DFSET=$(DFSET) \
-		--build-arg PACKAGER=$(PACKAGER) \
-		$(CCPROOT)
-
-backrest-restore-pgimg-buildah: backrest-restore-pgimg-build ;
-# only push to docker daemon if variable PGO_PUSH_TO_DOCKER_DAEMON is set to "true"
-ifeq ("$(IMG_PUSH_TO_DOCKER_DAEMON)", "true")
-	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-backrest-restore:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-backrest-restore:$(CCP_IMAGE_TAG)
-endif
-
-backrest-restore-pgimg-docker: backrest-restore-pgimg-build
 
 # ----- Special case image (pgbackrest) -----
 

--- a/bin/pull-from-gcr.sh
+++ b/bin/pull-from-gcr.sh
@@ -6,7 +6,6 @@ REGISTRY='us.gcr.io/container-suite'
 VERSION=${CCP_IMAGE_TAG?}
 GIS_VERSION=${CCP_POSTGIS_IMAGE_TAG?}
 IMAGES=(
-    crunchy-backrest-restore
     crunchy-pgadmin4
     crunchy-pgbadger
     crunchy-pgbouncer

--- a/bin/remove-all-images.sh
+++ b/bin/remove-all-images.sh
@@ -15,7 +15,7 @@
 
 for i in \
 restore pgdump pgrestore postgres-gis pgbadger pgpool \
-watch backup postgres pgbouncer pgadmin4 upgrade backrest-restore pgbench \
+watch backup postgres pgbouncer pgadmin4 upgrade pgbench \
 pgbasebackup-restore postgres-ha postgres-gis-ha
 do
 	docker rmi -f  $CCP_IMAGE_PREFIX/crunchy-$i:$CCP_IMAGE_TAG


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the new behavior (if this is a feature change)?**
The functionality of the crunchy-backrest-restore container is
now included in the new crunchy-pgbackrest. As such, the existing
reference to the obsolete container can now be removed.


**Other information**:
[ch9537]