### PR TITLE
Remove psutil dnf install

### DIFF
--- a/build/postgres-gis-ha/Dockerfile
+++ b/build/postgres-gis-ha/Dockerfile
@@ -31,8 +31,9 @@ LABEL name="postgres-gis-ha" \
 RUN if [ "$DFSET" = "centos" ] ; then \
 	${PACKAGER} -y install \
 		--setopt=skip_missing_names_on_install=False \
+		gcc \
+		python3-devel \
 		python3-pip \
-		python3-psutil \
 		python3-psycopg2 \
 	&& ${PACKAGER} -y clean all ; \
 fi
@@ -41,8 +42,9 @@ RUN if [ "$BASEOS" = "rhel7" ] ; then \
 	${PACKAGER} -y install \
 		--enablerepo="epel,rhel-7-server-optional-rpms" \
 		--setopt=skip_missing_names_on_install=False \
+		gcc \
+		python3-devel \
 		python3-pip \
-		python3-psutil \
 		python3-psycopg2 \
 	&& ${PACKAGER} -y clean all --enablerepo="epel,rhel-7-server-optional-rpms" ; \
 fi
@@ -51,8 +53,9 @@ RUN if [ "$BASEOS" = "ubi7" ] ; then \
 	${PACKAGER} -y install \
 		--enablerepo="epel,rhel-7-server-optional-rpms" \
 		--setopt=skip_missing_names_on_install=False \
+		gcc \
+		python3-devel \
 		python3-pip \
-		python3-psutil \
 		python3-psycopg2 \
 	&& ${PACKAGER} -y clean all --enablerepo="epel,rhel-7-server-optional-rpms" ; \
 fi
@@ -60,8 +63,9 @@ fi
 RUN if [ "$BASEOS" = "ubi8" ] ; then \
 	${PACKAGER} -y install \
 		--enablerepo="epel" \
+		gcc \
+		python3-devel \
 		python3-pip \
-		python3-psutil \
 		python3-psycopg2 \
 	&& ${PACKAGER} -y clean all --enablerepo="epel" ; \
 fi

--- a/build/postgres-ha/Dockerfile
+++ b/build/postgres-ha/Dockerfile
@@ -31,8 +31,9 @@ LABEL name="postgres-ha" \
 RUN if [ "$DFSET" = "centos" ] ; then \
 	${PACKAGER} -y install \
 		--setopt=skip_missing_names_on_install=False \
+		gcc \
+		python3-devel \
 		python3-pip \
-		python3-psutil \
 		python3-psycopg2 \
 	&& ${PACKAGER} -y clean all ; \
 fi
@@ -41,8 +42,9 @@ RUN if [ "$BASEOS" = "rhel7" ] ; then \
 	${PACKAGER} -y install \
 		--enablerepo="epel,rhel-7-server-optional-rpms" \
 		--setopt=skip_missing_names_on_install=False \
+		gcc \
+		python3-devel \
 		python3-pip \
-		python3-psutil \
 		python3-psycopg2 \
 	&& ${PACKAGER} -y clean all --enablerepo="epel,rhel-7-server-optional-rpms" ; \
 fi
@@ -51,8 +53,9 @@ RUN if [ "$BASEOS" = "ubi7" ] ; then \
 	${PACKAGER} -y install \
 		--enablerepo="epel,rhel-7-server-optional-rpms" \
 		--setopt=skip_missing_names_on_install=False \
+		gcc \
+		python3-devel \
 		python3-pip \
-		python3-psutil \
 		python3-psycopg2 \
 	&& ${PACKAGER} -y clean all --enablerepo="epel,rhel-7-server-optional-rpms" ; \
 fi
@@ -60,8 +63,9 @@ fi
 RUN if [ "$BASEOS" = "ubi8" ] ; then \
 	${PACKAGER} -y install \
 		--enablerepo="epel" \
+		gcc \
+		python3-devel \
 		python3-pip \
-		python3-psutil \
 		python3-psycopg2 \
 	&& ${PACKAGER} -y clean all --enablerepo="epel" ; \
 fi


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently we are installing psutil using dnf.


**What is the new behavior (if this is a feature change)?**
Instead of installing psutil with dnf this will instead install gcc and python3-devel which allows the pip install further down to resolve psutil as a dependency and compile and install it into the system.  This actually reduces the resulting container size and remove the psutil dependency.


**Other information**:
