### PR TITLE
Ensure tar present in Postgres UBI 8 containers

### DIFF
--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -53,6 +53,8 @@ RUN if [ "$DFSET" = "centos" ] ; then \
         	procps-ng \
         	pgaudit_analyze \
         	unzip \
+        	bzip2 \
+        	lz4 \
         && ${PACKAGER} -y clean all ; \
 else \
         ${PACKAGER} -y install \
@@ -75,6 +77,9 @@ else \
 		wal2json${PG_MAJOR//.} \
 		file \
 		unzip \
+		tar \
+		bzip2 \
+		lz4 \
 	&& ${PACKAGER} -y install \
 		--setopt=tsflags='' \
 		--enablerepo="epel" \


### PR DESCRIPTION
Like 28068ca9, tar is now present in the Postgres container for UBI 8.

This also ensures that bzip2 + lz4 are available, should one select
those modes.