### PR TITLE
Update pgpool install for new package name and install location

### DIFF
--- a/build/pgpool/Dockerfile
+++ b/build/pgpool/Dockerfile
@@ -19,8 +19,8 @@ LABEL name="pgpool" \
 
 RUN ${PACKAGER} -y install \
 		--setopt=skip_missing_names_on_install=False \
-		pgpool-II-${PG_MAJOR//.} \
-		pgpool-II-${PG_MAJOR//.}-extensions \
+		pgpool-II_${PG_MAJOR//.} \
+		pgpool-II_${PG_MAJOR//.}-extensions \
 	&& ${PACKAGER} -y clean all
 
 # Preserving PGVERSION out of paranoia
@@ -32,8 +32,8 @@ ADD bin/pgpool /opt/crunchy/bin
 ADD bin/common /opt/crunchy/bin
 ADD conf/pgpool /opt/crunchy/conf
 
-RUN ln -sf /opt/crunchy/conf/pool_hba.conf /etc/pgpool-II-${PG_MAJOR//.}/pool_hba.conf \
-	&& ln -sf /opt/crunchy/conf/pgpool/pool_passwd /etc/pgpool-II-${PG_MAJOR//.}/pool_passwd
+RUN ln -sf /opt/crunchy/conf/pool_hba.conf /etc/pgpool-II_${PG_MAJOR//.}/pool_hba.conf \
+	&& ln -sf /opt/crunchy/conf/pgpool/pool_passwd /etc/pgpool-II_${PG_MAJOR//.}/pool_passwd
 
 RUN chgrp -R 0 /opt/crunchy && \
 	chmod -R g=u /opt/crunchy


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
With the release of the new pgpool package the current Dockerfiles will break because of the change in the install location.  Also, while the install will work we want it to match the new package name.


**What is the new behavior (if this is a feature change)?**
Update the package name and install location for pgpool.


**Other information**:
This will need to be back ported all the way to the 4.4 release line otherwise it will be broken with any new builds.