### PR TITLE
Update build order for PostGIS HA image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,8 +197,8 @@ endif
 postgres-ha-pgimg-docker: postgres-ha-pgimg-build
 
 # ----- Special case pg-based image (postgres-gis-ha) -----
-# Special case args: POSTGIS_LBL
-postgres-gis-ha-pgimg-build: postgres-ha-pgimg-build $(CCPROOT)/build/postgres-gis-ha/Dockerfile
+# Special case args: PATRONI_VER
+postgres-gis-ha-pgimg-build: postgres-gis-pgimg-build $(CCPROOT)/build/postgres-gis-ha/Dockerfile
 	$(IMGCMDSTEM) \
 		-f $(CCPROOT)/build/postgres-gis-ha/Dockerfile \
 		-t $(CCP_IMAGE_PREFIX)/crunchy-postgres-gis-ha:$(CCP_POSTGIS_IMAGE_TAG) \
@@ -206,8 +206,9 @@ postgres-gis-ha-pgimg-build: postgres-ha-pgimg-build $(CCPROOT)/build/postgres-g
 		--build-arg BASEVER=$(CCP_VERSION) \
 		--build-arg PG_FULL=$(CCP_PG_FULLVERSION) \
 		--build-arg PG_MAJOR=$(CCP_PGVERSION) \
+		--build-arg PATRONI_VER=$(CCP_PATRONI_VERSION) \
+		--build-arg POSTGIS_VER=$(CCP_POSTGIS_VERSION) \
 		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
-		--build-arg POSTGIS_LBL=$(subst .,,$(CCP_POSTGIS_VERSION)) \
 		--build-arg DFSET=$(DFSET) \
 		--build-arg PACKAGER=$(PACKAGER) \
 		$(CCPROOT)

--- a/build/postgres-gis-ha/Dockerfile
+++ b/build/postgres-gis-ha/Dockerfile
@@ -2,14 +2,24 @@ ARG BASEOS
 ARG BASEVER
 ARG PG_FULL
 ARG PREFIX
-FROM ${PREFIX}/crunchy-postgres-ha:${BASEOS}-${PG_FULL}-${BASEVER}
+ARG POSTGIS_VER
+FROM ${PREFIX}/crunchy-postgres-gis:${BASEOS}-${PG_FULL}-${POSTGIS_VER}-${BASEVER}
+# crunchy-postgres image runs as USER 26, switch back to install packages
+USER 0
 
+# ===== Early lines ordered for leveraging cache, reorder carefully =====
 # For RHEL8 all arguments used in main code has to be specified after FROM
 ARG BASEOS
+ARG PG_FULL
 ARG DFSET
 ARG PACKAGER
 ARG PG_MAJOR
-ARG POSTGIS_LBL
+
+# Preserving PGVERSION out of paranoia
+ENV PGROOT="/usr/pgsql-${PG_MAJOR}" PGVERSION="${PG_MAJOR}"
+
+# ===== Steps unique to this image after here =====
+ARG PATRONI_VER
 
 LABEL name="postgres-gis-ha" \
 	summary="Includes PostGIS extensions on top of crunchy-postgres-ha" \
@@ -18,34 +28,12 @@ LABEL name="postgres-gis-ha" \
 	io.k8s.display-name="Crunchy PostGIS HA" \
 	io.openshift.tags="postgresql,postgres,postgis,spatial,geospatial,gis,map,database,ha,crunchy"
 
-USER 0
-
-RUN if [ "$BASEOS" = "centos7" ] ; then \
+RUN if [ "$DFSET" = "centos" ] ; then \
 	${PACKAGER} -y install \
 		--setopt=skip_missing_names_on_install=False \
-		libRmath \
-		pgrouting${POSTGIS_LBL}_${PG_MAJOR//.} \
-		plr${PG_MAJOR//.} \
-		postgis${POSTGIS_LBL}_${PG_MAJOR//.} \
-		postgis${POSTGIS_LBL}_${PG_MAJOR//.}-client \
-		postgresql${PG_MAJOR//.}-plperl \
-		perl \
-		R-core \
-	&& ${PACKAGER} -y clean all ; \
-fi
-
-RUN if [ "$BASEOS" = "centos8" ] ; then \
-	${PACKAGER} -y install \
-		--setopt=skip_missing_names_on_install=False \
-		--enablerepo="powertools" \
-		libRmath \
-		pgrouting${POSTGIS_LBL}_${PG_MAJOR//.} \
-		plr${PG_MAJOR//.} \
-		postgis${POSTGIS_LBL}_${PG_MAJOR//.} \
-		postgis${POSTGIS_LBL}_${PG_MAJOR//.}-client \
-		postgresql${PG_MAJOR//.}-plperl \
-		perl \
-		R-core \
+		python3-pip \
+		python3-psutil \
+		python3-psycopg2 \
 	&& ${PACKAGER} -y clean all ; \
 fi
 
@@ -53,16 +41,9 @@ RUN if [ "$BASEOS" = "rhel7" ] ; then \
 	${PACKAGER} -y install \
 		--enablerepo="epel,rhel-7-server-optional-rpms" \
 		--setopt=skip_missing_names_on_install=False \
-		libRmath \
-		pgrouting${POSTGIS_LBL}_${PG_MAJOR//.} \
-		plr${PG_MAJOR//.} \
-		postgis${POSTGIS_LBL}_${PG_MAJOR//.} \
-		postgis${POSTGIS_LBL}_${PG_MAJOR//.}-client \
-		postgresql${PG_MAJOR//.}-plperl \
-		perl \
-		R-core \
-		texinfo-tex \
-		texlive-epsf \
+		python3-pip \
+		python3-psutil \
+		python3-psycopg2 \
 	&& ${PACKAGER} -y clean all --enablerepo="epel,rhel-7-server-optional-rpms" ; \
 fi
 
@@ -70,40 +51,51 @@ RUN if [ "$BASEOS" = "ubi7" ] ; then \
 	${PACKAGER} -y install \
 		--enablerepo="epel,rhel-7-server-optional-rpms" \
 		--setopt=skip_missing_names_on_install=False \
-		libRmath \
-		pgrouting${POSTGIS_LBL}_${PG_MAJOR//.} \
-		plr${PG_MAJOR//.} \
-		postgis${POSTGIS_LBL}_${PG_MAJOR//.} \
-		postgis${POSTGIS_LBL}_${PG_MAJOR//.}-client \
-		postgresql${PG_MAJOR//.}-plperl \
-		perl \
-		R-core \
-		texinfo-tex \
-		texlive-epsf \
+		python3-pip \
+		python3-psutil \
+		python3-psycopg2 \
 	&& ${PACKAGER} -y clean all --enablerepo="epel,rhel-7-server-optional-rpms" ; \
 fi
 
 RUN if [ "$BASEOS" = "ubi8" ] ; then \
-	${PACKAGER} -y --enablerepo="epel,codeready-builder-for-rhel-8-x86_64-rpms" install libaec libdap armadillo \
-	&& ${PACKAGER} -y install \
+	${PACKAGER} -y install \
 		--enablerepo="epel" \
 		--setopt=skip_missing_names_on_install=False \
-		libRmath \
-		pgrouting${POSTGIS_LBL}_${PG_MAJOR//.} \
-		plr${PG_MAJOR//.} \
-		postgis${POSTGIS_LBL}_${PG_MAJOR//.} \
-		postgis${POSTGIS_LBL}_${PG_MAJOR//.}-client \
-		postgresql${PG_MAJOR//.}-plperl \
-		perl \
-		R-core \
-		texlive-epsf \
-	&& ${PACKAGER} -y clean all --enablerepo="epel,codeready-builder-for-rhel-8-x86_64-rpms" ; \
+		python3-pip \
+		python3-psutil \
+		python3-psycopg2 \
+	&& ${PACKAGER} -y clean all --enablerepo="epel" ; \
 fi
+
+# install patroni for Kube
+RUN pip3 install --upgrade python-dateutil \
+	&& pip3 install patroni[kubernetes]=="${PATRONI_VER}"
+
+RUN useradd crunchyadm -g 0 -u 17
+
+ENV PATH="${PGROOT}/bin:${PATH}"
+
+RUN mkdir -p /crunchyadm /tablespaces
+
+# Adjust ownership for the folders to be the "postgres" user and allow the group
+# permissions to match the user ones EXCEPT for the /tablespaces folder, which
+# will only have permissions on the user
+RUN chown -R postgres:postgres /crunchyadm /tablespaces && \
+	chmod -R g=u /crunchyadm /tablespaces
 
 # open up the postgres port
 EXPOSE 5432
 
+ADD bin/postgres-ha /opt/crunchy/bin/postgres-ha
 ADD bin/postgres-gis-ha /opt/crunchy/bin/postgres-ha
+ADD conf/postgres-ha /opt/crunchy/conf/postgres-ha
+
+ADD yq /opt/crunchy/bin
+RUN chmod +x /opt/crunchy/bin/yq
+
+# The VOLUME directive must appear after all RUN directives to ensure the proper
+# volume permissions are applied when building the image
+VOLUME ["/pgdata", "/pgwal", "/pgconf", "/backrestrepo", "/sshd"]
 
 ENTRYPOINT ["/opt/crunchy/bin/postgres-ha/bootstrap-postgres-ha.sh"]
 


### PR DESCRIPTION
The PostGIS HA image now builds off of the base PostGIS image
instead of the base HA image, which should speed up the overall
build times.