### PR TITLE
Add the orafce Extension

### DIFF
--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -60,6 +60,7 @@ RUN if [ "$DFSET" = "centos" ] ; then \
         	bzip2 \
         	lz4 \
 			krb5-workstation \
+			orafce_${PG_MAJOR//.} \
         && ${PACKAGER} -y clean all ; \
 else \
         ${PACKAGER} -y install --nodocs \
@@ -89,6 +90,7 @@ else \
 		bzip2 \
 		lz4 \
 		krb5-workstation \
+		orafce_${PG_MAJOR//.} \
 	&& ${PACKAGER} -y install --nodocs \
 		--setopt=tsflags='' \
 		--enablerepo="epel" \

--- a/build/upgrade/Dockerfile
+++ b/build/upgrade/Dockerfile
@@ -33,6 +33,7 @@ RUN if [ "$BASEOS" = "ubi8" ] ; then \
 		"postgresql${PG_MAJOR//.}-server" \
 		"pgaudit${PG_MAJOR//.}*" \
 		"pgnodemx${PG_MAJOR//.}" \
+		"orafce_${PG_MAJOR//.}" \
 		unzip \
 		&& ${PACKAGER} -y clean all ; \
 else \
@@ -46,6 +47,7 @@ else \
 		"postgresql${PG_MAJOR//.}-server" \
 		"pgaudit${PG_MAJOR//.}*" \
 		"pgnodemx${PG_MAJOR//.}" \
+		"orafce_${PG_MAJOR//.}" \
 		unzip \
 		&& ${PACKAGER} -y clean all ; \
 fi
@@ -61,7 +63,8 @@ RUN for pg_version in $UPGRADE_PG_VERSIONS; do \
                 postgresql${pg_version}-contrib \
                 postgresql${pg_version}-server \
                 pgaudit${pg_version} \
-                pgnodemx${pg_version} ; \
+                pgnodemx${pg_version} \
+				orafce_${pg_version} ; \
         else \
             ${PACKAGER} -y install --nodocs \
                 --setopt=skip_missing_names_on_install=False \
@@ -71,7 +74,8 @@ RUN for pg_version in $UPGRADE_PG_VERSIONS; do \
                 postgresql${pg_version}-contrib \
                 postgresql${pg_version}-server \
                 pgaudit${pg_version} \
-                pgnodemx${pg_version} ; \
+                pgnodemx${pg_version} \
+				orafce_${pg_version} ; \
         fi \
 	done && ${PACKAGER} -y clean all ;
 


### PR DESCRIPTION
Adds the `orafce` extension to all Postgres container builds.

This increases the size of a PG container slightly:
```bash
REPOSITORY                                                         TAG                        IMAGE ID       CREATED          SIZE
# before
registry.developers.crunchydata.com/crunchydata/crunchy-postgres   ubi8-14.4-0                926adcbc25fb   13 days ago      902 MB
# after
util.io/crunchy-postgres                                           ubi8-14.4-fce1             c251291ea087   20 minutes ago   910 MB
```

[sc-15211]