### PR TITLE
replace ADD with COPY in all Dockerfiles

### DIFF
--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -76,10 +76,10 @@ fi
 # Both keys are added to support building all PG versions
 # of this container. PG 11+ requires RPM-GPG-KEY-crunchydata
 # PG 9.5, 9.6 and 10 require CRUNCHY-GPG-KEY.public on RHEL machines
-ADD conf/*KEY* /
+COPY conf/*KEY* /
 
 # Add any available Crunchy PG repo files
-ADD conf/crunchypg${PG_LBL}.repo /etc/yum.repos.d/
+COPY conf/crunchypg${PG_LBL}.repo /etc/yum.repos.d/
 # Import both keys to support all required repos
 RUN rpm --import RPM-GPG-KEY-crunchydata*
 RUN if [ "$DFSET" = "rhel" ] ; then rpm --import CRUNCHY-GPG-KEY.public ; fi

--- a/build/pgadmin4/Dockerfile
+++ b/build/pgadmin4/Dockerfile
@@ -66,9 +66,9 @@ fi
 # Preserving PGVERSION out of paranoia
 ENV PGROOT="/usr/pgsql-${PG_MAJOR}" PGVERSION="${PG_MAJOR}"
 
-ADD bin/pgadmin4/ /opt/crunchy/bin
-ADD bin/common /opt/crunchy/bin
-ADD conf/pgadmin4/ /opt/crunchy/conf
+COPY bin/pgadmin4/ /opt/crunchy/bin
+COPY bin/common /opt/crunchy/bin
+COPY conf/pgadmin4/ /opt/crunchy/conf
 
 RUN cp /opt/crunchy/conf/httpd.conf /etc/httpd/conf/httpd.conf \
 	&& rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/ssl.conf

--- a/build/pgbackrest/Dockerfile
+++ b/build/pgbackrest/Dockerfile
@@ -47,15 +47,15 @@ RUN mkdir -p /opt/crunchy/bin /opt/crunchy/conf /pgdata /backrestrepo \
 	/var/log/pgbackrest
 
 # add pgbackrest-restore files
-ADD bin/pgbackrest-restore /opt/crunchy/bin
-ADD conf/pgbackrest-restore /opt/crunchy/conf
+COPY bin/pgbackrest-restore /opt/crunchy/bin
+COPY conf/pgbackrest-restore /opt/crunchy/conf
 
 # add pgbackrest files
-ADD bin/pgbackrest /opt/crunchy/bin
+COPY bin/pgbackrest /opt/crunchy/bin
 
 # add pgbackrest-common files
-ADD bin/common /opt/crunchy/bin
-ADD bin/pgbackrest-common /opt/crunchy/bin
+COPY bin/common /opt/crunchy/bin
+COPY bin/pgbackrest-common /opt/crunchy/bin
 
 # set user and group ownership
 RUN chown -R postgres:postgres /opt/crunchy  \
@@ -63,7 +63,7 @@ RUN chown -R postgres:postgres /opt/crunchy  \
 
 # add the pgbackrest-repo specific files and directories, and
 # set the appropriate permissions and ownership
-ADD bin/pgbackrest-repo /usr/local/bin
+COPY bin/pgbackrest-repo /usr/local/bin
 RUN chmod +x /usr/local/bin/pgbackrest-repo.sh /usr/local/bin/archive-push-s3.sh \
 		/usr/local/bin/archive-push-gcs.sh \
 	&& mkdir -p /etc/pgbackrest \

--- a/build/pgbadger/Dockerfile
+++ b/build/pgbadger/Dockerfile
@@ -4,7 +4,7 @@ ARG PG_FULL
 ARG PREFIX
 FROM golang:1.15.5 as badgerserver-build
 WORKDIR /go/src/github.com/crunchydata/crunchy-containers
-ADD ./badger ./badger
+COPY ./badger ./badger
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o badgerserver ./badger
 
 FROM ${PREFIX}/crunchy-base:${BASEOS}-${PG_FULL}-${BASEVER}
@@ -49,9 +49,9 @@ RUN mkdir -p /opt/crunchy/bin /opt/crunchy/conf /report
 COPY --from=badgerserver-build \
 	/go/src/github.com/crunchydata/crunchy-containers/badgerserver \
 	/opt/crunchy/bin
-ADD conf/pgbadger /opt/crunchy/conf
-ADD bin/common /opt/crunchy/bin
-ADD bin/pgbadger /opt/crunchy/bin
+COPY conf/pgbadger /opt/crunchy/conf
+COPY bin/common /opt/crunchy/bin
+COPY bin/pgbadger /opt/crunchy/bin
 
 RUN chown -R postgres:postgres /opt/crunchy /report /bin && \
 	chmod -R g=u /opt/crunchy /report /bin

--- a/build/pgbouncer/Dockerfile
+++ b/build/pgbouncer/Dockerfile
@@ -27,9 +27,9 @@ ENV PGVERSION="${PG_MAJOR}"
 
 RUN mkdir -p /opt/crunchy/bin /opt/crunchy/conf /pgconf
 
-ADD bin/pgbouncer /opt/crunchy/bin
-ADD bin/common /opt/crunchy/bin
-ADD conf/pgbouncer /opt/crunchy/conf
+COPY bin/pgbouncer /opt/crunchy/bin
+COPY bin/common /opt/crunchy/bin
+COPY conf/pgbouncer /opt/crunchy/conf
 
 RUN chown -R 2:0 /opt/crunchy /pgconf && \
 	chmod -R g=u /opt/crunchy /pgconf

--- a/build/pgpool/Dockerfile
+++ b/build/pgpool/Dockerfile
@@ -27,9 +27,9 @@ ENV PGVERSION="${PG_MAJOR}"
 
 RUN mkdir -p /opt/crunchy/bin /opt/crunchy/conf
 
-ADD bin/pgpool /opt/crunchy/bin
-ADD bin/common /opt/crunchy/bin
-ADD conf/pgpool /opt/crunchy/conf
+COPY bin/pgpool /opt/crunchy/bin
+COPY bin/common /opt/crunchy/bin
+COPY conf/pgpool /opt/crunchy/conf
 
 RUN ln -sf /opt/crunchy/conf/pool_hba.conf /etc/pgpool-II_${PG_MAJOR//.}/pool_hba.conf \
 	&& ln -sf /opt/crunchy/conf/pgpool/pool_passwd /etc/pgpool-II_${PG_MAJOR//.}/pool_passwd

--- a/build/postgres-gis/Dockerfile
+++ b/build/postgres-gis/Dockerfile
@@ -47,7 +47,7 @@ fi
 # open up the postgres port
 EXPOSE 5432
 
-ADD bin/postgres-gis /opt/crunchy/bin/postgres
+COPY bin/postgres-gis /opt/crunchy/bin/postgres
 
 ENTRYPOINT ["/opt/crunchy/bin/uid_postgres.sh"]
 

--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -124,11 +124,11 @@ RUN chown -R postgres:postgres /opt/crunchy /var/lib/pgsql \
 # open up the postgres port
 EXPOSE 5432
 
-ADD bin/postgres_common /opt/crunchy/bin
-ADD bin/common /opt/crunchy/bin
-ADD conf/postgres_common /opt/crunchy/conf
-ADD tools/pgmonitor/postgres_exporter/common /opt/crunchy/bin/modules/pgexporter
-ADD tools/pgmonitor/postgres_exporter/linux /opt/crunchy/bin/modules/pgexporter
+COPY bin/postgres_common /opt/crunchy/bin
+COPY bin/common /opt/crunchy/bin
+COPY conf/postgres_common /opt/crunchy/conf
+COPY tools/pgmonitor/postgres_exporter/common /opt/crunchy/bin/modules/pgexporter
+COPY tools/pgmonitor/postgres_exporter/linux /opt/crunchy/bin/modules/pgexporter
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh && rm -f /run/nologin
 

--- a/build/upgrade/Dockerfile
+++ b/build/upgrade/Dockerfile
@@ -19,7 +19,7 @@ LABEL name="upgrade" \
 	io.openshift.tags="postgresql,postgres,upgrade,database,crunchy"
 
 # Add in the repository files with the correct PostgreSQL versions
-ADD conf/crunchypg*.repo /etc/yum.repos.d/
+COPY conf/crunchypg*.repo /etc/yum.repos.d/
 
 # install the highest version of PostgreSQL + pgAudit and its dependencies as
 # well as unzip
@@ -80,9 +80,9 @@ RUN for pg_version in $UPGRADE_PG_VERSIONS; do \
 	done && ${PACKAGER} -y clean all ;
 
 RUN mkdir -p /opt/crunchy/bin /pgolddata /pgnewdata /opt/crunchy/conf
-ADD bin/upgrade/ /opt/crunchy/bin
-ADD bin/common /opt/crunchy/bin
-ADD conf/upgrade/ /opt/crunchy/conf
+COPY bin/upgrade/ /opt/crunchy/bin
+COPY bin/common /opt/crunchy/bin
+COPY conf/upgrade/ /opt/crunchy/conf
 
 RUN chown -R postgres:postgres /opt/crunchy /pgolddata /pgnewdata && \
 	chmod -R g=u /opt/crunchy /pgolddata /pgnewdata


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently, in many crunchy container images, `ADD` is used instead of `COPY`. The functionality of both commands is identical when copying files. `ADD` is now considered a vulnerability by various container scanners. Docker itself recommends the use of `COPY` if `ADD` is not necessary.

- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy
- https://www.aquasec.com/cloud-native-academy/docker-container/docker-cis-benchmark/#Container-Images-and-Build-File-Configuration


**What is the new behavior (if this is a feature change)?**



**Other information**:
