### PR TITLE
Select password encryption method during cluster bootstrap

### DIFF
--- a/bin/postgres-ha/bootstrap/pre-bootstrap.sh
+++ b/bin/postgres-ha/bootstrap/pre-bootstrap.sh
@@ -395,6 +395,13 @@ build_bootstrap_config_file() {
       "${CRUNCHY_DIR}/bin/yq" m -i -a "${pghba_file}" "${CRUNCHY_DIR}/conf/postgres-ha/postgres-ha-pghba-notls.yaml"
     fi
 
+    # If SCRAM passwords are selected, set this as part of the bootstrapped
+    # password parameter
+    if [[ "${PGHA_PASSWORD_TYPE}" == "scram-sha-256" ]]
+    then
+      "${CRUNCHY_DIR}/bin/yq" w -i "${bootstrap_file}" bootstrap.dcs.postgresql.parameters.password_encryption "scram-sha-256"
+    fi
+
     # If this is being restored to a new cluster, disable archive_mode to
     # prevent WAL from being pushed while potentiallystill connected to another
     # pgBackRest repository while initializing (e.g. while performing a


### PR DESCRIPTION
This adds the `PGHA_PASSWORD_TYPE` environmental variable that
allows the toggling of password encryption (hashing) method to be
set across all Postgres instances during a cluster bootstrap.

Issue: [ch11049]