### PR TITLE
Remove 'postgresVersion10' from Docs

### DIFF
--- a/docs/content/container-specifications/crunchy-pgadmin4.md
+++ b/docs/content/container-specifications/crunchy-pgadmin4.md
@@ -26,7 +26,7 @@ The following features are supported by the crunchy-pgadmin4 container:
 
 The crunchy-pgadmin4 Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL ({{<param postgresVersion13 >}}, {{<param postgresVersion12 >}}, {{<param postgresVersion11 >}}, and {{<param postgresVersion10 >}})
+* PostgreSQL ({{<param postgresVersion13 >}}, {{<param postgresVersion12 >}}, and {{<param postgresVersion11 >}})
 * [pgAdmin4](https://www.pgadmin.org/)
 * CentOS 7, UBI 8 - publicly available
 * UBI 7, UBI 8 - customers only

--- a/docs/content/container-specifications/crunchy-pgbackrest.md
+++ b/docs/content/container-specifications/crunchy-pgbackrest.md
@@ -34,7 +34,7 @@ The following volumes are mounted by the `crunchy-pgbackrest` container:
 
 The crunchy-backrest-restore Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL ({{<param postgresVersion13 >}}, {{<param postgresVersion12 >}}, {{<param postgresVersion11 >}}, and {{<param postgresVersion10 >}})
+* PostgreSQL ({{<param postgresVersion13 >}}, {{<param postgresVersion12 >}}, and {{<param postgresVersion11 >}})
 * [pgBackRest](https://pgbackrest.org/) (2.33)
 * CentOS 7, UBI 8 - publicly available
 * UBI 7, UBI 8 - customers only

--- a/docs/content/container-specifications/crunchy-pgbouncer.md
+++ b/docs/content/container-specifications/crunchy-pgbouncer.md
@@ -20,7 +20,7 @@ The following features are supported by the crunchy-pgbouncer container:
 
 The crunchy-pgbouncer Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL ({{<param postgresVersion13 >}}, {{<param postgresVersion12 >}}, {{<param postgresVersion11 >}}, and {{<param postgresVersion10 >}})
+* PostgreSQL ({{<param postgresVersion13 >}}, {{<param postgresVersion12 >}}, and {{<param postgresVersion11 >}})
 * [pgBouncer](https://pgbouncer.github.io/)
 * CentOS 7, UBI 8 - publicly available
 * UBI 7, UBI 8 - customers only

--- a/docs/content/container-specifications/crunchy-pgpool.md
+++ b/docs/content/container-specifications/crunchy-pgpool.md
@@ -26,7 +26,7 @@ The following features are supported by the `crunchy-postgres` container:
 
 The crunchy-pgpool Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL ({{<param postgresVersion13 >}}, {{<param postgresVersion12 >}}, {{<param postgresVersion11 >}}, and {{<param postgresVersion10 >}})
+* PostgreSQL ({{<param postgresVersion13 >}}, {{<param postgresVersion12 >}}, and {{<param postgresVersion11 >}})
 * [pgPool II](http://www.pgpool.net/mediawiki/index.php/Main_Page)
 * CentOS 7, UBI 8 - publicly available
 * UBI 7, UBI 8 - customers only

--- a/docs/content/container-specifications/crunchy-postgres/_index.md
+++ b/docs/content/container-specifications/crunchy-postgres/_index.md
@@ -17,9 +17,9 @@ The following features are supported by the `crunchy-postgres` container:
 
 The crunchy-postgres Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL ({{<param postgresVersion13 >}}, {{<param postgresVersion12 >}}, {{<param postgresVersion11 >}}, and {{<param postgresVersion10 >}})
+* PostgreSQL ({{<param postgresVersion13 >}}, {{<param postgresVersion12 >}}, and {{<param postgresVersion11 >}})
 * [pgBackRest](https://pgbackrest.org/) (2.33)
-* pgBench ({{<param postgresVersion13 >}}, {{<param postgresVersion12 >}}, {{<param postgresVersion11 >}}, and {{<param postgresVersion10 >}})
+* pgBench ({{<param postgresVersion13 >}}, {{<param postgresVersion12 >}}, and {{<param postgresVersion11 >}})
 * rsync
 * CentOS 7, UBI 8 - publicly available
 * UBI 7, UBI 8 - customers only

--- a/docs/content/container-specifications/crunchy-upgrade.md
+++ b/docs/content/container-specifications/crunchy-upgrade.md
@@ -36,7 +36,7 @@ The following features are supported by the crunchy-upgrade container:
 
 The crunchy-upgrade Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL ({{<param postgresVersion13 >}}, {{<param postgresVersion12 >}}, {{<param postgresVersion11 >}}, and {{<param postgresVersion10 >}})
+* PostgreSQL ({{<param postgresVersion13 >}}, {{<param postgresVersion12 >}}, and {{<param postgresVersion11 >}})
 * CentOS 7, UBI 8 - publicly available
 * UBI 7, UBI 8 - customers only
 


### PR DESCRIPTION
Removes all use of `postgresVersion10` in the Docs.