### PR TITLE
Update postgis to include codeready repo

### DIFF
--- a/build/postgres-gis/Dockerfile
+++ b/build/postgres-gis/Dockerfile
@@ -56,16 +56,22 @@ RUN if [ "$BASEOS" = "ubi7" ] ; then \
 fi
 
 RUN if [ "$BASEOS" = "ubi8" ] ; then \
-	${PACKAGER} -y --enablerepo="epel,codeready-builder-for-rhel-8-x86_64-rpms" install libaec libdap armadillo \
+	${PACKAGER} -y install \
+		--enablerepo="epel" \
+		--enablerepo="codeready-builder-for-rhel-8-x86_64-rpms" \
+		libaec libdap armadillo \
 	&& ${PACKAGER} -y install \
 		--enablerepo="epel" \
+		--enablerepo="codeready-builder-for-rhel-8-x86_64-rpms" \
 		--setopt=skip_missing_names_on_install=False \
 		pgrouting${POSTGIS_LBL}_${PG_MAJOR//.} \
 		plr${PG_MAJOR//.} \
 		postgis${POSTGIS_LBL}_${PG_MAJOR//.} \
 		postgis${POSTGIS_LBL}_${PG_MAJOR//.}-client \
 		postgresql${PG_MAJOR//.}-plperl \
-	&& ${PACKAGER} -y clean all --enablerepo="epel,codeready-builder-for-rhel-8-x86_64-rpms" ; \
+	&& ${PACKAGER} -y clean all \
+		--enablerepo="epel" \
+		--enablerepo="codeready-builder-for-rhel-8-x86_64-rpms" ; \
 fi
 
 # open up the postgres port


### PR DESCRIPTION
The newest postgis requires gdal35. Gdal35 requires a package from codeready-builder-for-rhel-8-x86_64-rpms.  When we enable repos to install postgis packages, we now include codeready.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
[sc-18072]