### PR TITLE
Fixes Default nss_wrapper Dir in PGHA SSHD Script

### DIFF
--- a/bin/postgres-ha/bootstrap/sshd.sh
+++ b/bin/postgres-ha/bootstrap/sshd.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # define the default nss_wrapper dir for this container and the ssh nss_wrapper dir
-NSS_WRAPPER_DEFAULT_DIR="/tmp/nss_wrapper/postgres-ha"
+NSS_WRAPPER_DEFAULT_DIR="/tmp/nss_wrapper/postgres"
 NSS_WRAPPER_SSH_DIR="/tmp/nss_wrapper/ssh"
 
 # Configures nss_wrapper passwd and group files for SSH connections


### PR DESCRIPTION
The `NSS_WRAPPER_DEFAULT_DIR` in the `sshd.sh` script for the `crunchy-postgres-ha` container now references the proper directory, as defined in the `crunchy-postgres` Dockerfile (specifically `/tmp/nss_wrapper/postgres`).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

`NSS_WRAPPER_DEFAULT_DIR` is set to `/tmp/nss_wrapper/postgres-ha` in the `crunchy-postgres-ha` `sshd.sh` script.

[ch9887]

**What is the new behavior (if this is a feature change)?**

`NSS_WRAPPER_DEFAULT_DIR` is set to `/tmp/nss_wrapper/postgres` in the `crunchy-postgres-ha` `sshd.sh` script.

**Other information**:

N/A