### PR TITLE
Suggestions to improve the Docker primary examples.

### DIFF
--- a/docs/content/examples/postgresql/primary.md
+++ b/docs/content/examples/postgresql/primary.md
@@ -33,22 +33,26 @@ To shutdown the instance and remove the container for each example, run the foll
 ## Docker
 
 
-To create the example and run the container:
+To create the example and run the container first pick a tag from, for example, 
+https://www.crunchydata.com/developers/download-postgres/containers/postgresql14
+then run:
 ```
-cd $CCPROOT/examples/docker/primary
+cd examples/docker/primary
+export CCP_IMAGE_PREFIX=registry.developers.crunchydata.com/crunchydata
+export CCP_IMAGE_TAG=ubi8-14.2-1
 ./run.sh
 ```
 
 Connect from your local host as follows:
 ```
-psql -h localhost -U testuser -W userdb
+PGPASSWORD=password psql -h localhost -U primaryuser userdb
 ```
 
 ## Kubernetes and OpenShift
 
 To create the example:
 ```
-cd $CCPROOT/examples/kube/primary
+cd examples/kube/primary
 ./run.sh
 ```
 
@@ -59,5 +63,5 @@ psql -h primary -U postgres postgres
 
 ## Helm
 
-This example resides under the `$CCPROOT/examples/helm` directory. View the README to run this
+This example resides under the `examples/helm` directory. View the README to run this
 example using Helm [here](https://github.com/CrunchyData/crunchy-containers/blob/master/examples/helm/primary/README.md).

--- a/examples/docker/primary/run.sh
+++ b/examples/docker/primary/run.sh
@@ -24,6 +24,7 @@ docker volume create --driver local --name=primary-pgdata
 docker run \
     -p 5432:5432 \
     -v primary-pgdata:/pgdata \
+    -e MODE=postgres \
     -e PG_MODE=primary \
     -e PG_USER=testuser \
     -e PG_PASSWORD=password \


### PR DESCRIPTION
1) The use of the $CCPROOT env var requires it be exported first,
   and the individual example do mention that, so I think it should
   just be removed.

2) Add -e MODE to run.sh, without which run.sh fails

3) Add exports of CCP_IMAGE_PREFIX and CCP_IMAGE_TAG where to find
   them, to the example, without which run.sh also fails

4) Add the use of PGPASSWORD to the psql example, without which
   the user will have to review run.sh to figure out what the password
   is, giving the user a little extra work

I am assuming these examples are meant for beginners getting familiar,
so I believe they should just work. From them the reader will then be
able to extract what one needs to deploy a proper container later.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Examples that don't work

**What is the new behavior (if this is a feature change)?**

Examples that work

**Other information**:
