### PR TITLE
Add pgBackRest Script to Base PG Container & Hide Sensitive pgBackRest Config

### DIFF
--- a/bin/postgres_common/exporter/install.sh
+++ b/bin/postgres_common/exporter/install.sh
@@ -43,7 +43,7 @@ fi
 
 echo_info "Using setup file '${function_file}' for pgMonitor"
 cp "${function_file}" "/tmp/setup_pg.sql"
-sed -i "s,/usr/bin/pgbackrest-info.sh,${CRUNCHY_DIR}/bin/postgres-ha/pgbackrest/pgbackrest_info.sh,g" "/tmp/setup_pg.sql"
+sed -i "s,/usr/bin/pgbackrest-info.sh,${CRUNCHY_DIR}/bin/postgres/pgbackrest_info.sh,g" "/tmp/setup_pg.sql"
 
 psql -U postgres --port="${PG_PRIMARY_PORT}" -d postgres \
     < "/tmp/setup_pg.sql" >> /tmp/pgmonitor-setup.stdout 2>> /tmp/pgmonitor-setup.stderr

--- a/bin/postgres_common/postgres/pgbackrest.sh
+++ b/bin/postgres_common/postgres/pgbackrest.sh
@@ -115,7 +115,7 @@ then
     echo_info "pgBackRest: BACKREST_SKIP_CREATE_STANZA is 'true'.  Skipping stanza creation.." 
 else
     echo_info "pgBackRest: The following pgbackrest env vars have been set:"
-    ( set -o posix ; set | grep -oP "^PGBACKREST.*" )
+    ( set -o posix ; set | grep -oP "^PGBACKREST.*" | sed -e 's/\(KEY\|PASS\|SECRET\)=.*/\1=*********/' )
 
     echo_info "pgBackRest: Executing 'stanza-create' to create stanza '${PGBACKREST_STANZA}'.."
     pgbackrest stanza-create --no-online --log-level-console=info \

--- a/bin/postgres_common/postgres/pgbackrest_info.sh
+++ b/bin/postgres_common/postgres/pgbackrest_info.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright 2019 - 2021 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /tmp/pgbackrest_env.sh > /tmp/pgbackrest_env.stdout 2> /tmp/pgbackrest_env.stderr
+
+cmd_args=()
+# if TLS verification is disabled, pass in the appropriate flag
+# otherwise, leave the default behavior and verify TLS
+if [[ "${PGHA_PGBACKREST_S3_VERIFY_TLS}" == "false" ]]
+then
+    cmd_args+=("--no-repo1-s3-verify-tls")
+fi
+
+echo $(echo -n "$conf|" | tr '/' '_'; pgbackrest --output=json ${cmd_args[*]} info | tr -d '\n')


### PR DESCRIPTION
The `crunchy-postgres` container now hides sensitive pgBackRest env vars when printing pgBackRest configuration during container startup:

```
Sun Aug  8 18:12:31 UTC 2021 INFO: pgBackRest: The following pgbackrest env vars have been set:
PGBACKREST=true
PGBACKREST_LOG_PATH=/tmp
PGBACKREST_PG1_PATH=/pgdata/backrest
PGBACKREST_REPO1_PATH=/backrestrepo/backrest-backups
PGBACKREST_REPO1_S3_KEY=*********
PGBACKREST_REPO1_S3_KEY_SECRET=*********
PGBACKREST_STANZA=db
Sun Aug  8 18:12:32 UTC 2021 INFO: pgBackRest: Executing 'stanza-create' to create stanza 'db'..
2021-08-08 18:12:32.018 P00   INFO: stanza-create command begin 2.33: --exec-id=117-ada47aeb --log-level-console=info --log-path=/tmp --no-online --pg1-path=/pgdata/backrest --repo1-path=/backrestrepo/backrest-backups --stanza=db
2021-08-08 18:12:32.020 P00   INFO: stanza-create for stanza 'db' on repo1
2021-08-08 18:12:32.356 P00   INFO: stanza-create command end: completed successfully (339ms)
```

Closes #1375
[ch12235]

---

Additionally, the `pgbackrest_info.sh` script is now included in the base PG container (the script also remains in the `postgres-ha` bin directory to maintain compatibility with PGO).

Closes #1376
[ch12234]