### PR TITLE
Allow for TLS to be toggled

### DIFF
--- a/bin/postgres-ha/bootstrap/pre-bootstrap.sh
+++ b/bin/postgres-ha/bootstrap/pre-bootstrap.sh
@@ -386,7 +386,11 @@ build_bootstrap_config_file() {
       if [[ -f "/pgconf/tls/ca.crl" ]]
       then
         "${CRUNCHY_DIR}/bin/yq" w -i "${bootstrap_file}" bootstrap.dcs.postgresql.parameters.ssl_crl_file "/pgconf/tls/ca.crl"
+        "${CRUNCHY_DIR}/bin/yq" w -i "${bootstrap_file}" postgresql.parameters.ssl_crl_file "/pgconf/tls/ca.crl"
       fi
+    else
+      echo_info "Disabling TLS in postgresql.conf"
+      "${CRUNCHY_DIR}/bin/yq" m -i -a "${bootstrap_file}" "${CRUNCHY_DIR}/conf/postgres-ha/postgres-ha-pgconf-notls.yaml"
     fi
 
     if [[ "${PGHA_TLS_ONLY}" != "true" ]]

--- a/conf/postgres-ha/postgres-ha-pgconf-notls.yaml
+++ b/conf/postgres-ha/postgres-ha-pgconf-notls.yaml
@@ -1,0 +1,8 @@
+---
+postgresql:
+  parameters:
+    ssl: "off"
+    ssl_cert_file: ""
+    ssl_key_file: ""
+    ssl_ca_file: ""
+    ssl_crl_file: ""

--- a/conf/postgres-ha/postgres-ha-pgconf-tls.yaml
+++ b/conf/postgres-ha/postgres-ha-pgconf-tls.yaml
@@ -7,3 +7,9 @@ bootstrap:
         ssl_cert_file: "/pgconf/tls/tls.crt"
         ssl_key_file: "/pgconf/tls/tls.key"
         ssl_ca_file: "/pgconf/tls/ca.crt"
+postgresql:
+  parameters:
+    ssl: "on"
+    ssl_cert_file: "/pgconf/tls/tls.crt"
+    ssl_key_file: "/pgconf/tls/tls.key"
+    ssl_ca_file: "/pgconf/tls/ca.crt"


### PR DESCRIPTION
These changes allow for TLS to be toggled during the container
bootstrap process.

Issue: [ch10622]