### PR TITLE
Update postgis to include codeready repo

### DIFF
--- a/build/postgres-gis/Dockerfile
+++ b/build/postgres-gis/Dockerfile
@@ -33,15 +33,21 @@ RUN if [ "$BASEOS" = "centos8" ] ; then \
 fi
 
 RUN if [ "$BASEOS" = "ubi8" ] ; then \
-	${PACKAGER} -y --enablerepo="epel" --enablerepo="codeready-builder-for-rhel-8-x86_64-rpms" --nodocs install libaec libdap armadillo \
+	${PACKAGER} -y install --nodocs \
+		--enablerepo="epel" \
+		--enablerepo="codeready-builder-for-rhel-8-x86_64-rpms" \
+		libaec libdap armadillo \
 	&& ${PACKAGER} -y install --nodocs \
 		--enablerepo="epel" \
+		--enablerepo="codeready-builder-for-rhel-8-x86_64-rpms" \
 		pgrouting${POSTGIS_LBL}_${PG_MAJOR//.} \
 		postgis${POSTGIS_LBL}_${PG_MAJOR//.} \
 		postgis${POSTGIS_LBL}_${PG_MAJOR//.}-client \
 		postgresql${PG_MAJOR//.}-plperl \
 		postgresql${PG_MAJOR//.}-pltcl \
-	&& ${PACKAGER} -y clean all --enablerepo="epel" --enablerepo="codeready-builder-for-rhel-8-x86_64-rpms" ; \
+	&& ${PACKAGER} -y clean all \
+		--enablerepo="epel" \
+		--enablerepo="codeready-builder-for-rhel-8-x86_64-rpms" ; \
 fi
 
 # open up the postgres port


### PR DESCRIPTION
The newest PostGIS requires gdal35. Gdal35 requires a package from codeready-builder-for-rhel-8-x86_64-rpms.  When we enable repos to install PostGIS packages, we now include codeready.

In the future, we may be able to combine the two separate `microdnf` install lines (36 and 40) but keeping out of caution.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
[sc-18072]