### PR TITLE
Update Crunchy Postgres Exporter integration

### DIFF
--- a/bin/install-deps.sh
+++ b/bin/install-deps.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Dependency Versions
-PGMONITOR_COMMIT='v4.4'
+PGMONITOR_COMMIT='v4.5-RC2'
 OPENSHIFT_CLIENT='https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz'
 CERTSTRAP_VERSION=1.1.1
 YQ_VERSION=3.3.0

--- a/bin/postgres_common/exporter/install.sh
+++ b/bin/postgres_common/exporter/install.sh
@@ -21,24 +21,21 @@ export PGHOST="/tmp"
 test_server "postgres" "${PGHOST?}" "${PGHA_PG_PORT}" "postgres"
 VERSION=$(psql --port="${PG_PRIMARY_PORT}" -d postgres -qtAX -c "SELECT current_setting('server_version_num')")
 
-if (( ${VERSION?} >= 90500 )) && (( ${VERSION?} < 90600 ))
+if (( ${VERSION?} >= 90600 )) && (( ${VERSION?} < 100000 ))
 then
-    function_file="${CRUNCHY_DIR}/bin/modules/pgexporter/setup_pg95.sql"
-elif (( ${VERSION?} >= 90600 )) && (( ${VERSION?} < 100000 ))
-then
-    function_file="${CRUNCHY_DIR}/bin/modules/pgexporter/setup_pg96.sql"
+    function_file="${CRUNCHY_DIR}/bin/modules/pgexporter/pg96/setup.sql"
 elif (( ${VERSION?} >= 100000 )) && (( ${VERSION?} < 110000 ))
 then
-    function_file="${CRUNCHY_DIR}/bin/modules/pgexporter/setup_pg10.sql"
+    function_file="${CRUNCHY_DIR}/bin/modules/pgexporter/pg10/setup.sql"
 elif (( ${VERSION?} >= 110000 )) && (( ${VERSION?} < 120000 ))
 then
-    function_file="${CRUNCHY_DIR}/bin/modules/pgexporter/setup_pg11.sql"
+    function_file="${CRUNCHY_DIR}/bin/modules/pgexporter/pg11/setup.sql"
 elif (( ${VERSION?} >= 120000 )) && (( ${VERSION?} < 130000 ))
 then
-    function_file="${CRUNCHY_DIR}/bin/modules/pgexporter/setup_pg12.sql"
+    function_file="${CRUNCHY_DIR}/bin/modules/pgexporter/pg12/setup.sql"
 elif (( ${VERSION?} >= 130000 ))
 then
-    function_file="${CRUNCHY_DIR}/bin/modules/pgexporter/setup_pg13.sql"
+    function_file="${CRUNCHY_DIR}/bin/modules/pgexporter/pg13/setup.sql"
 else
     echo_err "Unknown or unsupported version of PostgreSQL.  Exiting.."
     exit 1

--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -106,7 +106,8 @@ EXPOSE 5432
 ADD bin/postgres_common /opt/crunchy/bin
 ADD bin/common /opt/crunchy/bin
 ADD conf/postgres_common /opt/crunchy/conf
-ADD tools/pgmonitor/exporter/postgres /opt/crunchy/bin/modules/pgexporter
+ADD tools/pgmonitor/postgres_exporter/common /opt/crunchy/bin/modules/pgexporter
+ADD tools/pgmonitor/postgres_exporter/linux /opt/crunchy/bin/modules/pgexporter
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh && rm -f /run/nologin
 


### PR DESCRIPTION
This aligns the Crunchy Postgres Exporter integration with pgMonitor
4.5, bringing in new metrics that are collected for various parts
of the Postgres cluster.

Issue: [ch11157]