### PR TITLE
Reduce the number of layers in the GIS HA image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,7 @@ postgres-gis-ha-pgimg-build: postgres-gis-pgimg-build $(CCPROOT)/build/postgres-
 		--build-arg PREFIX=$(CCP_IMAGE_PREFIX) \
 		--build-arg DFSET=$(DFSET) \
 		--build-arg PACKAGER=$(PACKAGER) \
+		--layers=false \
 		$(CCPROOT)
 
 postgres-gis-ha-pgimg-buildah: postgres-gis-ha-pgimg-build ;


### PR DESCRIPTION
Red Hat certification requires a certain number of image layers. This image has a few too many, so we squash in the last phase.

Back-patch of #1456
Issue: [sc-14754]