### PR TITLE
Set system python for EL8 pgAdmin 4 containers to be python3

### DIFF
--- a/build/pgadmin4/Dockerfile
+++ b/build/pgadmin4/Dockerfile
@@ -56,7 +56,8 @@ RUN if [ "$BASEOS" = "centos8" ] ; then \
         && chmod -R g=u /usr/lib/python3.6/site-packages/pgadmin4-web \
                 /var/lib/pgadmin /var/log/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd \
         && ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python3.6/site-packages/pgadmin4-web/config_local.py \
-        && ln -sf /var/lib/pgadmin/pgadmin.conf /etc/httpd/conf.d/pgadmin.conf ; \
+        && ln -sf /var/lib/pgadmin/pgadmin.conf /etc/httpd/conf.d/pgadmin.conf \
+        && alternatives --set python /usr/bin/python3 ; \
 fi
 
 RUN if [ "$BASEOS" = "ubi7" ] ; then \
@@ -95,7 +96,8 @@ RUN if [ "$BASEOS" = "ubi8" ] ; then \
         && chmod -R g=u /usr/lib/python3.6/site-packages/pgadmin4-web \
                 /var/lib/pgadmin /var/log/pgadmin /certs /etc/httpd /run/httpd /var/log/httpd \
         && ln -sf /var/lib/pgadmin/config_local.py /usr/lib/python3.6/site-packages/pgadmin4-web/config_local.py \
-        && ln -sf /var/lib/pgadmin/pgadmin.conf /etc/httpd/conf.d/pgadmin.conf ; \
+        && ln -sf /var/lib/pgadmin/pgadmin.conf /etc/httpd/conf.d/pgadmin.conf \
+        && alternatives --set python /usr/bin/python3 ; \
 fi
 
 # Preserving PGVERSION out of paranoia


### PR DESCRIPTION
Python 2 is not installed in these, nor will it be, so this is a
safe measure, and it also allows for some specific pgAdmin 4
functionality to work.

Issue: [ch10718]
fixes CrunchyData/postgres-operator#2320