### PR TITLE
Container Compaction: Crunchy pgAdmin4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ pgbackrest-images: pgbackrest pgbackrest-repo
 #===========================================
 
 crunchyadm: admin-pgimg-$(IMGBUILDER)
-pgadmin4: pgadmin4-pgimg-$(IMGBUILDER)
+pgadmin4: pgadmin4-img-$(IMGBUILDER)
 pgbackrest: pgbackrest-pgimg-$(IMGBUILDER)
 pgbackrest-repo: pgbackrest-repo-pgimg-$(IMGBUILDER)
 pgbadger: pgbadger-img-$(IMGBUILDER)

--- a/bin/pgadmin4/start-pgadmin4.sh
+++ b/bin/pgadmin4/start-pgadmin4.sh
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source /opt/cpm/bin/common_lib.sh
+CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+source "${CRUNCHY_DIR}/bin/common_lib.sh"
 enable_debugging
 
 export PATH=$PATH:/usr/pgsql-*/bin
@@ -40,13 +41,13 @@ then
         echo_err "ENABLE_TLS true but /certs/server.key or /certs/server.crt not found, aborting"
         exit 1
     fi
-    cp /opt/cpm/conf/pgadmin-https.conf /var/lib/pgadmin/pgadmin.conf
+    cp "${CRUNCHY_DIR}/conf/pgadmin-https.conf" /var/lib/pgadmin/pgadmin.conf
 else
     echo_info "TLS disabled. Applying http configuration.."
-    cp /opt/cpm/conf/pgadmin-http.conf /var/lib/pgadmin/pgadmin.conf
+    cp "${CRUNCHY_DIR}/conf/pgadmin-http.conf" /var/lib/pgadmin/pgadmin.conf
 fi
 
-cp /opt/cpm/conf/config_local.py /var/lib/pgadmin/config_local.py
+cp "${CRUNCHY_DIR}/conf/config_local.py" /var/lib/pgadmin/config_local.py
 
 if [[ -z "${SERVER_PATH}" ]]
 then

--- a/build/pgadmin4/Dockerfile
+++ b/build/pgadmin4/Dockerfile
@@ -2,13 +2,16 @@ ARG BASEOS
 ARG BASEVER
 ARG PG_FULL
 ARG PREFIX
-FROM ${PREFIX}/crunchy-pg-base:${BASEOS}-${PG_FULL}-${BASEVER}
+FROM ${PREFIX}/crunchy-base:${BASEOS}-${PG_FULL}-${BASEVER}
 
 # For RHEL8 all arguments used in main code has to be specified after FROM
 ARG BASEOS
 ARG DFSET
 ARG PACKAGER
 ARG PG_MAJOR
+
+# Needed due to lack of environment substitution trick on ADD
+ARG PG_LBL
 
 LABEL name="pgadmin4" \
 	summary="pgAdmin4 GUI utility" \
@@ -17,7 +20,27 @@ LABEL name="pgadmin4" \
 	io.k8s.display-name="pgAdmin 4" \
 	io.openshift.tags="postgresql,postgres,monitoring,pgadmin4,pgadmin,database,crunchy"
 
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /var/lib/pgadmin /var/log/pgadmin \
+# Crunchy Postgres repo GPG Keys
+# Both keys are added to support building all PG versions
+# of this container. PG 11+ requires RPM-GPG-KEY-crunchydata
+# PG 9.5, 9.6 and 10 require CRUNCHY-GPG-KEY.public on RHEL machines
+ADD conf/*KEY* /
+
+# Add any available Crunchy PG repo files
+ADD conf/crunchypg${PG_LBL}.repo /etc/yum.repos.d/
+# Import both keys to support all required repos
+RUN rpm --import RPM-GPG-KEY-crunchydata*
+RUN if [ "$DFSET" = "rhel" ] ; then rpm --import CRUNCHY-GPG-KEY.public ; fi
+
+RUN if [ "$BASEOS" = "centos8" ] ; then \
+	${PACKAGER} -qy module disable postgresql ; \
+fi
+
+RUN if [ "$BASEOS" = "ubi8" ] ; then \
+	${PACKAGER} -qy module disable postgresql ; \
+fi
+
+RUN mkdir -p /opt/crunchy/bin /opt/crunchy/conf /var/lib/pgadmin /var/log/pgadmin \
         /certs /run/httpd
 
 RUN if [ "$BASEOS" = "centos7" ] ; then \
@@ -99,11 +122,11 @@ fi
 # Preserving PGVERSION out of paranoia
 ENV PGROOT="/usr/pgsql-${PG_MAJOR}" PGVERSION="${PG_MAJOR}"
 
-ADD bin/pgadmin4/ /opt/cpm/bin
-ADD bin/common /opt/cpm/bin
-ADD conf/pgadmin4/ /opt/cpm/conf
+ADD bin/pgadmin4/ /opt/crunchy/bin
+ADD bin/common /opt/crunchy/bin
+ADD conf/pgadmin4/ /opt/crunchy/conf
 
-RUN cp /opt/cpm/conf/httpd.conf /etc/httpd/conf/httpd.conf \
+RUN cp /opt/crunchy/conf/httpd.conf /etc/httpd/conf/httpd.conf \
 	&& rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/ssl.conf
 
 EXPOSE 5050
@@ -114,8 +137,8 @@ RUN chmod g=u /etc/passwd
 # volume permissions are applied when building the image
 VOLUME ["/var/lib/pgadmin", "/certs", "/run/httpd"]
 
-ENTRYPOINT ["opt/cpm/bin/uid_daemon.sh"]
+ENTRYPOINT ["opt/crunchy/bin/uid_daemon.sh"]
 
 USER 2
 
-CMD ["/opt/cpm/bin/start-pgadmin4.sh"]
+CMD ["/opt/crunchy/bin/start-pgadmin4.sh"]


### PR DESCRIPTION
This change updates the crunchy-pgadmin4 container to be based off of
crunchy-base image instead of crunchy-pg-base. This is one step closer to
removing the crunchy-pg-base image entirely. The binary and config paths are
also updated to use `/opt/crunchy` instead of `/opt/cpm`.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**


**What is the new behavior (if this is a feature change)?**



**Other information**:
[ch9428]