### PR TITLE
Backpatch: Remove httpd PID file creation line from pgadmin script

### DIFF
--- a/bin/pgadmin4/start-pgadmin4.sh
+++ b/bin/pgadmin4/start-pgadmin4.sh
@@ -71,6 +71,5 @@ cd ${PGADMIN_DIR?}
 
 echo_info "Starting Apache web server.."
 /usr/sbin/httpd -D FOREGROUND &
-echo $! > $APACHE_PIDFILE
 
 wait


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the new behavior (if this is a feature change)?**

This commit removes the line that attempts to create the `httpd.pid` file in the start-pgadmin.sh script as it appears to interfere with startup for Centos7 and UBI7 containers.

**Other information**:
Issue: [sc-17594]