### PR TITLE
Clean and/or Re-create Files on PGHA Init

### DIFF
--- a/bin/common/nss_wrapper.sh
+++ b/bin/common/nss_wrapper.sh
@@ -21,7 +21,7 @@ CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
 # Define nss_wrapper directory and passwd & group files that will be utilized by nss_wrapper.  The
 # nss_wrapper_env.sh script (which also sets these vars) isn't sourced here since the nss_wrapper
 # has not yet been setup, and we therefore don't yet want the nss_wrapper vars in the environment.
-mkdir /tmp/nss_wrapper
+mkdir -p /tmp/nss_wrapper
 chmod g+rwx /tmp/nss_wrapper
 
 NSS_WRAPPER_DIR="/tmp/nss_wrapper/${NSS_WRAPPER_SUBDIR}"

--- a/bin/postgres-ha/bootstrap-postgres-ha.sh
+++ b/bin/postgres-ha/bootstrap-postgres-ha.sh
@@ -201,6 +201,9 @@ fi
 # Configure users and groups
 source "${CRUNCHY_DIR}/bin/uid_postgres_no_exec.sh"
 
+# remove the "initialized" file and initialize logs if they already exist (e.g. after a restart)
+rm -f "/tmp/pgha_initialized" "/tmp/patroni_initialize_check.log"
+
 # Perform cluster pre-initialization (set defaults, load secrets, peform validation, log config details, etc.)
 source "${CRUNCHY_DIR}/bin/postgres-ha/bootstrap/pre-bootstrap.sh"
 

--- a/bin/postgres-ha/bootstrap/pre-bootstrap.sh
+++ b/bin/postgres-ha/bootstrap/pre-bootstrap.sh
@@ -262,10 +262,10 @@ validate_env() {
 build_bootstrap_config_file() {
 
     bootstrap_file="/tmp/postgres-ha-bootstrap.yaml"
-    echo "---" >> "${bootstrap_file}"
+    echo "---" > "${bootstrap_file}"
 
     pghba_file="/tmp/postgres-ha-pghba.yaml"
-    cat "${CRUNCHY_DIR}/conf/postgres-ha/postgres-ha-pghba-bootstrap.yaml" >> "${pghba_file}"
+    cat "${CRUNCHY_DIR}/conf/postgres-ha/postgres-ha-pghba-bootstrap.yaml" > "${pghba_file}"
 
     if [[ "${PGHA_BASE_BOOTSTRAP_CONFIG}" == "true" ]]
     then

--- a/bin/postgres-ha/bootstrap/sshd.sh
+++ b/bin/postgres-ha/bootstrap/sshd.sh
@@ -53,6 +53,8 @@ then
         exit 1
     fi
 
+    # remove the file before copying if it already exists (e.g. after a restart)
+    rm -f /tmp/id_ed25519
     cp /sshd/id_ed25519 /tmp
     chmod 400 /tmp/id_ed25519
 


### PR DESCRIPTION
Various files created and/or utilized when initializing the `crunchy-postgres-ha` container are now properly cleaned and/or recreated when the various initialize scripts are run to initialize the container (and therefore Patroni and PostgreSQL).  This ensures various config files are created with the proper contents if they already exist (e.g. due to a restart of the container), while also ensuring the log files do not continuously grow.

Additionally, the `nss_wrapper` init script will no longer display an error if the `nss_wrapper` directory already exists.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Various files created and/or utilized by the PGHA container are not recreated if they already exist, which can lead to invalid configuration files after container restarts.

**What is the new behavior (if this is a feature change)?**

Various files created and/or utilized by the PGHA container are now cleaned or recreated if they already exist, ensuring they contain the proper (and required) contents after a container restart.

**Other information**:

N/A