### PR TITLE
Add pgAdmin to Independent Images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ images = crunchy-postgres \
 all: pgimages pg-independent-images pgbackrest-images
 
 # Build images that either don't have a PG dependency or using the latest PG version is all that is needed
-pg-independent-images: pgbouncer
-# pg-independent-images: pgadmin4 pgbadger pgbouncer pgpool
+pg-independent-images: pgbouncer pgadmin4
+# pg-independent-images: pgbadger pgpool
 
 # Build images that require a specific postgres version - ordered for potential concurrent benefits
 pgimages: postgres postgres-gis upgrade


### PR DESCRIPTION
Adds the pgadmin container to `pg-independent-images` in the `Makefile`.

[sc-13267]