### PR TITLE
Pin pgAdmin Version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ CCP_PATRONI_VERSION ?= 2.1.3
 CCP_BACKREST_VERSION ?= 2.36
 CCP_VERSION ?= 5.0.5
 CCP_POSTGIS_VERSION ?= 3.1
+CCP_PGADMIN_VERSION ?= 4.20
 PACKAGER ?= yum
 
 # Valid values: buildah (default), docker
@@ -58,8 +59,8 @@ endif
 images = crunchy-postgres \
 	crunchy-upgrade \
 	crunchy-pgbackrest \
-	crunchy-pgbouncer
-	# crunchy-pgadmin4
+	crunchy-pgbouncer \
+	crunchy-pgadmin4
 	# crunchy-pgbadger
 	# crunchy-pgpool
 
@@ -268,6 +269,28 @@ ifeq ("$(IMG_PUSH_TO_DOCKER_DAEMON)", "true")
 endif
 
 upgrade-img-docker: upgrade-img-build
+
+# Special case args: CCP_PGADMIN_VERSION
+pgadmin4-img-build: ccbase-image $(CCPROOT)/build/pgadmin4/Dockerfile
+	$(IMGCMDSTEM) \
+		-f $(CCPROOT)/build/pgadmin4/Dockerfile \
+		-t $(CCP_IMAGE_PREFIX)/crunchy-pgadmin4:$(CCP_IMAGE_TAG) \
+		--build-arg BASEOS=$(CCP_BASEOS) \
+		--build-arg BASEVER=$(CCP_VERSION) \
+		--build-arg PG_FULL=$(CCP_PG_FULLVERSION) \
+		--build-arg PG_MAJOR=$(CCP_PGVERSION) \
+		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
+		--build-arg PGADMIN_VER=$(CCP_PGADMIN_VERSION) \
+		--build-arg PACKAGER=$(PACKAGER) \
+		$(CCPROOT)
+
+pgadmin4-img-buildah: pgadmin4-img-build ;
+# only push to docker daemon if variable IMG_PUSH_TO_DOCKER_DAEMON is set to "true"
+ifeq ("$(IMG_PUSH_TO_DOCKER_DAEMON)", "true")
+	sudo --preserve-env buildah push $(CCP_IMAGE_PREFIX)/crunchy-pgadmin4:$(CCP_IMAGE_TAG) docker-daemon:$(CCP_IMAGE_PREFIX)/crunchy-pgadmin4:$(CCP_IMAGE_TAG)
+endif
+
+pgadmin4-img-docker: pgadmin-img-build
 
 # ----- Extra images -----
 %-img-build: ccbase-image $(CCPROOT)/build/%/Dockerfile

--- a/build/pgadmin4/Dockerfile
+++ b/build/pgadmin4/Dockerfile
@@ -8,9 +8,7 @@ FROM ${PREFIX}/crunchy-base:${BASEOS}-${PG_FULL}-${BASEVER}
 ARG BASEOS
 ARG PACKAGER
 ARG PG_MAJOR
-
-# Needed due to lack of environment substitution trick on ADD
-ARG PG_LBL
+ARG PGADMIN_VER
 
 LABEL name="pgadmin4" \
 	summary="pgAdmin4 GUI utility" \
@@ -29,7 +27,7 @@ RUN if [ "$BASEOS" = "centos8" ] ; then \
                 python3-mod_wsgi \
                 openssl \
                 sqlite \
-                --setopt=obsoletes=0 pgadmin4 \
+                --setopt=obsoletes=0 pgadmin4-${PGADMIN_VER} \
                 postgresql${PG_MAJOR//.}-server \
         && ${PACKAGER} -y clean all \
         && chown -R 2:0 /usr/lib/python3.6/site-packages/pgadmin4-web \
@@ -49,7 +47,7 @@ RUN if [ "$BASEOS" = "ubi8" ] ; then \
                 python3-mod_wsgi \
                 openssl \
                 sqlite \
-                pgadmin4 \
+                pgadmin4-${PGADMIN_VER} \
                 postgresql${PG_MAJOR//.}-server \
         && ${PACKAGER} -y clean all --enablerepo="epel" \
         && chown -R 2:0 /usr/lib/python3.6/site-packages/pgadmin4-web \


### PR DESCRIPTION
Pins the pgAdmin version in the Makefile. 

Also updates the pgAdmin Make targets and Dockerfile to accommodate an argument for providing a specific pgAdmin version.

This same change will need to be backpatched to v4.

[sc-13733]