### PR TITLE
Pin psycopg v4.7

### DIFF
--- a/build/pgadmin4/Dockerfile
+++ b/build/pgadmin4/Dockerfile
@@ -25,6 +25,7 @@ RUN if [ "$BASEOS" = "centos7" ] ; then \
                 --setopt=skip_missing_names_on_install=False \
                 mod_ssl \
                 mod_wsgi \
+                python3-psycopg2-2.8.*\
                 openssl \
                 --setopt=obsoletes=0 pgadmin4-${PGADMIN_VER} \
                 pgadmin4-web-${PGADMIN_VER} \
@@ -68,6 +69,7 @@ RUN if [ "$BASEOS" = "ubi7" ] ; then \
                 --enablerepo="epel,rhel-7-server-extras-rpms" \
                 mod_ssl \
                 mod_wsgi \
+                python3-psycopg2-2.8.*\
                 openssl \
                 --setopt=obsoletes=0 pgadmin4-${PGADMIN_VER} \
                 pgadmin4-web-${PGADMIN_VER} \
@@ -88,6 +90,7 @@ RUN if [ "$BASEOS" = "ubi8" ] ; then \
                 --enablerepo="epel" \
                 mod_ssl \
                 python3-mod_wsgi \
+                python3-psycopg2-2.8.*\
                 openssl \
                 sqlite \
                 pgadmin4-${PGADMIN_VER} \


### PR DESCRIPTION
Issue: [sc-17162]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
PgAdmin is sensitive to the version of psycopg2 and will fail to connect to a database with the wrong version. We need psycopg2 to be pinned to v2.8.


**What is the new behavior (if this is a feature change)?**
Users will be able to connect to their databases via pgadmin.


**Other information**:
