### PR TITLE
Use archive_command=false For New Cluster Restore

### DIFF
--- a/bin/postgres-ha/bootstrap/post-bootstrap.sh
+++ b/bin/postgres-ha/bootstrap/post-bootstrap.sh
@@ -20,35 +20,6 @@ enable_debugging
 
 echo_info "postgres-ha post-bootstrap starting"
 
-# When using the 'pgbackrest_init' bootstrap method and restoring to a new
-# cluster, make sure backrest is stopped before writing to the DB.  This is
-# because when using this bootstrap method, the current instance will still
-# be connected to the pgBackRest repository for another cluster (i.e. the
-# cluster being bootstrapped from), and we want to ensure there is no ability to
-# push WAL to that repo.  Please note that when using 'pgbackrest_init'
-# archive_mode should also be disabled, and this simply
-# serves as an extra precaution.
-if [[ "${PGHA_BOOTSTRAP_METHOD}" == "pgbackrest_init" ]]
-then
-    # get the name of the cluster source from the pgBackRest repository
-    if [[ "${PGBACKREST_REPO1_PATH}" =~ \/backrestrepo\/(.*)-backrest-shared-repo$ ]];
-    then
-        bootstrap_cluster_source="${BASH_REMATCH[1]}"
-    fi
-
-    # get the name of the cluster target
-    if [[ "${PGBACKREST_DB_PATH}" =~ \/pgdata\/(.*)$ ]];
-    then
-        bootstrap_cluster_target="${BASH_REMATCH[1]}"
-    fi
-
-    if [[ "${bootstrap_cluster_source}" != "${bootstrap_cluster_target}" ]];
-    then
-        pgbackrest stop
-        err_check "$?" "post bootstrap" "Could not stop pgBackRest, ${setup_file} will not be run"
-    fi
-fi
-
 if [[ "${PGHA_BOOTSTRAP_METHOD}" == "initdb" ]]
 then
     # Run either a custom or the defaul setup.sql file

--- a/bin/postgres-ha/bootstrap/pre-bootstrap.sh
+++ b/bin/postgres-ha/bootstrap/pre-bootstrap.sh
@@ -413,11 +413,8 @@ build_bootstrap_config_file() {
 
         if [[ "${bootstrap_cluster_source}" != "${bootstrap_cluster_target}" ]];
         then
-            echo_info "Disabling archive mode for bootstrap method ${PGHA_BOOTSTRAP_METHOD}"
-            "${CRUNCHY_DIR}/bin/yq" w -i "${bootstrap_file}" postgresql.parameters.archive_mode "off"
-        else
-            echo_info "Enabling archive mode for bootstrap method ${PGHA_BOOTSTRAP_METHOD}"
-            "${CRUNCHY_DIR}/bin/yq" w -i "${bootstrap_file}" postgresql.parameters.archive_mode "on"
+            echo_info "Disabling archiving for bootstrap method ${PGHA_BOOTSTRAP_METHOD}"
+            /opt/cpm/bin/yq w -i --style=single "${bootstrap_file}" postgresql.parameters.archive_command "false"
         fi
     fi
 


### PR DESCRIPTION
When a new cluster is being created using an existing repository, e.g. using command:

```bash
pgo create mycluster2 --restore-from=mycluster1
```

The `archive_command` is now set to `false` during the initial restore and Patroni bootstrap.

In support of this change, `archive_mode` is no longer set to `off` when performing a pgBackRest restore during the initialization of a new cluster, nor is pgBackRest stopped post-initialization.  These settings (which effectively disable archive pushing) prevent the `.history` file from being archived during the restore process as needed for the proper management of PG timelines, and setting `archive_mode=false` ensures both archives are not pushed while restoring and bootstrapping from an existing/running cluster (since two DB's should not be pushing to the same pgBackRest repository), while also ensuring archives (including history files) are then pushed when the proper `archive_command` is subsequently configured during the cluster initialization process.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

`archive_mode` is set to `off` when performing a pgBackRest restore during the initialization of a new cluster, and pgBackRest is stopped post-initialization.

[ch10513]

**What is the new behavior (if this is a feature change)?**

`archive_mode` is no longer set to `off` when performing a pgBackRest restore during the initialization of a new cluster, nor is pgBackRest stopped post-initialization.  Additionally, when a new cluster is being created using using an existing repository the `archive_command` is now set to `false` during the initial restore. 

**Other information**:

N/A