### PR TITLE
Add krb5-workstation Package

### DIFF
--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -59,6 +59,7 @@ RUN if [ "$DFSET" = "centos" ] ; then \
         	unzip \
         	bzip2 \
         	lz4 \
+			krb5-workstation \
         && ${PACKAGER} -y clean all ; \
 else \
         ${PACKAGER} -y install --nodocs \
@@ -87,6 +88,7 @@ else \
 		tar \
 		bzip2 \
 		lz4 \
+		krb5-workstation \
 	&& ${PACKAGER} -y install --nodocs \
 		--setopt=tsflags='' \
 		--enablerepo="epel" \

--- a/build/upgrade/Dockerfile
+++ b/build/upgrade/Dockerfile
@@ -27,6 +27,7 @@ RUN if [ "$BASEOS" = "ubi8" ] ; then \
 	${PACKAGER} -y install --nodocs \
 		--disablerepo=crunchypg* \
 		--enablerepo="crunchypg${PG_MAJOR//.}" \
+		krb5-workstation \
 		"postgresql${PG_MAJOR//.}" \
 		"postgresql${PG_MAJOR//.}-contrib" \
 		"postgresql${PG_MAJOR//.}-server" \
@@ -39,6 +40,7 @@ else \
 		--setopt=skip_missing_names_on_install=False \
 		--disablerepo=crunchypg* \
 		--enablerepo="crunchypg${PG_MAJOR//.}" \
+		krb5-workstation \
 		"postgresql${PG_MAJOR//.}" \
 		"postgresql${PG_MAJOR//.}-contrib" \
 		"postgresql${PG_MAJOR//.}-server" \


### PR DESCRIPTION
Adds the `krb5-workstation` package to the `crunchy-postgres` and `crunchy-upgrade` containers as required for Kerberos authentication.

[sc-13235]