### PR TITLE
Refactors pgo-backrest Util

### DIFF
--- a/cmd/pgbackrest/main.go
+++ b/cmd/pgbackrest/main.go
@@ -17,13 +17,16 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
 	core_v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -50,7 +53,7 @@ const (
 	noRepoS3VerifyTLS = "--no-repo1-s3-verify-tls"
 )
 
-const containerName = "database"
+const containerNameDefault = "database"
 
 const (
 	pgtaskBackrestStanzaCreate = "stanza-create"
@@ -58,22 +61,20 @@ const (
 	pgtaskBackrestBackup       = "backup"
 )
 
-// getEnvRequired attempts to get an environmental variable that is required
-// by this program. If this cannot happen, we fatally exit
-func getEnvRequired(envVar string) string {
-	val := strings.TrimSpace(os.Getenv(envVar))
-
-	if val == "" {
-		log.Fatalf("required environmental variable %q not set, exiting.", envVar)
-	}
-
-	log.Debugf("%s set to: %s", envVar, val)
-
-	return val
+type config struct {
+	command, commandOpts, container, namespace, podName, repoType, selector string
+	compareHash, localGCSStorage, localS3Storage, s3VerifyTLS               bool
 }
 
 func main() {
+	ctx := context.Background()
 	log.Info("crunchy-pgbackrest starts")
+
+	debugFlag, _ := strconv.ParseBool(os.Getenv("CRUNCHY_DEBUG"))
+	if debugFlag {
+		log.SetLevel(log.DebugLevel)
+	}
+	log.Infof("debug flag set to %t", debugFlag)
 
 	config, err := NewConfig()
 	if err != nil {
@@ -85,103 +86,30 @@ func main() {
 		panic(err)
 	}
 
-	debugFlag, _ := strconv.ParseBool(os.Getenv("CRUNCHY_DEBUG"))
-	if debugFlag {
-		log.SetLevel(log.DebugLevel)
-	}
-	log.Infof("debug flag set to %t", debugFlag)
+	// first load any configuration provided (e.g. via environment variables)
+	cfg := loadConfiguration(ctx, k)
 
-	namespace := getEnvRequired("NAMESPACE")
-	command := getEnvRequired("COMMAND")
-	podName := getEnvRequired("PODNAME")
+	// create the proper pgBackRest command
+	cmd := createPGBackRestCommand(cfg)
+	log.Infof("command to execute is [%s]", strings.Join(cmd, " "))
 
-	commandOpts := os.Getenv("COMMAND_OPTS")
-	log.Debugf("COMMAND_OPTS set to: %s", commandOpts)
-
-	repoType := os.Getenv("PGBACKREST_REPO1_TYPE")
-	log.Debugf("PGBACKREST_REPO1_TYPE set to: %s", repoType)
-
-	// determine the setting of PGHA_PGBACKREST_LOCAL_S3_STORAGE
-	// we will discard the error and treat the value as "false" if it is not
-	// explicitly set
-	localS3Storage, _ := strconv.ParseBool(os.Getenv("PGHA_PGBACKREST_LOCAL_S3_STORAGE"))
-	log.Debugf("PGHA_PGBACKREST_LOCAL_S3_STORAGE set to: %t", localS3Storage)
-
-	// determine the setting of PGHA_PGBACKREST_LOCAL_GCS_STORAGE
-	// we will discard the error and treat the value as "false" if it is not
-	// explicitly set
-	localGCSStorage, _ := strconv.ParseBool(os.Getenv("PGHA_PGBACKREST_LOCAL_GCS_STORAGE"))
-	log.Debugf("PGHA_PGBACKREST_LOCAL_GCS_STORAGE set to: %t", localGCSStorage)
-
-	// parse the environment variable and store the appropriate boolean value
-	// we will discard the error and treat the value as "false" if it is not
-	// explicitly set
-	s3VerifyTLS, _ := strconv.ParseBool(os.Getenv("PGHA_PGBACKREST_S3_VERIFY_TLS"))
-	log.Debugf("PGHA_PGBACKREST_S3_VERIFY_TLS set to: %t", s3VerifyTLS)
-
-	bashCmd := []string{"bash"}
-	cmdStrs := []string{backrestCommand}
-
-	switch command {
-	default:
-		log.Fatalf("unsupported backup command specified: %s", command)
-	case pgtaskBackrestStanzaCreate:
-		log.Info("backrest stanza-create command requested")
-		cmdStrs = append(cmdStrs, backrestStanzaCreateCommand, commandOpts)
-	case pgtaskBackrestInfo:
-		log.Info("backrest info command requested")
-		cmdStrs = append(cmdStrs, backrestInfoCommand, commandOpts)
-	case pgtaskBackrestBackup:
-		log.Info("backrest backup command requested")
-		cmdStrs = append(cmdStrs, backrestBackupCommand, commandOpts)
+	var output, stderr string
+	// now run the proper exec command depending on whether or not the config hashes should first
+	// be compared prior to executing the PGBackRest command
+	if !cfg.compareHash {
+		output, stderr, err = runCommand(k, cfg, cmd)
+	} else {
+		output, stderr, err = compareHashAndRunCommand(k, cfg, cmd)
 	}
 
-	if localS3Storage {
-		// if the first backup fails, still attempt the 2nd one
-		cmdStrs = append(cmdStrs, ";")
-		cmdStrs = append(cmdStrs, cmdStrs...)
-		cmdStrs[len(cmdStrs)-1] = repoTypeFlagS3 // a trick to overwite the second ";"
-		// pass in the flag to disable TLS verification, if set
-		// otherwise, maintain default behavior and verify TLS
-		if !s3VerifyTLS {
-			cmdStrs = append(cmdStrs, noRepoS3VerifyTLS)
-		}
-		log.Info("backrest command will be executed for both local and s3 storage")
-	} else if repoType == "s3" {
-		cmdStrs = append(cmdStrs, repoTypeFlagS3)
-		// pass in the flag to disable TLS verification, if set
-		// otherwise, maintain default behavior and verify TLS
-		if !s3VerifyTLS {
-			cmdStrs = append(cmdStrs, noRepoS3VerifyTLS)
-		}
-		log.Info("s3 flag enabled for backrest command")
-	}
-
-	if localGCSStorage {
-		// if the first backup fails, still attempt the 2nd one
-		cmdStrs = append(cmdStrs, ";")
-		cmdStrs = append(cmdStrs, cmdStrs...)
-		cmdStrs[len(cmdStrs)-1] = repoTypeFlagGCS // a trick to overwite the second ";"
-		log.Info("backrest command will be executed for both local and gcs storage")
-	} else if repoType == "gcs" {
-		cmdStrs = append(cmdStrs, repoTypeFlagGCS)
-		log.Info("gcs flag enabled for backrest command")
-	}
-
-	log.Infof("command to execute is [%s]", strings.Join(cmdStrs, " "))
-
-	reader := strings.NewReader(strings.Join(cmdStrs, " "))
-	output, stderr, err := k.Exec(namespace, podName, containerName, reader, bashCmd)
-	if err != nil {
-		log.Info("output=[" + output + "]")
-		log.Info("stderr=[" + stderr + "]")
-		log.Fatal(err)
-	}
+	// log any output and check for errors
 	log.Info("output=[" + output + "]")
 	log.Info("stderr=[" + stderr + "]")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	log.Info("crunchy-pgbackrest ends")
-
 }
 
 // Exec returns the stdout and stderr from running a command inside an existing
@@ -239,4 +167,191 @@ func NewForConfig(config *rest.Config) (*KubeAPI, error) {
 	api.Client, err = kubernetes.NewForConfig(api.Config)
 
 	return &api, err
+}
+
+// getEnvRequired attempts to get an environmental variable that is required
+// by this program. If this cannot happen, we fatally exit
+func getEnvRequired(envVar string) string {
+	val := strings.TrimSpace(os.Getenv(envVar))
+
+	if val == "" {
+		log.Fatalf("required environmental variable %q not set, exiting.", envVar)
+	}
+
+	log.Debugf("%s set to: %s", envVar, val)
+
+	return val
+}
+
+// loadConfiguration loads configuration from the environment as needed to run a pgBackRest
+// command
+func loadConfiguration(ctx context.Context, kubeapi *KubeAPI) config {
+	cfg := config{}
+
+	cfg.namespace = getEnvRequired("NAMESPACE")
+	cfg.command = getEnvRequired("COMMAND")
+
+	cfg.container = os.Getenv("CONTAINER")
+	if cfg.container == "" {
+		cfg.container = containerNameDefault
+	}
+	log.Debugf("CONTAINER set to: %s", cfg.container)
+
+	cfg.commandOpts = os.Getenv("COMMAND_OPTS")
+	log.Debugf("COMMAND_OPTS set to: %s", cfg.commandOpts)
+
+	cfg.selector = os.Getenv("SELECTOR")
+	log.Debugf("SELECTOR set to: %s", cfg.selector)
+
+	compareHashEnv := os.Getenv("COMPARE_HASH")
+	log.Debugf("COMPARE_HASH set to: %s", compareHashEnv)
+	if compareHashEnv != "" {
+		// default to false if an error parsing
+		cfg.compareHash, _ = strconv.ParseBool(compareHashEnv)
+	}
+
+	if cfg.selector == "" {
+		// if no selector then a Pod name must be provided
+		cfg.podName = getEnvRequired("PODNAME")
+	} else {
+		// if a selector is provided, then lookup the Pod via the provided selector to get the
+		// Pod name
+		pods, err := kubeapi.Client.CoreV1().Pods(cfg.namespace).List(ctx,
+			metav1.ListOptions{LabelSelector: cfg.selector})
+		if err != nil {
+			log.Fatal(err)
+		}
+		if len(pods.Items) != 1 {
+			log.Fatalf("found %d Pods using selector, but only expected one", len(pods.Items))
+		}
+		cfg.podName = pods.Items[0].GetName()
+	}
+	log.Debugf("PODNAME set to: %s", cfg.podName)
+
+	cfg.repoType = os.Getenv("PGBACKREST_REPO1_TYPE")
+	log.Debugf("PGBACKREST_REPO1_TYPE set to: %s", cfg.repoType)
+
+	// determine the setting of PGHA_PGBACKREST_LOCAL_S3_STORAGE
+	// we will discard the error and treat the value as "false" if it is not
+	// explicitly set
+	cfg.localS3Storage, _ = strconv.ParseBool(os.Getenv("PGHA_PGBACKREST_LOCAL_S3_STORAGE"))
+	log.Debugf("PGHA_PGBACKREST_LOCAL_S3_STORAGE set to: %t", cfg.localS3Storage)
+
+	// determine the setting of PGHA_PGBACKREST_LOCAL_GCS_STORAGE
+	// we will discard the error and treat the value as "false" if it is not
+	// explicitly set
+	cfg.localGCSStorage, _ = strconv.ParseBool(os.Getenv("PGHA_PGBACKREST_LOCAL_GCS_STORAGE"))
+	log.Debugf("PGHA_PGBACKREST_LOCAL_GCS_STORAGE set to: %t", cfg.localGCSStorage)
+
+	// parse the environment variable and store the appropriate boolean value
+	// we will discard the error and treat the value as "false" if it is not
+	// explicitly set
+	cfg.s3VerifyTLS, _ = strconv.ParseBool(os.Getenv("PGHA_PGBACKREST_S3_VERIFY_TLS"))
+	log.Debugf("PGHA_PGBACKREST_S3_VERIFY_TLS set to: %t", cfg.s3VerifyTLS)
+
+	return cfg
+}
+
+// createPGBackRestCommand form the proper pgBackRest command based on the configuration provided
+func createPGBackRestCommand(cfg config) []string {
+	cmd := []string{backrestCommand}
+
+	switch cfg.command {
+	default:
+		log.Fatalf("unsupported backup command specified: %s", cfg.command)
+	case pgtaskBackrestStanzaCreate:
+		log.Info("backrest stanza-create command requested")
+		cmd = append(cmd, backrestStanzaCreateCommand, cfg.commandOpts)
+	case pgtaskBackrestInfo:
+		log.Info("backrest info command requested")
+		cmd = append(cmd, backrestInfoCommand, cfg.commandOpts)
+	case pgtaskBackrestBackup:
+		log.Info("backrest backup command requested")
+		cmd = append(cmd, backrestBackupCommand, cfg.commandOpts)
+	}
+
+	if cfg.localS3Storage {
+		// if the first backup fails, still attempt the 2nd one
+		cmd = append(cmd, ";")
+		cmd = append(cmd, cmd...)
+		cmd[len(cmd)-1] = repoTypeFlagS3 // a trick to overwite the second ";"
+		// pass in the flag to disable TLS verification, if set
+		// otherwise, maintain default behavior and verify TLS
+		if !cfg.s3VerifyTLS {
+			cmd = append(cmd, noRepoS3VerifyTLS)
+		}
+		log.Info("backrest command will be executed for both local and s3 storage")
+	} else if cfg.repoType == "s3" {
+		cmd = append(cmd, repoTypeFlagS3)
+		// pass in the flag to disable TLS verification, if set
+		// otherwise, maintain default behavior and verify TLS
+		if !cfg.s3VerifyTLS {
+			cmd = append(cmd, noRepoS3VerifyTLS)
+		}
+		log.Info("s3 flag enabled for backrest command")
+	}
+
+	if cfg.localGCSStorage {
+		// if the first backup fails, still attempt the 2nd one
+		cmd = append(cmd, ";")
+		cmd = append(cmd, cmd...)
+		cmd[len(cmd)-1] = repoTypeFlagGCS // a trick to overwite the second ";"
+		log.Info("backrest command will be executed for both local and gcs storage")
+	} else if cfg.repoType == "gcs" {
+		cmd = append(cmd, repoTypeFlagGCS)
+		log.Info("gcs flag enabled for backrest command")
+	}
+
+	return cmd
+}
+
+// compareHashAndRunCommand calculates the hash of the pgBackRest configuration locally against
+// a hash of the pgBackRest configuration for the container being exec'd into to run a pgBackRest
+// command.  Only if the hashes match will the pgBackRest command be run, otherwise and error will
+// be written and exit code 1 will be returned.  This is done to ensure a pgBackRest command is only
+// run when it can be verified that the exepected configuration is present.
+func compareHashAndRunCommand(kubeapi *KubeAPI, cfg config, cmd []string) (string, string, error) {
+
+	// the base script used in both the local and exec commands created below
+	baseScript := `
+shopt -s globstar
+files=(/etc/pgbackrest/conf.d/**)
+for i in "${!files[@]}"; do
+	[[ -f "${files[$i]}" ]] || unset -v "files[$i]"
+done`
+
+	// the script run locally to get the local hash
+	localScript := baseScript + `
+sha1sum "${files[@]}" | sha1sum
+`
+
+	// the script to run remotely via exec
+	execScript := baseScript + `
+declare -r hash="$1"
+local_hash="$(sha1sum "${files[@]}" | sha1sum)" 
+if [[ "${local_hash}" != "${hash}" ]]; then
+	printf >&2 "hash %s does not match local hash %s" "${hash}" "${local_hash}"; exit 1;
+else
+	` + strings.Join(cmd, " ") + `
+fi
+`
+
+	localHashCmd := exec.Command("bash", "-ceu", "--", localScript)
+	hashOutput, err := localHashCmd.Output()
+	if err != nil {
+		log.Fatalf("unable to calculate hash for pgBackRest config: %v", err)
+	}
+	configHash := strings.TrimSuffix(string(hashOutput), "\n")
+	log.Debugf("caclulated config hash %s", configHash)
+
+	execCmd := []string{"bash", "-ceu", "--", execScript, "-", configHash}
+	return kubeapi.Exec(cfg.namespace, cfg.podName, cfg.container, nil, execCmd)
+}
+
+// runCommand runs the provided pgBackRest command according to the configuration
+// provided
+func runCommand(kubeapi *KubeAPI, cfg config, cmd []string) (string, string, error) {
+	bashCmd := []string{"bash"}
+	reader := strings.NewReader(strings.Join(cmd, " "))
+	return kubeapi.Exec(cfg.namespace, cfg.podName, cfg.container, reader, bashCmd)
 }


### PR DESCRIPTION
Refactors the `pgo-backrest` util as used to `exec` into containers and run pgBackRest commands. This includes better organizing the logic for obtaining configuration settings and forming the pgBackRest command. Additionally, now includes the ability to verify the hashes of the pgBackRest `conf.d` directory before running the command, while now also allowing for the discovery of the Pod to be exec'd into via labels.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
