### PR TITLE
Remove the /var/spool/pgbackrest Directory

### DIFF
--- a/build/pgbackrest/Dockerfile
+++ b/build/pgbackrest/Dockerfile
@@ -74,6 +74,10 @@ RUN chmod -R g=u /etc/pgbackrest \
 
 RUN mkdir /.ssh && chown postgres:postgres /.ssh && chmod o+rwx /.ssh
 
+# remove the default spool directory so that pgBackRest does not attempt to look there when
+# performing a restore (pgBackRest will not have permissions to access to this dir in all envs)
+RUN rm -rf /var/spool/pgbackrest
+
 # create necessary volumes for all modes
 #
 # /sshd and /backrestrepo required for the pgBackRest repo mode

--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -128,6 +128,10 @@ ADD tools/pgmonitor/postgres_exporter/linux /opt/crunchy/bin/modules/pgexporter
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh && rm -f /run/nologin
 
+# remove the default spool directory so that pgBackRest does not attempt to look there when
+# performing a restore (pgBackRest will not have permissions to access to this dir in all envs)
+RUN rm -rf /var/spool/pgbackrest
+
 # add volumes to allow override of pg_hba.conf and postgresql.conf
 # add volumes to allow storage of postgres WAL segment files
 # add volumes to locate WAL files to recover with


### PR DESCRIPTION
The default pgBackRest spool directory (`/var/spool/pgbackrest`) is now removed when building the `crunchy-postgres` and `crunchy-pgbackrest` containers.

This is done to prevent pgBackRest from looking in this directory when performing a restore, since it was not always have permissions to access this directory in all environments (e.g. OpenShift).

[sc-12726]