### PR TITLE
Ensure tar present in pgBackRest UBI 8 containers

### DIFF
--- a/build/pgbackrest/Dockerfile
+++ b/build/pgbackrest/Dockerfile
@@ -22,6 +22,9 @@ RUN if [ "$BASEOS" = "ubi8" ] ; then \
 		openssh-clients \
 		openssh-server \
 		shadow-utils \
+		tar \
+		bzip2 \
+		lz4 \
 		crunchy-backrest-${BACKREST_VER} \
 		&& ${PACKAGER} -y clean all ; \
 else \
@@ -29,6 +32,8 @@ else \
 		--setopt=skip_missing_names_on_install=False \
 		openssh-clients \
 		openssh-server \
+		bzip2 \
+		lz4 \
 		crunchy-backrest-${BACKREST_VER} \
 		&& ${PACKAGER} -y clean all ; \
 fi


### PR DESCRIPTION
tar is not present in the pgBackRest container for UBI 8,
but is now available.

This also ensures that bzip2 + lz4 are available, should one
select those modes.

Issue: [ch11325]