### PR TITLE
Updated pg upgrade Dockerfile to import all pg extensions.

### DIFF
--- a/build/upgrade/Dockerfile
+++ b/build/upgrade/Dockerfile
@@ -31,9 +31,17 @@ RUN if [ "$BASEOS" = "ubi8" ] ; then \
 		"postgresql${PG_MAJOR//.}" \
 		"postgresql${PG_MAJOR//.}-contrib" \
 		"postgresql${PG_MAJOR//.}-server" \
+		postgresql${PG_MAJOR//.}-plpython* \
 		"pgaudit${PG_MAJOR//.}*" \
+		pgaudit${PG_MAJOR//.}_set_user \
 		"pgnodemx${PG_MAJOR//.}" \
 		"orafce_${PG_MAJOR//.}" \
+		pg_partman_${PG_MAJOR//.} \
+		pg_cron_${PG_MAJOR//.} \
+		$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
+		$( printf '11\n'${PG_MAJOR} | sort -VC && echo timescaledb_${PG_MAJOR} ) \
+		wal2json_${PG_MAJOR//.} \
+		pgaudit_analyze \
 		unzip \
 		&& ${PACKAGER} -y clean all ; \
 else \
@@ -45,9 +53,17 @@ else \
 		"postgresql${PG_MAJOR//.}" \
 		"postgresql${PG_MAJOR//.}-contrib" \
 		"postgresql${PG_MAJOR//.}-server" \
+		postgresql${PG_MAJOR//.}-plpython* \
 		"pgaudit${PG_MAJOR//.}*" \
+		pgaudit${PG_MAJOR//.}_set_user \
 		"pgnodemx${PG_MAJOR//.}" \
 		"orafce_${PG_MAJOR//.}" \
+		pg_partman_${PG_MAJOR//.} \
+		pg_cron_${PG_MAJOR//.} \
+		$( printf '11\n'${PG_MAJOR} | sort -VC && echo postgresql${PG_MAJOR}-llvmjit ) \
+		$( printf '11\n'${PG_MAJOR} | sort -VC && echo timescaledb_${PG_MAJOR} ) \
+		wal2json_${PG_MAJOR//.} \
+		pgaudit_analyze \
 		unzip \
 		&& ${PACKAGER} -y clean all ; \
 fi
@@ -62,8 +78,16 @@ RUN for pg_version in $UPGRADE_PG_VERSIONS; do \
                 postgresql${pg_version} \
                 postgresql${pg_version}-contrib \
                 postgresql${pg_version}-server \
+				postgresql${pg_version}-plpython* \
                 pgaudit${pg_version} \
+				pgaudit${pg_version}_set_user \
+				pg_partman_${pg_version} \
+				pg_cron_${pg_version} \
                 pgnodemx${pg_version} \
+				$( printf '11\n'${pg_version} | sort -VC && echo postgresql${pg_version}-llvmjit ) \
+				$( printf '11\n'${pg_version} | sort -VC && echo timescaledb_${pg_version} ) \
+				wal2json_${pg_version} \
+				pgaudit_analyze \
 				orafce_${pg_version} ; \
         else \
             ${PACKAGER} -y install --nodocs \
@@ -73,8 +97,16 @@ RUN for pg_version in $UPGRADE_PG_VERSIONS; do \
                 postgresql${pg_version} \
                 postgresql${pg_version}-contrib \
                 postgresql${pg_version}-server \
+				postgresql${pg_version}-plpython* \
                 pgaudit${pg_version} \
+				pgaudit${pg_version}_set_user \
+				pg_partman_${pg_version} \
+				pg_cron_${pg_version} \
                 pgnodemx${pg_version} \
+				$( printf '11\n'${pg_version} | sort -VC && echo postgresql${pg_version}-llvmjit ) \
+				$( printf '11\n'${pg_version} | sort -VC && echo timescaledb_${pg_version} ) \
+				wal2json_${pg_version} \
+				pgaudit_analyze \
 				orafce_${pg_version} ; \
         fi \
 	done && ${PACKAGER} -y clean all ;


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently, the `crunchy-upgrade` image does not have all of the pg extensions installed. Therefore, when a pg cluster that is using any of the extensions that are not installed in the `crunchy-upgrade` image is upgraded, the upgrade will fail. 

[sc-16369]

**What is the new behavior (if this is a feature change)?**
All pg extensions are now installed when a `crunchy-upgrade` image is built. Therefore, any pg clusters using any extensions can be successfully upgraded.


**Other information**:
