### PR TITLE
Remove the download of yq as it is not used anymore in v5.x

### DIFF
--- a/bin/install-deps.sh
+++ b/bin/install-deps.sh
@@ -21,11 +21,6 @@ YQ_VERSION=3.3.0
 
 sudo yum -y install net-tools bind-utils wget unzip git
 
-#
-# download the yq container dependency
-#
-wget -O $CCPROOT/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64
-
 which buildah
 if [ $? -eq 1 ]; then
         echo "installing buildah"


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently install-deps.sh pulls down the yq binary which is no longer used.


**What is the new behavior (if this is a feature change)?**
It no longer pulls down the yq binary.


**Other information**:
