### PR TITLE
Support running install-deps on Debian-derived distributions.

### DIFF
--- a/bin/install-deps.sh
+++ b/bin/install-deps.sh
@@ -19,13 +19,21 @@ OPENSHIFT_CLIENT='https://github.com/openshift/origin/releases/download/v3.11.0/
 CERTSTRAP_VERSION=1.1.1
 YQ_VERSION=3.3.0
 
-sudo yum -y install net-tools bind-utils wget unzip git
+if [ ! -f /etc/debian_release ]; then
+    sudo yum -y install net-tools bind-utils wget unzip git
+else
+    sudo apt -y satisfy net-tools bind-utils wget unzip git
+fi
 
 which buildah
 if [ $? -eq 1 ]; then
         echo "installing buildah"
-        sudo subscription-manager repos --enable=rhel-7-server-extras-rpms
-        sudo yum -y install buildah
+        if [ ! -f /etc/debian_release ]; then
+             sudo subscription-manager repos --enable=rhel-7-server-extras-rpms
+             sudo yum -y install buildah
+        else
+             sudo apt -y install buildah
+        fi
 fi
 
 FILE='openshift-origin-client.tgz'


### PR DESCRIPTION
Support running install-deps on Debian-derived distributions.

With these changes, both "make setup" and subsequent steps run
successfully on Debian-derived distributions. Tested on Debian sid.

At the moment the list of package names is exactly the same, but this is
not guaranteed to be the case.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

"make setup" only works on RedHat-based distributions.

**What is the new behavior (if this is a feature change)?**

"make setup" also works on Debian-based distributions such as Debian, Ubuntu and Mint.
