### PR TITLE
Upgrade compaction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ endif
 # ----- Upgrade Images -----
 upgrade: upgrade-$(CCP_PGVERSION)
 
-upgrade-%: upgrade-pgimg-$(IMGBUILDER) ;
+upgrade-%: upgrade-img-$(IMGBUILDER) ;
 
 upgrade-9.5: # Do nothing but log to avoid erroring out on missing Dockerfile
 	$(info Upgrade build skipped for 9.5)

--- a/bin/upgrade/start.sh
+++ b/bin/upgrade/start.sh
@@ -133,6 +133,9 @@ rm ${PGDATAOLD?}/postmaster.pid
 # changing to /tmp is necessary since pg_upgrade has to have write access
 cd /tmp
 
+# pg_upgrade expects the old pgdata directory to have u=rwx (0700) permissions
+chmod 0700 ${PGDATAOLD?}
+
 ${PGBINNEW?}/pg_upgrade
 rc=$?
 if (( $rc ==  0 )); then

--- a/bin/upgrade/start.sh
+++ b/bin/upgrade/start.sh
@@ -25,7 +25,8 @@
 # $NEW_VERSION (e.g. 9.6)
 #
 
-source /opt/cpm/bin/common_lib.sh
+CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+source "${CRUNCHY_DIR}/bin/common_lib.sh"
 enable_debugging
 
 function trap_sigterm() {
@@ -97,7 +98,7 @@ case $OLD_VERSION in
     ;;
 esac
 
-export PATH=/opt/cpm/bin:${PGBINNEW?}:$PATH
+export PATH="${CRUNCHY_DIR}/bin:${PGBINNEW?}:$PATH"
 
 # Create a clean new data directory
 options=" "

--- a/build/upgrade/Dockerfile
+++ b/build/upgrade/Dockerfile
@@ -2,12 +2,16 @@ ARG BASEOS
 ARG BASEVER
 ARG PG_FULL
 ARG PREFIX
-FROM ${PREFIX}/crunchy-pg-base:${BASEOS}-${PG_FULL}-${BASEVER}
+FROM ${PREFIX}/crunchy-base:${BASEOS}-${PG_FULL}-${BASEVER}
 
 # For RHEL8 all arguments used in main code has to be specified after FROM
+ARG BASEOS
 ARG DFSET
 ARG PACKAGER
 ARG PG_MAJOR
+
+# Needed due to lack of environment substitution trick on ADD
+ARG PG_LBL
 
 LABEL name="upgrade" \
 	summary="Provides a pg_upgrade capability that performs a major PostgreSQL upgrade." \
@@ -16,8 +20,26 @@ LABEL name="upgrade" \
 	io.k8s.display-name="Crunchy PostgreSQL upgrade container" \
 	io.openshift.tags="postgresql,postgres,upgrade,database,crunchy"
 
+# Crunchy Postgres repo GPG Keys
+# Both keys are added to support building all PG versions
+# of this container. PG 11+ requires RPM-GPG-KEY-crunchydata
+# PG 9.5, 9.6 and 10 require CRUNCHY-GPG-KEY.public on RHEL machines
+ADD conf/*KEY* /
+
 # Add in the repository files with the correct PostgreSQL versions
 ADD conf/crunchypg*.repo /etc/yum.repos.d/
+
+# Import both keys to support all required repos
+RUN rpm --import RPM-GPG-KEY-crunchydata*
+RUN if [ "$DFSET" = "rhel" ] ; then rpm --import CRUNCHY-GPG-KEY.public ; fi
+
+RUN if [ "$BASEOS" = "centos8" ] ; then \
+	${PACKAGER} -qy module disable postgresql ; \
+fi
+
+RUN if [ "$BASEOS" = "ubi8" ] ; then \
+	${PACKAGER} -qy module disable postgresql ; \
+fi
 
 # install the highest version of PostgreSQL + pgAudit and its dependencies as
 # well as unzip
@@ -44,13 +66,13 @@ RUN ${PACKAGER} -y install \
 	pgaudit[1-9][0-9] \
 	&& ${PACKAGER} -y clean all
 
-RUN mkdir -p /opt/cpm/bin /pgolddata /pgnewdata /opt/cpm/conf
-ADD bin/upgrade/ /opt/cpm/bin
-ADD bin/common /opt/cpm/bin
-ADD conf/upgrade/ /opt/cpm/conf
+RUN mkdir -p /opt/crunchy/bin /pgolddata /pgnewdata /opt/crunchy/conf
+ADD bin/upgrade/ /opt/crunchy/bin
+ADD bin/common /opt/crunchy/bin
+ADD conf/upgrade/ /opt/crunchy/conf
 
-RUN chown -R postgres:postgres /opt/cpm /pgolddata /pgnewdata && \
-	chmod -R g=u /opt/cpm /pgolddata /pgnewdata
+RUN chown -R postgres:postgres /opt/crunchy /pgolddata /pgnewdata && \
+	chmod -R g=u /opt/crunchy /pgolddata /pgnewdata
 
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
@@ -59,8 +81,8 @@ RUN chmod g=u /etc/passwd && \
 # volume permissions are applied when building the image
 VOLUME /pgolddata /pgnewdata
 
-ENTRYPOINT ["opt/cpm/bin/uid_postgres.sh"]
+ENTRYPOINT ["opt/crunchy/bin/uid_postgres.sh"]
 
 USER 26
 
-CMD ["/opt/cpm/bin/start.sh"]
+CMD ["/opt/crunchy/bin/start.sh"]

--- a/build/upgrade/Dockerfile
+++ b/build/upgrade/Dockerfile
@@ -51,6 +51,7 @@ RUN ${PACKAGER} -y install \
 	"postgresql${PG_MAJOR//.}-contrib" \
 	"postgresql${PG_MAJOR//.}-server" \
 	"pgaudit${PG_MAJOR//.}*" \
+	"pgnodemx${PG_MAJOR//.}" \
 	unzip \
 	&& ${PACKAGER} -y clean all
 
@@ -64,6 +65,7 @@ RUN ${PACKAGER} -y install \
 	postgresql[1-9][0-9]-contrib \
 	postgresql[1-9][0-9]-server \
 	pgaudit[1-9][0-9] \
+	pgnodemx[1-9][0-9] \
 	&& ${PACKAGER} -y clean all
 
 RUN mkdir -p /opt/crunchy/bin /pgolddata /pgnewdata /opt/crunchy/conf


### PR DESCRIPTION
This change updates the crunchy-upgrade container to be based off of
crunchy-base image instead of crunchy-pg-base. This is one step closer to
removing the crunchy-pg-base image entirely. The binary and config paths are
also updated to use `/opt/crunchy` instead of `/opt/cpm`.

This set of changes also includes two bug fixes for the upgrade container:

First, the pgnodemx package has been added to the crunchy-postgres image and is now
included in the default postgresql.conf as an included shared object.
pg_upgrade needs access to any custom shared object files that are installed in
the "old" database. The upgrade image now includes the pgnodemx package for all
versions of postgres that are supported by crunchy repos.

There was also a permissions issue that caused the upgrade job to fail. pg_upgrade 
expects the old pgdata directory to have u=rwx (0700) permissions.
This change updates the permissions in the upgrade/start.sh to meet this
expectation and complete the upgrade.
[ch4854]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

Tested centos7 and ubi8 in gke, tested ubi8 in gcp (ocp 3.11). Was able to follow upgrade example docs to complete a major upgrade (with test data)

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
[ch9428]