### PR TITLE
Ensure "archive_mode" is enabled for restores in place

### DIFF
--- a/bin/postgres-ha/bootstrap/post-bootstrap.sh
+++ b/bin/postgres-ha/bootstrap/post-bootstrap.sh
@@ -21,16 +21,33 @@ enable_debugging
 
 echo_info "postgres-ha post-bootstrap starting"
 
-# When using the 'pgbackrest_init' bootstrap method, make sure backrest is stopped before writing
-# to the DB.  This is because when using this bootstrap method, the current instance will still
-# be connected to the pgBackRest repository for another cluster (i.e. the cluster being
-# bootstrapped from), and we want to ensure there is no ability to push WAL to that repo.  Please
-# note that when using 'pgbackrest_init' archive_mode should also be disabled, and this simply 
+# When using the 'pgbackrest_init' bootstrap method and restoring to a new
+# cluster, make sure backrest is stopped before writing to the DB.  This is
+# because when using this bootstrap method, the current instance will still
+# be connected to the pgBackRest repository for another cluster (i.e. the
+# cluster being bootstrapped from), and we want to ensure there is no ability to
+# push WAL to that repo.  Please note that when using 'pgbackrest_init'
+# archive_mode should also be disabled, and this simply
 # serves as an extra precaution.
 if [[ "${PGHA_BOOTSTRAP_METHOD}" == "pgbackrest_init" ]]
 then
-    pgbackrest stop
-    err_check "$?" "post bootstrap" "Could not stop pgBackRest, ${setup_file} will not be run"
+    # get the name of the cluster source from the pgBackRest repository
+    if [[ "${PGBACKREST_REPO1_PATH}" =~ \/backrestrepo\/(.*)-backrest-shared-repo$ ]];
+    then
+        bootstrap_cluster_source="${BASH_REMATCH[1]}"
+    fi
+
+    # get the name of the cluster target
+    if [[ "${PGBACKREST_DB_PATH}" =~ \/pgdata\/(.*)$ ]];
+    then
+        bootstrap_cluster_target="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ "${bootstrap_cluster_source}" != "${bootstrap_cluster_target}" ]];
+    then
+        pgbackrest stop
+        err_check "$?" "post bootstrap" "Could not stop pgBackRest, ${setup_file} will not be run"
+    fi
 fi
 
 if [[ "${PGHA_BOOTSTRAP_METHOD}" == "initdb" ]]

--- a/bin/postgres-ha/bootstrap/pre-bootstrap.sh
+++ b/bin/postgres-ha/bootstrap/pre-bootstrap.sh
@@ -386,13 +386,34 @@ build_bootstrap_config_file() {
       "${CRUNCHY_DIR}/bin/yq" m -i -a "${pghba_file}" "${CRUNCHY_DIR}/conf/postgres-ha/postgres-ha-pghba-notls.yaml"
     fi
 
-    # Disable archive_mode to prevent WAL from being pushed while potentially still connected
-    # to another pgBackRest repository while initializing (e.g. while performing a pgBackRest
-    # restore)
+    # If this is being restored to a new cluster, disable archive_mode to
+    # prevent WAL from being pushed while potentiallystill connected to another
+    # pgBackRest repository while initializing (e.g. while performing a
+    # pgBackRest restore).
+    #
+    # Otherwise, ensure that archive_mode is set explicitly to on.
     if [[ "${PGHA_BOOTSTRAP_METHOD}" == "pgbackrest_init" ]]
     then
-      echo_info "Disabling archive mode for bootstrap method ${PGHA_BOOTSTRAP_METHOD}"
-      "${CRUNCHY_DIR}/bin/yq" w -i "${bootstrap_file}" postgresql.parameters.archive_mode "off"
+        # get the name of the cluster source from the pgBackRest repository
+        if [[ "${PGBACKREST_REPO1_PATH}" =~ \/backrestrepo\/(.*)-backrest-shared-repo$ ]];
+        then
+            bootstrap_cluster_source="${BASH_REMATCH[1]}"
+        fi
+
+        # get the name of the cluster target
+        if [[ "${PGBACKREST_DB_PATH}" =~ \/pgdata\/(.*)$ ]];
+        then
+            bootstrap_cluster_target="${BASH_REMATCH[1]}"
+        fi
+
+        if [[ "${bootstrap_cluster_source}" != "${bootstrap_cluster_target}" ]];
+        then
+            echo_info "Disabling archive mode for bootstrap method ${PGHA_BOOTSTRAP_METHOD}"
+            "${CRUNCHY_DIR}/bin/yq" w -i "${bootstrap_file}" postgresql.parameters.archive_mode "off"
+        else
+            echo_info "Enabling archive mode for bootstrap method ${PGHA_BOOTSTRAP_METHOD}"
+            "${CRUNCHY_DIR}/bin/yq" w -i "${bootstrap_file}" postgresql.parameters.archive_mode "on"
+        fi
     fi
 
     # merge the pg_hba.conf settings into the main bootstrap file


### PR DESCRIPTION
When restoring a PostgreSQL cluster that will be utilizing the same
pgBackRest repository (e.g. a "restore in place"), pgBackRest needs to
have "archive_mode" set to "on" in order to properly push history and
other files.

This is in contrast to "archive_mode" being set to "off" when restoring
to a cluster that will use a new pgBackRest repository. This had been
the only setting in the restore process, which did not account for the
"in place" scenario.

Issue: [ch10506]