### PR TITLE
Build yq with new Go instead of pulling down old binary

### DIFF
--- a/bin/install-deps.sh
+++ b/bin/install-deps.sh
@@ -22,9 +22,17 @@ YQ_VERSION=3.3.0
 sudo yum -y install net-tools bind-utils wget unzip git
 
 #
-# download the yq container dependency
+# checkout and build the yq container dependency
 #
-wget -O $CCPROOT/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64
+mkdir /tmp/yq
+cd /tmp/yq
+git clone https://github.com/mikefarah/yq.git
+cd yq
+git checkout ${YQ_VERSION}
+go build
+mv yq $CCPROOT/yq
+cd /tmp
+rm -rf yq
 
 which buildah
 if [ $? -eq 1 ]; then


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
 Currently the install-deps.sh pulls down the yq binary from a very old version built with Go 1.14.x and is very out of date.


**What is the new behavior (if this is a feature change)?**
 This will now clone the yq repo and build it with the installed Go version to use in the build.


**Other information**:
