### PR TITLE
Adds the nss_wrapper for Arbitrary UID Support in OpenShift

### DIFF
--- a/bin/common/nss_wrapper.sh
+++ b/bin/common/nss_wrapper.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Copyright 2021 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+
+# The following sets up an nss_wrapper environment in accordance with OpenShift
+# guidance for supporting arbitrary user ID's
+
+# Define nss_wrapper directory and passwd & group files that will be utilized by nss_wrapper.  The
+# nss_wrapper_env.sh script (which also sets these vars) isn't sourced here since the nss_wrapper
+# has not yet been setup, and we therefore don't yet want the nss_wrapper vars in the environment.
+NSS_WRAPPER_DIR="/tmp/nss_wrapper/${NSS_WRAPPER_SUBDIR}"
+NSS_WRAPPER_PASSWD="${NSS_WRAPPER_DIR}/passwd"
+NSS_WRAPPER_GROUP="${NSS_WRAPPER_DIR}/group"
+
+# create the nss_wrapper directory
+mkdir -p "${NSS_WRAPPER_DIR}"
+
+# grab the current user ID and group ID
+USER_ID=$(id -u)
+export USER_ID
+GROUP_ID=$(id -g)
+export GROUP_ID
+
+# get copies of the passwd and group files
+[[ -f "${NSS_WRAPPER_PASSWD}" ]] || cp "/etc/passwd" "${NSS_WRAPPER_PASSWD}"
+[[ -f "${NSS_WRAPPER_GROUP}" ]] || cp "/etc/group" "${NSS_WRAPPER_GROUP}"
+
+# if the username is missing from the passwd file, then add it
+if [[ ! $(cat "${NSS_WRAPPER_PASSWD}") =~ ${CRUNCHY_NSS_USERNAME}:x:${USER_ID} ]]; then
+    echo "nss_wrapper: adding user"
+    passwd_tmp="${NSS_WRAPPER_DIR}/passwd_tmp"
+    cp "${NSS_WRAPPER_PASSWD}" "${passwd_tmp}"
+    sed -i "/${CRUNCHY_NSS_USERNAME}:x:/d" "${passwd_tmp}"
+    # needed for OCP 4.x because crio updates /etc/passwd with an entry for USER_ID
+    sed -i "/${USER_ID}:x:/d" "${passwd_tmp}"   
+    printf '${CRUNCHY_NSS_USERNAME}:x:${USER_ID}:${GROUP_ID}:${CRUNCHY_NSS_USER_DESC}:${HOME}:/bin/bash\n' >> "${passwd_tmp}"
+    envsubst < "${passwd_tmp}" > "${NSS_WRAPPER_PASSWD}"
+    rm "${passwd_tmp}"
+else
+    echo "nss_wrapper: user exists"
+fi 
+
+# if the username (which will be the same as the group name) is missing from group file, then add it
+if [[ ! $(cat "${NSS_WRAPPER_GROUP}") =~ ${CRUNCHY_NSS_USERNAME}:x:${USER_ID} ]]; then
+    echo "nss_wrapper: adding group"
+    group_tmp="${NSS_WRAPPER_DIR}/group_tmp"
+    cp "${NSS_WRAPPER_GROUP}" "${group_tmp}"
+    sed -i "/${CRUNCHY_NSS_USERNAME}:x:/d" "${group_tmp}"
+    printf '${CRUNCHY_NSS_USERNAME}:x:${USER_ID}:${CRUNCHY_NSS_USERNAME}\n' >> "${group_tmp}"
+    envsubst < "${group_tmp}" > "${NSS_WRAPPER_GROUP}"
+    rm "${group_tmp}"
+else
+    echo "nss_wrapper: group exists"
+fi
+
+# export the nss_wrapper env vars
+source "${CRUNCHY_DIR}/bin/nss_wrapper_env.sh"
+echo "nss_wrapper: environment configured"

--- a/bin/common/nss_wrapper_env.sh
+++ b/bin/common/nss_wrapper_env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 - 2021 Crunchy Data Solutions, Inc.
+# Copyright 2021 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
-    
-source "${CRUNCHY_DIR}/bin/uid_postgres_no_exec.sh"
+# define nss_wrapper directory and passwd & group files that will be utilized by nss_wrapper
+NSS_WRAPPER_DIR="/tmp/nss_wrapper/${NSS_WRAPPER_SUBDIR}"
+NSS_WRAPPER_PASSWD="${NSS_WRAPPER_DIR}/passwd"
+NSS_WRAPPER_GROUP="${NSS_WRAPPER_DIR}/group"
 
-exec "$@"
+export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+export NSS_WRAPPER_PASSWD="${NSS_WRAPPER_PASSWD}"
+export NSS_WRAPPER_GROUP="${NSS_WRAPPER_GROUP}"

--- a/bin/common/uid_daemon.sh
+++ b/bin/common/uid_daemon.sh
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if ! whoami &> /dev/null; then
-  if [ -w /etc/passwd ]; then
-    echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/bin/bash" >> /etc/passwd
-  fi
-fi
+CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+    
+export CRUNCHY_NSS_USERNAME="${USER_NAME:-default}"
+export CRUNCHY_NSS_USER_DESC="${USER_NAME:-default} user"
+    
+source "${CRUNCHY_DIR}/bin/nss_wrapper.sh"
+
 exec "$@"

--- a/bin/common/uid_postgres_no_exec.sh
+++ b/bin/common/uid_postgres_no_exec.sh
@@ -13,22 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if ! whoami &> /dev/null
-then
-    if [[ -w /etc/passwd ]]
-    then
-        sed  "/postgres:x:26:/d" /etc/passwd >> /tmp/uid.tmp
-        cp /tmp/uid.tmp /etc/passwd
-        rm -f /tmp/uid.tmp
-        echo "${USER_NAME:-postgres}:x:$(id -u):0:${USER_NAME:-postgres} user:${HOME}:/bin/bash" >> /etc/passwd
-    fi
-
-    if [[ -w /etc/group ]]
-    then
-        sed  "/postgres:x:26/d" /etc/group >> /tmp/gid.tmp
-        cp /tmp/gid.tmp /etc/group
-        rm -f /tmp/gid.tmp
-        echo "nfsnobody:x:65534:" >> /etc/group
-        echo "postgres:x:$(id -g):postgres" >> /etc/group
-    fi
-fi
+CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+    
+export CRUNCHY_NSS_USERNAME="${USER_NAME:-postgres}"
+export CRUNCHY_NSS_USER_DESC="PostgreSQL Server"
+    
+source "${CRUNCHY_DIR}/bin/nss_wrapper.sh"

--- a/bin/pgbackrest-repo/uid_pgbackrest.sh
+++ b/bin/pgbackrest-repo/uid_pgbackrest.sh
@@ -13,23 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if ! whoami &> /dev/null
-then
-    if [[ -w /etc/passwd ]]
-    then
-        sed  "/pgbackrest:x:2000:/d" /etc/passwd >> /tmp/uid.tmp
-        cp /tmp/uid.tmp /etc/passwd
-        rm -f /tmp/uid.tmp
-        echo "${USER_NAME:-pgbackrest}:x:$(id -u):0:${USER_NAME:-pgbackrest} user:${HOME}:/bin/bash" >> /etc/passwd
-    fi
+CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+    
+export CRUNCHY_NSS_USERNAME="${USER_NAME:-pgbackrest}"
+export CRUNCHY_NSS_USER_DESC="${USER_NAME:-pgbackrest} user"
+   
+source "${CRUNCHY_DIR}/bin/nss_wrapper.sh"
 
-    if [[ -w /etc/group ]]
-    then
-        sed  "/pgbackrest:x:2000/d" /etc/group >> /tmp/gid.tmp
-        cp /tmp/gid.tmp /etc/group
-        rm -f /tmp/gid.tmp
-        echo "nfsnobody:x:65534:" >> /etc/group
-        echo "pgbackrest:x:$(id -g):pgbackrest" >> /etc/group
-    fi
-fi
 exec "$@"

--- a/bin/postgres-ha/bootstrap/sshd.sh
+++ b/bin/postgres-ha/bootstrap/sshd.sh
@@ -13,9 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# define the default nss_wrapper dir for this container and the ssh nss_wrapper dir
+NSS_WRAPPER_DEFAULT_DIR="/tmp/nss_wrapper/postgres-ha"
+NSS_WRAPPER_SSH_DIR="/tmp/nss_wrapper/ssh"
+
+# Configures nss_wrapper passwd and group files for SSH connections
+function nss_wrapper_ssh() {
+    mkdir -p "${NSS_WRAPPER_SSH_DIR}"
+    cp "${NSS_WRAPPER_DEFAULT_DIR}/passwd" "${NSS_WRAPPER_SSH_DIR}"
+    cp "${NSS_WRAPPER_DEFAULT_DIR}/group" "${NSS_WRAPPER_SSH_DIR}"
+}
+
 if [[ ${ENABLE_SSHD} == "true" ]]
 then
     echo_info "Applying SSHD.."
+    
+    # configure nss_wrapper files for ssh connections
+    nss_wrapper_ssh
+    echo_info "nss_wrapper: ssh configured"
+
     echo_info 'Checking for SSH Host Keys in /sshd..'
 
     if [[ ! -f /sshd/ssh_host_ed25519_key ]]; then
@@ -37,15 +53,8 @@ then
         exit 1
     fi
 
-    echo_info "setting up .ssh directory"
-    if [ -d "${HOME}/.ssh" ]; then 
-        echo_info ".ssh directory already exists and will not be created"
-    else 
-        mkdir ~/.ssh
-    fi
-    cp /sshd/config ~/.ssh/
     cp /sshd/id_ed25519 /tmp
-    chmod 400 /tmp/id_ed25519 ~/.ssh/config
+    chmod 400 /tmp/id_ed25519
 
     echo_info 'Starting SSHD..'
     /usr/sbin/sshd -f /sshd/sshd_config

--- a/bin/postgres_common/postgres/sshd.sh
+++ b/bin/postgres_common/postgres/sshd.sh
@@ -13,9 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# define the default nss_wrapper dir for this container and the ssh nss_wrapper dir
+NSS_WRAPPER_DEFAULT_DIR="/tmp/nss_wrapper/postgres"
+NSS_WRAPPER_SSH_DIR="/tmp/nss_wrapper/ssh"
+
+# Configures nss_wrapper passwd and group files for SSH connections
+function nss_wrapper_ssh() {
+    mkdir -p "${NSS_WRAPPER_SSH_DIR}"
+    cp "${NSS_WRAPPER_DEFAULT_DIR}/passwd" "${NSS_WRAPPER_SSH_DIR}"
+    cp "${NSS_WRAPPER_DEFAULT_DIR}/group" "${nss_wrappeNSS_WRAPPER_SSH_DIRr_ssh_dir}"
+}
+
 if [[ ${ENABLE_SSHD} == "true" ]]
 then
     echo_info "Applying SSHD.."
+
+    # configure nss_wrapper files for ssh connections
+    nss_wrapper_ssh
+    echo_info "nss_wrapper: ssh configured"
+
     echo_info 'Checking for SSH Host Keys in /sshd..'
 
     if [[ ! -f /sshd/ssh_host_ed25519_key ]]; then

--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -39,13 +39,14 @@ ARG EPEL8_RPM=https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch
 
 RUN if [ "$BASEOS" = "rhel7" ] ; then \
 	${PACKAGER} -y --enablerepo=rhel-7-server-ose-3.11-rpms update \
+        && ${PACKAGER} -y install ${EPEL7_RPM} \
 	&& ${PACKAGER} -y install \
 		--setopt=skip_missing_names_on_install=False \
-		${EPEL7_RPM} \
 		bind-utils \
 		gettext \
 		hostname \
 		procps-ng \
+		nss_wrapper \
 	&& sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/epel*.repo \
 	&& ${PACKAGER} -y clean all --enablerepo=rhel-7-server-ose-3.11-rpms ; \
 fi
@@ -59,6 +60,7 @@ RUN if [ "$BASEOS" = "ubi7" ] ; then \
                 gettext \
                 hostname \
                 procps-ng \
+                nss_wrapper \
         && sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/epel*.repo \
         && ${PACKAGER} -y clean all --enablerepo=rhel-7-server-ose-3.11-rpms ; \
 fi
@@ -72,19 +74,21 @@ RUN if [ "$BASEOS" = "ubi8" ] ; then \
                 gettext \
                 hostname \
                 procps-ng \
+                nss_wrapper \
         && sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/epel*.repo \
         && ${PACKAGER} -y clean all ; \
 fi
 
 RUN if [ "$BASEOS" = "centos7" ] ; then \
         ${PACKAGER} -y update \
+        && ${PACKAGER} -y install epel-release \
         && ${PACKAGER} -y install \
                 --setopt=skip_missing_names_on_install=False \
-                epel-release \
                 bind-utils \
                 gettext \
                 hostname \
                 procps-ng \
+                nss_wrapper \
         && ${PACKAGER} -y clean all ; \
 fi
 
@@ -98,6 +102,7 @@ RUN if [ "$BASEOS" = "centos8" ] ; then \
 		gettext \
 		hostname \
 		procps-ng \
+		nss_wrapper \
 	&& ${PACKAGER} -y clean all ; \
 fi
 

--- a/build/pgadmin4/Dockerfile
+++ b/build/pgadmin4/Dockerfile
@@ -112,11 +112,12 @@ RUN cp /opt/crunchy/conf/httpd.conf /etc/httpd/conf/httpd.conf \
 
 EXPOSE 5050
 
-RUN chmod g=u /etc/passwd
-
 # The VOLUME directive must appear after all RUN directives to ensure the proper
 # volume permissions are applied when building the image
 VOLUME ["/var/lib/pgadmin", "/certs", "/run/httpd"]
+
+# Defines a unique directory name that will be utilized by the nss_wrapper in the UID script
+ENV NSS_WRAPPER_SUBDIR="pgadmin"
 
 ENTRYPOINT ["opt/crunchy/bin/uid_daemon.sh"]
 

--- a/build/pgbackrest-repo/Dockerfile
+++ b/build/pgbackrest-repo/Dockerfile
@@ -25,9 +25,7 @@ RUN chown -R pgbackrest:pgbackrest /opt/crunchy \
 ADD bin/pgbackrest-repo/uid_pgbackrest.sh /opt/crunchy/bin
 
 # set permissions for pgbackrest user
-RUN chmod g=u /etc/passwd \
-	&& chmod g=u /etc/group \
-	&& chmod -R g=u /etc/pgbackrest \
+RUN chmod -R g=u /etc/pgbackrest \
 	&& rm -f /run/nologin
 
 # set ownership to pgbackrest user
@@ -35,6 +33,9 @@ RUN chown pgbackrest:pgbackrest /.ssh && chmod o+rwx /.ssh
 
 # set user to pgbackrest user
 USER 2000
+
+# Defines a unique directory name that will be utilized by the nss_wrapper in the UID script
+ENV NSS_WRAPPER_SUBDIR="pgbackrest-repo"
 
 ENTRYPOINT ["/opt/crunchy/bin/uid_pgbackrest.sh"]
 

--- a/build/pgbackrest/Dockerfile
+++ b/build/pgbackrest/Dockerfile
@@ -53,9 +53,7 @@ RUN chmod +x /usr/local/bin/pgbackrest-repo.sh /usr/local/bin/archive-push-s3.sh
 	&& mkdir -p /etc/pgbackrest \
 	&& chown -R postgres:postgres /etc/pgbackrest
 
-RUN chmod g=u /etc/passwd \
-	&& chmod g=u /etc/group \
-	&& chmod -R g=u /etc/pgbackrest \
+RUN chmod -R g=u /etc/pgbackrest \
 	&& rm -f /run/nologin
 
 RUN mkdir /.ssh && chown postgres:postgres /.ssh && chmod o+rwx /.ssh
@@ -70,6 +68,9 @@ RUN mkdir /.ssh && chown postgres:postgres /.ssh && chmod o+rwx /.ssh
 VOLUME ["/sshd", "/pgdata", "/backrestrepo"]
 
 USER 26
+
+# Defines a unique directory name that will be utilized by the nss_wrapper in the UID script
+ENV NSS_WRAPPER_SUBDIR="pgbackrest"
 
 ENTRYPOINT ["/opt/crunchy/bin/uid_postgres.sh"]
 

--- a/build/pgbadger/Dockerfile
+++ b/build/pgbadger/Dockerfile
@@ -75,12 +75,12 @@ RUN chown -R postgres:postgres /opt/crunchy /report /bin && \
 # pgbadger port
 EXPOSE 10000
 
-RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-
 # The VOLUME directive must appear after all RUN directives to ensure the proper
 # volume permissions are applied when building the image
 VOLUME ["/pgdata", "/report"]
+
+# Defines a unique directory name that will be utilized by the nss_wrapper in the UID script
+ENV NSS_WRAPPER_SUBDIR="pgbadger"
 
 ENTRYPOINT ["opt/crunchy/bin/uid_postgres.sh"]
 

--- a/build/pgbouncer/Dockerfile
+++ b/build/pgbouncer/Dockerfile
@@ -37,11 +37,12 @@ RUN chown -R 2:0 /opt/crunchy /pgconf && \
 
 EXPOSE 6432
 
-RUN chmod g=u /etc/passwd
-
 # The VOLUME directive must appear after all RUN directives to ensure the proper
 # volume permissions are applied when building the image
 VOLUME ["/pgconf"]
+
+# Defines a unique directory name that will be utilized by the nss_wrapper in the UID script
+ENV NSS_WRAPPER_SUBDIR="pgbouncer"
 
 ENTRYPOINT ["opt/crunchy/bin/uid_daemon.sh"]
 

--- a/build/pgpool/Dockerfile
+++ b/build/pgpool/Dockerfile
@@ -42,12 +42,13 @@ RUN chgrp -R 0 /opt/crunchy && \
 # open up the postgres port
 EXPOSE 5432
 
-RUN chmod g=u /etc/passwd
-
 # add volumes to allow override of pgpool config files
 # The VOLUME directive must appear after all RUN directives to ensure the proper
 # volume permissions are applied when building the image
 VOLUME ["/pgconf"]
+
+# Defines a unique directory name that will be utilized by the nss_wrapper in the UID script
+ENV NSS_WRAPPER_SUBDIR="pgpool"
 
 ENTRYPOINT ["opt/crunchy/bin/uid_daemon.sh"]
 

--- a/build/postgres-appdev/Dockerfile
+++ b/build/postgres-appdev/Dockerfile
@@ -75,15 +75,15 @@ ADD conf/postgres_common/postgres /opt/crunchy/conf
 
 ADD tools/pgmonitor/exporter/postgres /opt/crunchy/bin/modules/pgexporter
 
-RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
 
 # add volumes to allow override of pg_hba.conf and postgresql.conf
 # The VOLUME directive must appear after all RUN directives to ensure the proper
 # volume permissions are applied when building the image
 VOLUME ["/pgconf", "/pgdata"]
+
+# Defines a unique directory name that will be utilized by the nss_wrapper in the UID script
+ENV NSS_WRAPPER_SUBDIR="postgres-appdev"
 
 ENTRYPOINT ["/opt/crunchy/bin/uid_postgres.sh"]
 

--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -104,9 +104,6 @@ ADD bin/common /opt/crunchy/bin
 ADD conf/postgres_common /opt/crunchy/conf
 ADD tools/pgmonitor/exporter/postgres /opt/crunchy/bin/modules/pgexporter
 
-RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh && rm -f /run/nologin
 
 # add volumes to allow override of pg_hba.conf and postgresql.conf
@@ -117,6 +114,9 @@ RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh && rm -f /run/nologin
 # The VOLUME directive must appear after all RUN directives to ensure the proper
 # volume permissions are applied when building the image
 VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/recover", "/backrestrepo"]
+
+# Defines a unique directory name that will be utilized by the nss_wrapper in the UID script
+ENV NSS_WRAPPER_SUBDIR="postgres"
 
 ENTRYPOINT ["/opt/crunchy/bin/uid_postgres.sh"]
 

--- a/build/upgrade/Dockerfile
+++ b/build/upgrade/Dockerfile
@@ -55,12 +55,12 @@ ADD conf/upgrade/ /opt/crunchy/conf
 RUN chown -R postgres:postgres /opt/crunchy /pgolddata /pgnewdata && \
 	chmod -R g=u /opt/crunchy /pgolddata /pgnewdata
 
-RUN chmod g=u /etc/passwd && \
-	chmod g=u /etc/group
-
 # The VOLUME directive must appear after all RUN directives to ensure the proper
 # volume permissions are applied when building the image
 VOLUME /pgolddata /pgnewdata
+
+# Defines a unique directory name that will be utilized by the nss_wrapper in the UID script
+ENV NSS_WRAPPER_SUBDIR="upgrade"
 
 ENTRYPOINT ["opt/crunchy/bin/uid_postgres.sh"]
 


### PR DESCRIPTION
Adds and enables the `nss_wrapper` for all containers using UID entrypoint scripts, specifically as needed for compatibility with the `restricted` SCC in OpenShift (and therefore the random UID's that are assigned to containers by OpenShift). This is done in accordance with RedHat guidance (see https://access.redhat.com/articles/4859371), specifically replacing the current solution which directly modifies the `/etc/passwd` and `/etc/group` files.

With this change, the `nss_wrapper` will now always be enabled when an entrypoint script (e.g. `uid_postgres.sh`, `uid_pgbackrest.sh`, etc.) is called. Additionally, the `/etc/passwd` and `/etc/group` files are no longer writeable, and entrypoint script naming has been maintained to ensure a seamless and transparent transition to the `nss_wrapper` solution (i.e. consumers of the containers are not required to make any changes to maintain current behavior and functionality).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Writeable `/etc/passwd` and `/etc/group` files are utilized to support arbitrary UID's in OpenShift.

[ch9887]

**What is the new behavior (if this is a feature change)?**

The `nss_wrapper` is utilized to support arbitrary UID's in OpenShift.

**Other information**:

Please note that this solution is intended to be compatible with all Docker and Kubernetes examples within the Crunchy Container Suite, as well as with all currently supported versions of the Crunchy PostgreSQL Operator.