### PR TITLE
Modify JIT defaults

### DIFF
--- a/conf/postgres-ha/postgres-ha-bootstrap.yaml
+++ b/conf/postgres-ha/postgres-ha-bootstrap.yaml
@@ -10,6 +10,7 @@ bootstrap:
   dcs:
     postgresql:
       parameters:
+        jit: off
         unix_socket_directories: /tmp,/crunchyadm
         wal_level: logical
   post_bootstrap: /opt/crunchy/bin/postgres-ha/bootstrap/post-bootstrap.sh


### PR DESCRIPTION
Given issues related to memory leaks with certain of the monitoring
queries being traced to JIT (CrunchyData/pgmonitor#182), JIT compilation
will be an opt-in feature.

Issue: [ch9928]