### PR TITLE
Containers Compaction: Crunchy Postgres Appdev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ postgres-ha: postgres-ha-pgimg-$(IMGBUILDER)
 postgres-gis: postgres-gis-pgimg-$(IMGBUILDER)
 postgres-gis-ha: postgres-gis-ha-pgimg-$(IMGBUILDER)
 
-postgres-appdev: commands postgres-appdev-pgimg-$(IMGBUILDER)
+postgres-appdev: commands postgres-appdev-img-$(IMGBUILDER)
 
 #===========================================
 # Pattern-based image generation targets

--- a/build/postgres-appdev/Dockerfile
+++ b/build/postgres-appdev/Dockerfile
@@ -33,15 +33,6 @@ RUN ${PACKAGER} -y install \
 
 ENV PGROOT="/usr/pgsql-${PG_MAJOR}"
 
-# add path settings for postgres user
-# bash_profile is loaded in login, but not with exec
-# bashrc to set permissions in OCP when using exec
-# HOME is / in OCP
-ADD conf/.bash_profile /var/lib/pgsql/
-ADD conf/.bashrc /var/lib/pgsql
-ADD conf/.bash_profile /
-ADD conf/.bashrc /
-
 #RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgconf
 

--- a/build/postgres-appdev/Dockerfile
+++ b/build/postgres-appdev/Dockerfile
@@ -2,12 +2,33 @@ ARG BASEOS
 ARG BASEVER
 ARG PG_FULL
 ARG PREFIX
-FROM ${PREFIX}/crunchy-pg-base:${BASEOS}-${PG_FULL}-${BASEVER}
+FROM ${PREFIX}/crunchy-base:${BASEOS}-${PG_FULL}-${BASEVER}
 
 # For RHEL8 all arguments used in main code has to be specified after FROM
 ARG DFSET
 ARG PACKAGER
 ARG PG_MAJOR
+
+# Needed due to lack of environment substitution trick on ADD
+ARG PG_LBL
+
+# Crunchy Postgres repo GPG Keys
+# Both keys are added to support building all PG versions
+# of this container. PG 11+ requires RPM-GPG-KEY-crunchydata
+# PG 9.5, 9.6 and 10 require CRUNCHY-GPG-KEY.public on RHEL machines
+ADD conf/*KEY* /
+
+# Add any available Crunchy PG repo files
+ADD conf/crunchypg${PG_LBL}.repo /etc/yum.repos.d/
+# Import both keys to support all required repos
+RUN rpm --import RPM-GPG-KEY-crunchydata*
+
+RUN ${PACKAGER} -y install \
+		--setopt=skip_missing_names_on_install=False \
+		--disablerepo=crunchypg* \
+		--enablerepo="crunchypg${PG_LBL}" \
+		postgresql${PG_LBL} \
+	&& ${PACKAGER} -y clean all
 
 LABEL name="postgres-appdev" \
 	summary="A PostgreSQL image that makes life easier for application developers. NOT FOR PRODUCTION USE" \
@@ -20,39 +41,39 @@ RUN ${PACKAGER} -y install \
 	--setopt=skip_missing_names_on_install=False \
 	libRmath \
 	openssl\
-	pgrouting_${PG_MAJOR//.} \
+	pgrouting25_${PG_MAJOR//.} \
 	plr${PG_MAJOR//.} \
 	postgis25_${PG_MAJOR//.} \
 	postgis25_${PG_MAJOR//.}-client \
 	postgresql${PG_MAJOR//.}-contrib \
 	postgresql${PG_MAJOR//.}-plpython* \
 	postgresql${PG_MAJOR//.}-server \
+	pgnodemx${PG_MAJOR//.} \
 	R-core \
 	rsync \
 	&& ${PACKAGER} -y clean all
 
 ENV PGROOT="/usr/pgsql-${PG_MAJOR}"
 
-#RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgwal /pgconf /backup /recover /backrestrepo
-RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgdata /pgconf
+RUN mkdir -p /opt/crunchy/bin /opt/crunchy/conf /pgdata /pgconf
 
-RUN chown -R postgres:postgres /opt/cpm /var/lib/pgsql \
+RUN chown -R postgres:postgres /opt/crunchy /var/lib/pgsql \
 	/pgdata /pgconf && \
-	chmod -R g=u /opt/cpm /var/lib/pgsql \
+	chmod -R g=u /opt/crunchy /var/lib/pgsql \
 	/pgdata /pgconf
 
 # open up the postgres port
 EXPOSE 5432
 
-ADD bin/postgres /opt/cpm/bin
-ADD bin/postgres-gis /opt/cpm/bin
-ADD bin/common /opt/cpm/bin
+ADD bin/postgres_common/postgres /opt/crunchy/bin
+ADD bin/postgres-gis /opt/crunchy/bin
+ADD bin/common /opt/crunchy/bin
 # We load appdev scripts last so they overwrite the earlier ones
-ADD bin/postgres-appdev /opt/cpm/bin
-ADD conf/postgres /opt/cpm/conf
+ADD bin/postgres-appdev /opt/crunchy/bin
+ADD conf/postgres_common/postgres /opt/crunchy/conf
 ####### TODO If we put in PGAdmin need to put the conf here as well
 
-ADD tools/pgmonitor/exporter/postgres /opt/cpm/bin/modules/pgexporter
+ADD tools/pgmonitor/exporter/postgres /opt/crunchy/bin/modules/pgexporter
 
 RUN chmod g=u /etc/passwd && \
 	chmod g=u /etc/group
@@ -64,8 +85,8 @@ RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 # volume permissions are applied when building the image
 VOLUME ["/pgconf", "/pgdata"]
 
-ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
+ENTRYPOINT ["/opt/crunchy/bin/uid_postgres.sh"]
 
 USER 26
 
-CMD ["/opt/cpm/bin/start.sh"]
+CMD ["/opt/crunchy/bin/start.sh"]


### PR DESCRIPTION
This change updates the crunchy-postgres-appdev container to be based off of
the crunchy-base image instead of crunchy-pg-base. This is one step closer to
removing the crunchy-pg-base image entirely.

As part of previous compaction changes the binary and config paths were updated
to use `/opt/crunchy` instead of `/opt/cpm`. In order for the appdev container
to build and run with the updated crunchy-postgres scripts the image needed to
install the correct version of the pgrouting and pgnodemx packages. The
postgresql.conf file expects that the image includes the pgnodemx shared
library.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

Built image using centos7 pg 11 and pg12, was able to run the docker example and access the postgres database

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
