### PR TITLE
Move to pkill

### DIFF
--- a/bin/pgbackrest-repo/pgbackrest-repo.sh
+++ b/bin/pgbackrest-repo/pgbackrest-repo.sh
@@ -26,7 +26,7 @@ function nss_wrapper_ssh() {
 
 function trap_sigterm() {
 	echo "Signal trap triggered, beginning shutdown.."
-	killall sshd
+	pkill sshd
 }
 
 trap 'trap_sigterm' SIGINT SIGTERM

--- a/bin/postgres-ha/bootstrap-postgres-ha.sh
+++ b/bin/postgres-ha/bootstrap-postgres-ha.sh
@@ -24,16 +24,16 @@ trap_sigterm() {
 
     echo_warn "Signal trap triggered, beginning shutdown.." | tee -a "${PATRONI_POSTGRESQL_DATA_DIR}"/trap.output
 
-    killall patroni
+    pkill patroni
     echo_warn "Killed Patroni to gracefully shutdown PG" | tee -a "${PATRONI_POSTGRESQL_DATA_DIR}"/trap.output
 
     if [[ ${ENABLE_SSHD} == "true" ]]
     then
         echo_info "Killing SSHD.."
-        killall sshd
+        pkill sshd
     fi
 
-    while killall -0 patroni; do
+    while pkill -0 patroni; do
         echo_info "Waiting for Patroni to terminate.."
         sleep 1
     done
@@ -135,10 +135,10 @@ initialization_monitor() {
                 echo_info "Successfully removed cluster from the DCS"
 
                 # now kill patroni and sshd
-                killall patroni
-                killall sshd
+                pkill patroni
+                pkill sshd
 
-                while killall -0 patroni; do
+                while pkill -0 patroni; do
                     echo_info "Waiting for Patroni to terminate following init job..."
                     sleep 1
                 done

--- a/bin/postgres_common/postgres/start.sh
+++ b/bin/postgres_common/postgres/start.sh
@@ -31,7 +31,7 @@ function trap_sigterm() {
     fi
     if [[ ${ENABLE_SSHD} == "true" ]]; then
         echo_info "killing SSHD.."
-        killall sshd
+        pkill sshd
     fi
 }
 


### PR DESCRIPTION
Some calls were still using killall, which was missing in the
current package set. This moves to using pkill.

closes #1360