### PR TITLE
Turning huge_pages off by default in the postgresql.conf.sample file.

### DIFF
--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -100,6 +100,9 @@ else \
 	&& ${PACKAGER} -y clean all --enablerepo="epel" ; \
 fi
 
+# Set huge_pages to "off" to workaround issue # sc-17565
+RUN echo "huge_pages = off" >> ${PGROOT}/share/postgresql.conf.sample
+
 # install patroni for Kube
 RUN pip3 install --upgrade python-dateutil \
 	&& pip3 install patroni[kubernetes]=="${PATRONI_VER}"


### PR DESCRIPTION
[sc-17766]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**

In Postgres, huge_pages is set to "try" by default. There is an issue in Kubernetes that causes postgres to fail to start when huge pages are enabled on the node and huge pages are enabled in postgres, but no huge pages were requested for the postgres instance. 

[sc-17565]

**What is the new behavior (if this is a feature change)?**

Now, huge_pages is set to off by default.

[sc-17766]

**Other information**:
