### PR TITLE
Remove /crunchyadm directory

### DIFF
--- a/bin/postgres-ha/bootstrap-postgres-ha.sh
+++ b/bin/postgres-ha/bootstrap-postgres-ha.sh
@@ -145,7 +145,7 @@ initialization_monitor() {
             fi
         fi
 
-        touch "/crunchyadm/pgha_initialized"  # write file to indicate the cluster is fully initialized
+        touch "/tmp/pgha_initialized"  # write file to indicate the cluster is fully initialized
         echo_info "Node ${PATRONI_NAME} fully initialized for cluster ${PATRONI_SCOPE} and is ready for use"
     } &
 }

--- a/bin/postgres-ha/callbacks/pgha-on-role-change.sh
+++ b/bin/postgres-ha/callbacks/pgha-on-role-change.sh
@@ -43,7 +43,7 @@ source "${CRUNCHY_DIR}/bin/postgres-ha/pgbackrest/pgbackrest-set-env.sh"
 # is being utilized (e.g. with the PostgreSQL Operator), then this process will be handled
 # externally (e.g. within the PostgreSQL Operator when the repo host is updated following the
 # promotion of a replica to primary)
-if [[ -f "/crunchyadm/pgha_initialized" && "${role}" ==  "master" && "${PGHA_PGBACKREST}" == "true" ]]
+if [[ -f "/tmp/pgha_initialized" && "${role}" ==  "master" && "${PGHA_PGBACKREST}" == "true" ]]
 then
     curl -s -XPATCH -d '{"tags":{"primary_on_role_change":"true"}}' "localhost:${PGHA_PATRONI_PORT}/config"
     if [[ ! -v PGBACKREST_REPO1_HOST && ! -v PGBACKREST_REPO_HOST ]]

--- a/bin/postgres-ha/health/pgha-readiness.sh
+++ b/bin/postgres-ha/health/pgha-readiness.sh
@@ -22,7 +22,7 @@ source "${CRUNCHY_DIR}/bin/postgres-ha/common/pgha-common.sh"
 # while the cluster is initializing, readiness is determined based on whether or not the
 # 'pgha_initialized' file exists.  Once the cluster has been initialized and this file has been
 # created, the Patroni "health" endpoint will then be utilized for any future readiness checks.
-if [[ -f "/crunchyadm/pgha_initialized" ]]
+if [[ -f "/tmp/pgha_initialized" ]]
 then
 
     # set the Patroni port
@@ -33,7 +33,7 @@ then
 
     # the local node is considered heathly if the HTTP status code returned from the local "health"
     # endpoint is greated than 200 or less than 400, in accordance with the Kubernetes documenation
-    # for HTTP readiness checks, i.e. per the docs "any code greater than or equal to 200 and less 
+    # for HTTP readiness checks, i.e. per the docs "any code greater than or equal to 200 and less
     # than 400 indicates success. Any other code indicates failure."
     if [[ $status_code -ge 200 && $status_code -lt 400 ]]
     then

--- a/build/postgres-gis-ha/Dockerfile
+++ b/build/postgres-gis-ha/Dockerfile
@@ -73,13 +73,13 @@ RUN pip3 install --upgrade python-dateutil \
 
 ENV PATH="${PGROOT}/bin:${PATH}"
 
-RUN mkdir -p /crunchyadm /tablespaces
+RUN mkdir -p /tablespaces
 
 # Adjust ownership for the folders to be the "postgres" user and allow the group
 # permissions to match the user ones EXCEPT for the /tablespaces folder, which
 # will only have permissions on the user
-RUN chown -R postgres:postgres /crunchyadm /tablespaces && \
-	chmod -R g=u /crunchyadm /tablespaces
+RUN chown -R postgres:postgres /tablespaces && \
+	chmod -R g=u /tablespaces
 
 # open up the postgres port
 EXPOSE 5432

--- a/build/postgres-ha/Dockerfile
+++ b/build/postgres-ha/Dockerfile
@@ -73,13 +73,13 @@ RUN pip3 install --upgrade python-dateutil \
 
 ENV PATH="${PGROOT}/bin:${PATH}"
 
-RUN mkdir -p /crunchyadm /tablespaces
+RUN mkdir -p /tablespaces
 
 # Adjust ownership for the folders to be the "postgres" user and allow the group
 # permissions to match the user ones EXCEPT for the /tablespaces folder, which
 # will only have permissions on the user
-RUN chown -R postgres:postgres /crunchyadm /tablespaces && \
-	chmod -R g=u /crunchyadm /tablespaces
+RUN chown -R postgres:postgres /tablespaces && \
+	chmod -R g=u /tablespaces
 
 # open up the postgres port
 EXPOSE 5432

--- a/examples/kube/postgres-gis-ha/postgres-gis-ha.json
+++ b/examples/kube/postgres-gis-ha/postgres-gis-ha.json
@@ -102,8 +102,8 @@
                                 "command": [
                                     "/bin/bash",
                                     "-c",
-                                    "[[ -f '/crunchyadm/pgha_initialized' ]]",
-                                    "&& pg_isready -h /crunchyadm -U crunchyready"
+                                    "[[ -f '/tmp/pgha_initialized' ]]",
+                                    "&& pg_isready -h /tmp"
                                 ]
                             },
                             "initialDelaySeconds": 30,
@@ -201,10 +201,6 @@
                             {
                                 "name": "PGHA_INIT",
                                 "value": "true"
-                            },
-                            {
-                                "name": "PGHA_CRUNCHYADM",
-                                "value": "true"
                             }
                         ],
                         "volumeMounts": [
@@ -229,10 +225,6 @@
                             {
                                 "mountPath": "/pgconf/pgreplicator",
                                 "name": "pgreplicator"
-                            },
-                            {
-                                "mountPath": "/crunchyadm",
-                                "name": "crunchyadm"
                             }
                         ],
                         "ports": [
@@ -279,10 +271,6 @@
                         "secret": {
                             "secretName": "postgres-gis-ha-pgreplicator"
                         }
-                    },
-                    {
-                        "name": "crunchyadm",
-                        "emptyDir": {}
                     }
                 ],
                 "restartPolicy": "Always",
@@ -339,8 +327,8 @@
                                 "command": [
                                     "/bin/bash",
                                     "-c",
-                                    "[[ -f '/crunchyadm/pgha_initialized' ]]",
-                                    "&& pg_isready -h /crunchyadm -U crunchyready"
+                                    "[[ -f '/tmp/pgha_initialized' ]]",
+                                    "&& pg_isready -h /tmp"
                                 ]
                             },
                             "initialDelaySeconds": 30,
@@ -366,10 +354,6 @@
                             {
                                 "name": "PATRONI_POSTGRESQL_DATA_DIR",
                                 "value": "/pgdata/postgres-gis-ha-02"
-                            },
-                            {
-                                "name": "PGHA_CRUNCHYADM",
-                                "value": "true"
                             },
                             {
                                 "name": "PATRONI_SCOPE",
@@ -402,10 +386,6 @@
                             {
                                 "mountPath": "/pgconf/pgreplicator",
                                 "name": "pgreplicator"
-                            },
-                            {
-                                "mountPath": "/crunchyadm",
-                                "name": "crunchyadm"
                             }
                         ],
                         "ports": [
@@ -452,10 +432,6 @@
                         "secret": {
                             "secretName": "postgres-gis-ha-pgreplicator"
                         }
-                    },
-                    {
-                        "name": "crunchyadm",
-                        "emptyDir": {}
                     }
                 ],
                 "restartPolicy": "Always",

--- a/examples/kube/postgres-ha/postgres-ha.json
+++ b/examples/kube/postgres-ha/postgres-ha.json
@@ -207,10 +207,6 @@
                                 "value": "true"
                             },
                             {
-                                "name": "PGHA_CRUNCHYADM",
-                                "value": "true"
-                            },
-                            {
                                 "name": "PGHA_REPLICA_REINIT_ON_START_FAIL",
                                 "value": "true"
                             }
@@ -237,10 +233,6 @@
                             {
                                 "mountPath": "/pgconf/pgreplicator",
                                 "name": "pgreplicator"
-                            },
-                            {
-                                "mountPath": "/crunchyadm",
-                                "name": "crunchyadm"
                             }
                         ],
                         "ports": [
@@ -287,10 +279,6 @@
                         "secret": {
                             "secretName": "postgres-ha-pgreplicator"
                         }
-                    },
-                    {
-                        "name": "crunchyadm",
-                        "emptyDir": {}
                     }
                 ],
                 "restartPolicy": "Always",
@@ -382,10 +370,6 @@
                                 "value": "/pgdata/postgres-ha-02"
                             },
                             {
-                                "name": "PGHA_CRUNCHYADM",
-                                "value": "true"
-                            },
-                            {
                                 "name": "PGHA_REPLICA_REINIT_ON_START_FAIL",
                                 "value": "true"
                             }
@@ -412,10 +396,6 @@
                             {
                                 "mountPath": "/pgconf/pgreplicator",
                                 "name": "pgreplicator"
-                            },
-                            {
-                                "mountPath": "/crunchyadm",
-                                "name": "crunchyadm"
                             }
                         ],
                         "ports": [
@@ -462,10 +442,6 @@
                         "secret": {
                             "secretName": "postgres-ha-pgreplicator"
                         }
-                    },
-                    {
-                        "name": "crunchyadm",
-                        "emptyDir": {}
                     }
                 ],
                 "restartPolicy": "Always",


### PR DESCRIPTION
As the emptyDir for the /cruncyadm directory is no longer mounted,
this can present issues in OpenShift environments when trying to
create a file used in one of the readiness checks. This moves said
file to the /tmp directory, which is still writable.

Issue: [ch10071]